### PR TITLE
Add Support for Voxel Map ROS2 Publishing Via Point Map Conversion

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1383,7 +1383,6 @@ void BridgeROS2::timerPubMap()
         else if (auto vox = std::dynamic_pointer_cast<mrpt::maps::CVoxelMap>(mu.map);
                  vox)
         {
-            // internalPublishVoxelMap(*vox, mapTopic, mu.reference_frame);
             mrpt::maps::CSimplePointsMap::Ptr pm = vox->getOccupiedVoxels();
             if (pm)
             {

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -28,6 +28,7 @@
 #include <mrpt/maps/CPointsMapXYZI.h>
 #include <mrpt/maps/CPointsMapXYZIRT.h>
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/maps/CVoxelMap.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservationGPS.h>
 #include <mrpt/obs/CObservationIMU.h>
@@ -1377,6 +1378,26 @@ void BridgeROS2::timerPubMap()
                  grid)
         {
             internalPublishGridMap(*grid, mapTopic, mu.reference_frame);
+        }
+        // Is it a CVoxelMap?
+        else if (auto vox = std::dynamic_pointer_cast<mrpt::maps::CVoxelMap>(mu.map);
+                 vox)
+        {
+            // internalPublishVoxelMap(*vox, mapTopic, mu.reference_frame);
+            mrpt::maps::CSimplePointsMap::Ptr pm = vox->getOccupiedVoxels();
+            if (pm)
+            {
+                mrpt::obs::CObservationPointCloud obs;
+                obs.sensorLabel = mapTopic;
+                obs.pointcloud  = pm;
+                // Reuse code for point cloud observations: build a "fake" observation:
+                internalOn(obs, false /*no tf*/, mu.reference_frame);
+            }
+            else
+            {
+                MRPT_LOG_WARN_STREAM(
+                    "Voxel map '" << layerName << "' has no occupied voxels to publish.");
+            }
         }
         // Not empty?
         else if (mu.map)

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1380,8 +1380,7 @@ void BridgeROS2::timerPubMap()
             internalPublishGridMap(*grid, mapTopic, mu.reference_frame);
         }
         // Is it a CVoxelMap?
-        else if (auto vox = std::dynamic_pointer_cast<mrpt::maps::CVoxelMap>(mu.map);
-                 vox)
+        else if (auto vox = std::dynamic_pointer_cast<mrpt::maps::CVoxelMap>(mu.map); vox)
         {
             mrpt::maps::CSimplePointsMap::Ptr pm = vox->getOccupiedVoxels();
             if (pm)


### PR DESCRIPTION
This code adds the ability to publish point maps of occupied voxels in the ROS2 bridge, allowing for real-time visualization of 2D map generation. Since it only publishes occupied voxels, it is not overly computationally expensive.
It uses an existing MRPT function to get the points, so no custom, potentially slow point-wise code is involved.

An example RVIZ2 visualization of a map in the process of being created is shown here:
![image](https://github.com/user-attachments/assets/3176db1b-5451-46bc-849c-ce5abee1f284)


Closes #80 
