### PR TITLE
Remove use of mrpt deprecated maps

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -20,27 +20,27 @@ jobs:
         # https://ros.org/reps/rep-2000.html
         include:
           # Humble Hawksbill (May 2022 - May 2027)
-          #- docker_image: ubuntu:jammy
-          #  ros_distribution: humble
-          #  use_ros_testing: false
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
+            use_ros_testing: false
 
           - docker_image: ubuntu:jammy
             ros_distribution: humble
             use_ros_testing: true
 
           # Jazzy (2024 - 2029)
-          #- docker_image: ubuntu:noble
-          #  ros_distribution: jazzy
-          #  use_ros_testing: false
+          - docker_image: ubuntu:noble
+            ros_distribution: jazzy
+            use_ros_testing: false
 
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
             use_ros_testing: true
 
           # Rolling Ridley (No End-Of-Life)
-          #- docker_image: ubuntu:noble
-          #  ros_distribution: rolling
-          #  use_ros_testing: false
+          - docker_image: ubuntu:noble
+            ros_distribution: rolling
+            use_ros_testing: false
 
           - docker_image: ubuntu:noble
             ros_distribution: rolling

--- a/kitti_metrics_eval/apps/kitti-metrics-eval.cpp
+++ b/kitti_metrics_eval/apps/kitti-metrics-eval.cpp
@@ -371,7 +371,10 @@ vector<errors> calcSequenceErrors(vector<Matrix>& poses_gt, vector<Matrix>& pose
       int32_t last_frame = lastFrameFromSegmentLength(dist, first_frame, len);
 
       // continue, if sequence not long enough
-      if (last_frame == -1) continue;
+      if (last_frame == -1)
+      {
+        continue;
+      }
 
       // compute rotational and translational errors
       Matrix pose_delta_gt     = (poses_gt[first_frame]).inverse() * poses_gt[last_frame];

--- a/mola_input_euroc_dataset/src/EurocDataset.cpp
+++ b/mola_input_euroc_dataset/src/EurocDataset.cpp
@@ -250,7 +250,10 @@ void EurocDataset::spinOnce()
   }
   else
   {
-    if (paused) return;
+    if (paused)
+    {
+      return;
+    }
     // move forward replayed dataset time:
     last_dataset_time_ += dt;
   }

--- a/mola_input_kitti360_dataset/src/Kitti360Dataset.cpp
+++ b/mola_input_kitti360_dataset/src/Kitti360Dataset.cpp
@@ -60,7 +60,10 @@ void build_list_files(
     const std::string& dir, const std::string& file_extension, std::vector<std::string>& out_lst)
 {
   out_lst.clear();
-  if (!mrpt::system::directoryExists(dir)) return;
+  if (!mrpt::system::directoryExists(dir))
+  {
+    return;
+  }
 
   using direxpl = mrpt::system::CDirectoryExplorer;
   direxpl::TFileInfoList lstFiles;
@@ -672,19 +675,22 @@ void Kitti360Dataset::load_lidar(timestep_t step) const
     const auto& ys = obs->pointcloud->getPointsBufferRef_y();
 
     auto newPts = mrpt::maps::CGenericPointsMap::Create();
-    newPts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
-    newPts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    newPts->registerField_float("t");
+    newPts->registerField_float("intensity");
     newPts->reserve(xs.size());
 
-    auto* trgTs =
-        newPts->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+    auto* trgTs = newPts->getPointsBufferRef_float_field("t");
 
     auto ctx = newPts->prepareForInsertPointsFrom(*obs->pointcloud);
     ASSERT_(trgTs);
 
     for (size_t i = 0; i < xs.size(); i++)
     {
+#if MRPT_VERSION >= 0x020f03  // 2.15.3
       newPts->insertPointFrom(i, ctx);
+#else
+      newPts->insertPointFrom(*obs->pointcloud, i, ctx);
+#endif
 
       const auto  azimuth = std::atan2(ys[i], xs[i]);
       const float ptTime  = -0.05f * (azimuth + M_PIf) / (2.0f * M_PIf);

--- a/mola_input_kitti_dataset/src/KittiOdometryDataset.cpp
+++ b/mola_input_kitti_dataset/src/KittiOdometryDataset.cpp
@@ -27,7 +27,7 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
-#include <mrpt/maps/CPointsMapXYZI.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationImage.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRobotPose.h>
@@ -52,11 +52,16 @@ KittiOdometryDataset::KittiOdometryDataset()
   this->mrpt::system::COutputLogger::setLoggerName("KittiOdometryDataset");
 }
 
-static void build_list_files(
+namespace
+{
+void build_list_files(
     const std::string& dir, const std::string& file_extension, std::vector<std::string>& out_lst)
 {
   out_lst.clear();
-  if (!mrpt::system::directoryExists(dir)) return;
+  if (!mrpt::system::directoryExists(dir))
+  {
+    return;
+  }
 
   using direxpl = mrpt::system::CDirectoryExplorer;
   direxpl::TFileInfoList lstFiles;
@@ -68,12 +73,13 @@ static void build_list_files(
       lstFiles.begin(), lstFiles.end(), out_lst.begin(), [](auto& fil) { return fil.name; });
 }
 
-static void parse_calib_line(const std::string& line, Eigen::Matrix<double, 3, 4>& M)
+void parse_calib_line(const std::string& line, Eigen::Matrix<double, 3, 4>& M)
 {
   MRPT_TRY_START
 
   std::istringstream ss(line);
   for (Eigen::Index r = 0; r < M.rows(); r++)
+  {
     for (Eigen::Index c = 0; c < M.cols(); c++)
     {
       if (!(ss >> M(r, c)))
@@ -81,8 +87,11 @@ static void parse_calib_line(const std::string& line, Eigen::Matrix<double, 3, 4
         THROW_EXCEPTION_FMT("Error parsing calib line: `%s`", line.c_str());
       }
     }
+  }
   MRPT_TRY_END
 }
+
+}  // namespace
 
 void KittiOdometryDataset::initialize_rds(const Yaml& c)
 {
@@ -113,8 +122,10 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   publish_ground_truth_ = cfg.getOrDefault<bool>("publish_ground_truth", publish_ground_truth_);
 
   for (unsigned int i = 0; i < 4; i++)
+  {
     publish_image_[i] =
         cfg.getOrDefault<bool>(mrpt::format("publish_image_%u", i), publish_image_[i]);
+  }
 
   // Make list of all existing files and preload everything we may need later
   // to quickly replay the dataset in realtime:
@@ -126,7 +137,7 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
     mtimes.loadFromTextFile(seq_dir_ + std::string("/times.txt"));
     // Convert to std::vector:
     lst_timestamps_.resize(static_cast<std::size_t>(mtimes.size()));
-    Eigen::VectorXd::Map(&lst_timestamps_[0], mtimes.size()) = mtimes.asEigen();
+    Eigen::VectorXd::Map(lst_timestamps_.data(), mtimes.size()) = mtimes.asEigen();
   }
   const auto N = lst_timestamps_.size();
   MRPT_LOG_DEBUG_STREAM("Dataset timesteps: " << N);
@@ -139,7 +150,10 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   // Images  : "0000000000.png"
   // Non-uniform format. Solution: make a list of files and sort them.
   build_list_files(seq_dir_ + "/velodyne", "bin", lst_velodyne_);
-  if (!lst_velodyne_.empty()) ASSERTMSG_(lst_velodyne_.size() == N, "Velodyne: invalid file count");
+  if (!lst_velodyne_.empty())
+  {
+    ASSERTMSG_(lst_velodyne_.size() == N, "Velodyne: invalid file count");
+  }
 
   MRPT_LOG_INFO_STREAM(
       "Velodyne pointclouds: "
@@ -150,7 +164,9 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   {
     build_list_files(seq_dir_ + "/image_" + std::to_string(i), "png", lst_image_[i]);
     if (!lst_image_[i].empty())
+    {
       ASSERTMSG_(lst_image_[i].size() == N, mrpt::format("image_%u: invalid file count", i));
+    }
 
     MRPT_LOG_INFO_STREAM(
         "Camera channel `image_" << i << "`: "
@@ -159,7 +175,10 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
                                          : "Not found"));
 
     // Override user choice if not possible to publish images:
-    if (lst_image_[i].empty()) publish_image_[i] = false;
+    if (lst_image_[i].empty())
+    {
+      publish_image_[i] = false;
+    }
   }
 
   // Load sensors calibration:
@@ -174,7 +193,8 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   ENSURE_YAML_ENTRY_EXISTS(calib, "P3");
   ENSURE_YAML_ENTRY_EXISTS(calib, "Tr");
 
-  Eigen::Matrix<double, 3, 4> P[4], Tr;
+  Eigen::Matrix<double, 3, 4> P[4];
+  Eigen::Matrix<double, 3, 4> Tr;
   parse_calib_line(calib["Tr"].as<std::string>(), Tr);
   for (unsigned int i = 0; i < 4; i++)
   {
@@ -184,7 +204,10 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   // Camera intrinsics:
   for (unsigned int i = 0; i < 4; i++)
   {
-    const double fx = P[i](0, 0), fy = P[i](1, 1), cx = P[i](0, 2), cy = P[i](1, 2);
+    const double fx = P[i](0, 0);
+    const double fy = P[i](1, 1);
+    const double cx = P[i](0, 2);
+    const double cy = P[i](1, 2);
     cam_intrinsics_[i].setIntrinsicParamsFromValues(fx, fy, cx, cy);
 
     // Resolution: try loading the first image:
@@ -221,7 +244,10 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
   cam_poses_[0] = mrpt::poses::CPose3D(Trh).asTPose();
 
   // Cameras 1-3:
-  for (unsigned int i = 1; i < 4; i++) cam_poses_[0].composePose(cam_poses_[i], cam_poses_[i]);
+  for (unsigned int i = 1; i < 4; i++)
+  {
+    cam_poses_[0].composePose(cam_poses_[i], cam_poses_[i]);
+  }
 
   // Debug: dump poses.
   for (unsigned int i = 0; i < 4; i++)
@@ -253,7 +279,12 @@ void KittiOdometryDataset::initialize_rds(const Yaml& c)
     for (size_t i = 0; i < lst_timestamps_.size(); i++)
     {
       for (int row = 0, ij_idx = 0; row < 3; row++)
-        for (int col = 0; col < 4; col++, ij_idx++) m(row, col) = groundTruthPoses_(i, ij_idx);
+      {
+        for (int col = 0; col < 4; col++, ij_idx++)
+        {
+          m(row, col) = groundTruthPoses_(i, ij_idx);
+        }
+      }
 
       // ground truth is for cam0:
       const auto gtCam0Pose = mrpt::poses::CPose3D::FromHomogeneousMatrix(m);
@@ -288,7 +319,10 @@ void KittiOdometryDataset::spinOnce()
   const auto tNow = mrpt::Clock::now();
 
   // Starting time:
-  if (!last_play_wallclock_time_) last_play_wallclock_time_ = tNow;
+  if (!last_play_wallclock_time_)
+  {
+    last_play_wallclock_time_ = tNow;
+  }
 
   // get current replay time:
   auto         lckUIVars       = mrpt::lockHelper(dataset_ui_mtx_);
@@ -309,7 +343,10 @@ void KittiOdometryDataset::spinOnce()
   }
   else
   {
-    if (paused) return;
+    if (paused)
+    {
+      return;
+    }
     // move forward replayed dataset time:
     last_dataset_time_ += dt;
   }
@@ -322,7 +359,8 @@ void KittiOdometryDataset::spinOnce()
         10.0, "End of dataset reached! Nothing else to publish (CTRL+C to quit)");
     return;
   }
-  else if (!lst_timestamps_.empty())
+
+  if (!lst_timestamps_.empty())
   {
     MRPT_LOG_THROTTLE_INFO_FMT(
         5.0, "Dataset replay progress: %lu / %lu  (%4.02f%%)",
@@ -354,7 +392,10 @@ void KittiOdometryDataset::spinOnce()
 
     for (unsigned int i = 0; i < 4; i++)
     {
-      if (!publish_image_[i]) continue;
+      if (!publish_image_[i])
+      {
+        continue;
+      }
       ProfilerEntry tle(profiler_, "spinOnce.publishImage");
       load_img(i, replay_next_tim_index_);
       auto o = read_ahead_image_obs_[replay_next_tim_index_][i];
@@ -399,13 +440,19 @@ void KittiOdometryDataset::spinOnce()
     {
       for (unsigned int i = 0; i < 4; i++)
       {
-        if (!publish_image_[i]) continue;
+        if (!publish_image_[i])
+        {
+          continue;
+        }
         load_img(i, replay_next_tim_index_);
       }
     }
     if (0 == read_ahead_lidar_obs_.count(replay_next_tim_index_))
     {
-      if (publish_lidar_) load_lidar(replay_next_tim_index_);
+      if (publish_lidar_)
+      {
+        load_lidar(replay_next_tim_index_);
+      }
     }
   }
 
@@ -420,7 +467,10 @@ void KittiOdometryDataset::load_img(const unsigned int cam_idx, const timestep_t
   autoUnloadOldEntries();
 
   // Already loaded?
-  if (read_ahead_image_obs_[step][cam_idx]) return;
+  if (read_ahead_image_obs_[step][cam_idx])
+  {
+    return;
+  }
 
   ProfilerEntry tleg(profiler_, "load_img");
 
@@ -457,7 +507,10 @@ void KittiOdometryDataset::load_lidar(timestep_t step) const
   autoUnloadOldEntries();
 
   // Already loaded?
-  if (read_ahead_lidar_obs_[step]) return;
+  if (read_ahead_lidar_obs_[step])
+  {
+    return;
+  }
 
   ProfilerEntry tleg(profiler_, "load_lidar");
 
@@ -487,9 +540,9 @@ void KittiOdometryDataset::load_lidar(timestep_t step) const
   {
     // Due to the ring-like, rotating nature of 3D LIDARs, we cannot do this
     // in any more efficient way than go through the points one by one:
-    auto& xs = obs->pointcloud->getPointsBufferRef_x();
-    auto& ys = obs->pointcloud->getPointsBufferRef_y();
-    auto& zs = obs->pointcloud->getPointsBufferRef_z();
+    const auto& xs = obs->pointcloud->getPointsBufferRef_x();
+    const auto& ys = obs->pointcloud->getPointsBufferRef_y();
+    const auto& zs = obs->pointcloud->getPointsBufferRef_z();
 
     const Eigen::Vector3d uz(0., 0., 1.);
     for (size_t i = 0; i < xs.size(); i++)
@@ -508,11 +561,6 @@ void KittiOdometryDataset::load_lidar(timestep_t step) const
   // Kitti datasets.
   obs->sensorPose = mrpt::poses::CPose3D();
   obs->timestamp  = mrpt::Clock::fromDouble(lst_timestamps_.at(step));
-
-#if 0  // Export clouds to txt for debugging externally (e.g. python, matlab)
-    obs->pointcloud->save3D_to_text_file(
-        mrpt::format("kitti_%s_%06zu.txt", sequence_.c_str(), step));
-#endif
 
   mrpt::obs::CObservation::Ptr o;
   // Now, publish it as pointcloud or as an organized cloud:
@@ -541,12 +589,15 @@ void KittiOdometryDataset::load_lidar(timestep_t step) const
     rs->intensityImage.resize(rs->rowCount, rs->columnCount);
     rs->rangeImage.resize(rs->rowCount, rs->columnCount);
 
-    auto ptsXYZI = std::dynamic_pointer_cast<mrpt::maps::CPointsMapXYZI>(obs->pointcloud);
+    auto ptsXYZI = std::dynamic_pointer_cast<mrpt::maps::CGenericPointsMap>(obs->pointcloud);
     ASSERT_(ptsXYZI);
 
     const auto& xs = ptsXYZI->getPointsBufferRef_x();
     const auto& ys = ptsXYZI->getPointsBufferRef_y();
     const auto& zs = ptsXYZI->getPointsBufferRef_z();
+    const auto* Is = ptsXYZI->getPointsBufferRef_float_field("intensity");
+    ASSERT_(Is != nullptr);
+    ASSERT_EQUAL_(Is->size(), xs.size());
 
     const size_t nPts = xs.size();
 
@@ -562,21 +613,25 @@ void KittiOdometryDataset::load_lidar(timestep_t step) const
     for (size_t i = 0; i < nPts; i++)
     {
       // intensity comes normalized [0,1]
-      const float ptInt = ptsXYZI->getPointIntensity(i);
+      const float ptInt = (*Is)[i];
 
       const float range_xy = std::sqrt(mrpt::square(xs[i]) + mrpt::square(ys[i]));
       const float pitch    = std::asin(zs[i] / range_xy);
       const float yaw      = std::atan2(ys[i], xs[i]);
 
       float     proj_y = (pitch + abs(fov_down)) / fov;  // in[0.0, 1.0]
-      const int row =
-          std::min<int>(rs->rowCount - 1, std::max<int>(0, std::floor(proj_y * rs->rowCount)));
+      const int row    = std::min<int>(
+          rs->rowCount - 1,
+          std::max<int>(0, std::floor(proj_y * static_cast<float>(rs->rowCount))));
 
       const int col = std::min<int>(
-          rs->columnCount - 1, std::max<int>(0, rs->columnCount * (yaw + M_PIf) / (2 * M_PIf)));
+          rs->columnCount - 1,
+          std::max<int>(
+              0,
+              static_cast<int>(static_cast<float>(rs->columnCount) * (yaw + M_PIf) / (2 * M_PIf))));
 
-      rs->rangeImage(row, col)      = range_xy / rs->rangeResolution;
-      rs->intensityImage(row, col)  = ptInt * 255;
+      rs->rangeImage(row, col)      = static_cast<uint16_t>(range_xy / rs->rangeResolution);
+      rs->intensityImage(row, col)  = mrpt::f2u8(ptInt);
       rs->organizedPoints(row, col) = {xs[i], ys[i], zs[i]};
     }
 
@@ -630,7 +685,10 @@ mrpt::obs::CSensoryFrame::Ptr KittiOdometryDataset::datasetGetObservations(size_
 
   for (size_t i = 0; i < publish_image_.size(); i++)
   {
-    if (!publish_image_[i]) continue;
+    if (!publish_image_[i])
+    {
+      continue;
+    }
     sf->insert(getImage(i, timestep));
   }
 
@@ -647,8 +705,12 @@ constexpr size_t MAX_UNLOAD_LEN = 250;
 void KittiOdometryDataset::autoUnloadOldEntries() const
 {
   while (read_ahead_lidar_obs_.size() > MAX_UNLOAD_LEN)
+  {
     read_ahead_lidar_obs_.erase(read_ahead_lidar_obs_.begin());
+  }
 
   while (read_ahead_image_obs_.size() > MAX_UNLOAD_LEN)
+  {
     read_ahead_image_obs_.erase(read_ahead_image_obs_.begin());
+  }
 }

--- a/mola_input_lidar_bin_dataset/src/BinFileDataset.cpp
+++ b/mola_input_lidar_bin_dataset/src/BinFileDataset.cpp
@@ -19,7 +19,6 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
-#include <mrpt/maps/CPointsMapXYZI.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/system/CDirectoryExplorer.h>
 #include <mrpt/system/filesystem.h>
@@ -67,18 +66,18 @@ BinFileDataset::~BinFileDataset() = default;
 /**
  * @brief Initializes the module by reading parameters, finding files, and generating timestamps.
  */
-void BinFileDataset::initialize_rds(const mrpt::containers::yaml& c)
+void BinFileDataset::initialize_rds(const mrpt::containers::yaml& params)
 {
   using namespace std::string_literals;
 
   MRPT_START
   ProfilerEntry tle(profiler_, "initialize");
 
-  MRPT_LOG_DEBUG_STREAM("Initializing with these params:\n" << c);
+  MRPT_LOG_DEBUG_STREAM("Initializing with these params:\n" << params);
 
   // Mandatory parameters:
-  ENSURE_YAML_ENTRY_EXISTS(c, "params");
-  auto cfg = c["params"];
+  ENSURE_YAML_ENTRY_EXISTS(params, "params");
+  auto cfg = params["params"];
 
   // 1. Get parameters: 'path' (required) and 'rate_hz' (optional)
   YAML_LOAD_MEMBER_REQ(bin_dir, std::string);
@@ -126,7 +125,7 @@ size_t BinFileDataset::datasetSize() const { return lst_bin_files_.size(); }
  */
 void BinFileDataset::load_lidar(timestep_t step) const
 {
-  if (read_ahead_lidar_obs_.count(step))
+  if (read_ahead_lidar_obs_.count(step) != 0)
   {
     return;  // Already loaded
   }
@@ -209,7 +208,10 @@ void BinFileDataset::spinOnce()
   }
   else
   {
-    if (paused) return;
+    if (paused)
+    {
+      return;
+    }
     // move forward replayed dataset time:
     last_dataset_time_ += dt;
   }

--- a/mola_input_mulran_dataset/src/MulranDataset.cpp
+++ b/mola_input_mulran_dataset/src/MulranDataset.cpp
@@ -27,8 +27,6 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
-#include <mrpt/maps/CPointsMapXYZI.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
 #include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRobotPose.h>
@@ -37,6 +35,13 @@
 #include <mrpt/system/CDirectoryExplorer.h>
 #include <mrpt/system/filesystem.h>  //ASSERT_DIRECTORY_EXISTS_()
 #include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f04
+#include <mrpt/maps/CGenericPointsMap.h>
+#else
+#include <mrpt/maps/CPointsMapXYZI.h>
+#include <mrpt/maps/CPointsMapXYZIRT.h>
+#endif
 
 #include <Eigen/Dense>
 
@@ -501,32 +506,36 @@ void MulranDataset::load_lidar(timestep_t step) const
   auto obs         = mrpt::obs::CObservationPointCloud::Create();
   obs->sensorLabel = "lidar";
 
-  auto pts        = mrpt::maps::CPointsMapXYZIRT::Create();
+#if MRPT_VERSION >= 0x020f04
+  auto pts = mrpt::maps::CGenericPointsMap::Create();
+#else
+  auto pts = mrpt::maps::CPointsMapXYZIRT::Create();
+#endif
   obs->pointcloud = pts;
 
   // Load XYZI from kitti-like file:
   {
+#if MRPT_VERSION >= 0x020f04
+    mrpt::maps::CGenericPointsMap kittiData;
+#else
     mrpt::maps::CPointsMapXYZI kittiData;
+#endif
 
     bool loadOk = kittiData.loadFromKittiVelodyneFile(f);
     ASSERTMSG_(loadOk, mrpt::format("Error loading kitti scan file: '%s'", f.c_str()));
 
     // Normalize intensity data so it's maximum 1.0
 #if MRPT_VERSION >= 0x020f00  // 2.15.0
-    auto* Is = kittiData.getPointsBufferRef_float_field(
-        mrpt::maps::CPointsMapXYZIRT::POINT_FIELD_INTENSITY);
+    auto* Is = kittiData.getPointsBufferRef_float_field("intensity");
 #else
-    auto* Is = kittiData.getPointsBufferRef_intensity();
+    auto*                      Is = kittiData.getPointsBufferRef_intensity();
 #endif
     ASSERT_(Is && !Is->empty());
     const float max_intensity_inv = 1.0f / normalize_intensity_channel_maximum_;
     for (float& intensity : *Is)
     {
       intensity *= max_intensity_inv;
-      if (intensity > 1.0f)
-      {
-        intensity = 1.0f;
-      }
+      intensity = std::min(1.0f, intensity);
     }
 
     // Copy XYZI:
@@ -535,7 +544,21 @@ void MulranDataset::load_lidar(timestep_t step) const
 
   const size_t nPts = pts->size();
   ASSERT_EQUAL_(nPts, static_cast<size_t>(1024U) * 64U);
+
+#if MRPT_VERSION >= 0x020f04
+  pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+  pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+  pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
+
+  pts->resize(nPts);
+
+  auto* Ts = pts->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+  auto* Rs = pts->getPointsBufferRef_uint16_field(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
+  ASSERT_(Ts);
+  ASSERT_(Rs);
+#else
   pts->resize_XYZIRT(nPts, true /*i*/, true /*R*/, true /*t*/);
+#endif
 
   // Fixed to 10 Hz rotation in this dataset:
   const float sweepDuration = 0.1f;  //  [s]
@@ -545,70 +568,18 @@ void MulranDataset::load_lidar(timestep_t step) const
   {
     const int row = static_cast<int>(i) % 64;
     const int col = static_cast<int>(i) / 64;
+#if MRPT_VERSION >= 0x020f04
+    (*Ts)[i] = At + sweepDuration * static_cast<float>(col) / 1024.0f;
+    (*Rs)[i] = row;
+#else
     pts->setPointTime(i, At + sweepDuration * static_cast<float>(col) / 1024.0f);
     pts->setPointRing(i, row);
+#endif
   }
 
   // Pose:
   obs->sensorPose = ousterPoseOnVehicle_;
   obs->timestamp  = mrpt::Clock::fromDouble(LidarFileNameToTimestamp(lstPointCloudFiles_[step]));
-
-#if 0  // Export clouds to txt for debugging externally (e.g. python, matlab)
-    pts->saveXYZIRT_to_text_file(
-        mrpt::format("mulran_%s_%06zu.txt", sequence_.c_str(), step));
-#endif
-
-#if 0
-    {
-        auto rs         = mrpt::obs::CObservationRotatingScan::Create();
-        rs->sensorPose  = obs->sensorPose;
-        rs->sensorLabel = obs->sensorLabel;
-        rs->timestamp   = obs->timestamp;
-
-        rs->sweepDuration = 0.10;  // [sec]
-        rs->lidarModel    = "OS1-64";
-        rs->minRange      = 0.1;
-        rs->maxRange      = 120.0;
-
-        rs->columnCount     = 1024;
-        rs->rowCount        = 64;
-        rs->rangeResolution = 1e-2;  // 1 cm
-
-        rs->organizedPoints.resize(rs->rowCount, rs->columnCount);
-        rs->intensityImage.resize(rs->rowCount, rs->columnCount);
-        rs->rangeImage.resize(rs->rowCount, rs->columnCount);
-
-        auto ptsXYZI = std::dynamic_pointer_cast<mrpt::maps::CPointsMapXYZI>(
-            obs->pointcloud);
-        ASSERT_(ptsXYZI);
-
-        const auto& xs = ptsXYZI->getPointsBufferRef_x();
-        const auto& ys = ptsXYZI->getPointsBufferRef_y();
-        const auto& zs = ptsXYZI->getPointsBufferRef_z();
-
-        const size_t nPts = xs.size();
-
-        ASSERT_EQUAL_(nPts, 1024 * 64);
-
-        for (size_t i = 0; i < nPts; i++)
-        {
-            const int row = i % 64;
-            const int col = i / 64;
-
-            // intensity comes normalized [0,1]
-            const float ptInt = ptsXYZI->getPointIntensity(i);
-
-            const auto pt = mrpt::math::TPoint3Df(xs[i], ys[i], zs[i]);
-
-            rs->rangeImage(row, col)      = pt.norm() / rs->rangeResolution;
-            rs->intensityImage(row, col)  = (ptInt / 2048.0) * 255;
-            rs->organizedPoints(row, col) = pt;
-        }
-
-        // save:
-        o = std::dynamic_pointer_cast<mrpt::obs::CObservation>(rs);
-    }
-#endif
 
   // Store in the output queue:
   read_ahead_lidar_obs_[step] = std::move(obs);
@@ -683,8 +654,8 @@ mrpt::obs::CObservationGPS::Ptr MulranDataset::get_gps_by_row_index(size_t row) 
     // &stamp,&latitude,&longitude,&altitude,&cov[0],&cov[1],&cov[2],&cov[3],&cov[4],&cov[5],&cov[6],&cov[7],&cov[8]
   // clang-format on
 
-  auto gga = new mrpt::obs::gnss::Message_NMEA_GGA();
-  auto msg = mrpt::obs::gnss::gnss_message_ptr(gga);
+  auto* gga = new mrpt::obs::gnss::Message_NMEA_GGA();
+  auto  msg = mrpt::obs::gnss::gnss_message_ptr(gga);
 
   mrpt::system::TTimeParts tp;
   mrpt::system::timestampToParts(obs->timestamp, tp);

--- a/mola_input_paris_luco_dataset/include/mola_input_paris_luco_dataset/ParisLucoDataset.h
+++ b/mola_input_paris_luco_dataset/include/mola_input_paris_luco_dataset/ParisLucoDataset.h
@@ -42,14 +42,14 @@ namespace mola
  * (Paris).
  *
  * Point clouds are published as mrpt::obs::CObservationPointCloud
- * with clouds of types mrpt::maps::CPointsMapXYZIRT, with these populated
+ * with clouds of types mrpt::maps::CGenericPointsMap, with these populated
  * fields:
  * - `XYZ`
- * - `I`: Intensity, range [0.0 - 1.0?]
- * - `T`: Time of each point, in range [-0.05, 0.05] seconds (scan rate=10 Hz),
+ * - `intensity`: Intensity, range [0.0 - 1.0?]
+ * - `t`: Time of each point, in range [-0.05, 0.05] seconds (scan rate=10 Hz),
  *   such that "t=0" (the observation/scan timestamp) corresponds to the moment
  *   the scanner is facing forward.
- * - `R`: ring_id (0-31). It was not provided by the original dataset, but it is
+ * - `ring`: ring_id (0-31). It was not provided by the original dataset, but it is
  *   reconstructed from point elevation data in this package.
  *
  * Expected contents under `base_dir` directory:

--- a/mola_input_paris_luco_dataset/src/ParisLucoDataset.cpp
+++ b/mola_input_paris_luco_dataset/src/ParisLucoDataset.cpp
@@ -273,6 +273,8 @@ void ParisLucoDataset::load_lidar(timestep_t step) const
 
 #if MRPT_VERSION >= 0x020f04  // 2.15.4
   auto pts = mrpt::maps::CGenericPointsMap::Create();
+  pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+  pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
 #else
   auto  pts = mrpt::maps::CPointsMapXYZIRT::Create();
 #endif
@@ -326,12 +328,12 @@ void ParisLucoDataset::load_lidar(timestep_t step) const
 
   for (size_t i = 0; i < nPts; i++)
   {
-    const float depth = sqrt(mrpt::square(xs[i]) + mrpt::square(ys[i]));
+    const float depth = std::sqrt(mrpt::square(xs[i]) + mrpt::square(ys[i]));
     if (depth < 0.05)
     {
       continue;
     }
-    const float pitch = asin(zs[i] / depth);
+    const float pitch = std::asin(zs[i] / depth);
 
     int iP = mrpt::round(31 * (pitch + fov_down) / fov);
     mrpt::saturate(iP, 0, 31);
@@ -351,11 +353,6 @@ void ParisLucoDataset::load_lidar(timestep_t step) const
   // Lidar is at the origin of the vehicle frame:
   obs->sensorPose = mrpt::poses::CPose3D();
   obs->timestamp  = mrpt::Clock::fromDouble(lst_timestamps_.at(step));
-
-#if 0  // Export clouds to txt for debugging externally (e.g. python, matlab)
-    obs->pointcloud->save3D_to_text_file(
-        mrpt::format("paris_%s_%06zu.txt", sequence_.c_str(), step));
-#endif
 
   mrpt::obs::CObservation::Ptr o;
   o                           = std::dynamic_pointer_cast<mrpt::obs::CObservation>(obs);

--- a/mola_input_rawlog/src/RawlogDataset.cpp
+++ b/mola_input_rawlog/src/RawlogDataset.cpp
@@ -138,7 +138,10 @@ void RawlogDataset::spinOnce()
   }
   else
   {
-    if (paused) return;
+    if (paused)
+    {
+      return;
+    }
     // move forward replayed dataset time:
     last_dataset_time_ += dt;
   }

--- a/mola_kernel/src/interfaces/ExecutableBase.cpp
+++ b/mola_kernel/src/interfaces/ExecutableBase.cpp
@@ -66,7 +66,10 @@ void ExecutableBase::exposeParameters(const mrpt::containers::yaml& names_values
 {
   auto lck = mrpt::lockHelper(module_params_mtx_);
 
-  if (names_values.isNullNode() || names_values.empty()) return;
+  if (names_values.isNullNode() || names_values.empty())
+  {
+    return;
+  }
 
   ASSERT_(names_values.isMap());
 
@@ -89,7 +92,10 @@ void ExecutableBase::changeParameters(const mrpt::containers::yaml& names_values
 {
   auto lck = mrpt::lockHelper(module_params_mtx_);
 
-  if (names_values.isNullNode() || names_values.empty()) return;
+  if (names_values.isNullNode() || names_values.empty())
+  {
+    return;
+  }
   ASSERT_(names_values.isMap());
 
   for (const auto& [k, v] : names_values.asMapRange())

--- a/mola_launcher/src/MolaLauncherApp.cpp
+++ b/mola_launcher/src/MolaLauncherApp.cpp
@@ -73,7 +73,10 @@ void from_env_var_to_list(
   // Append to list:
   for (const auto& path : pathList)
   {
-    if (!subStringPattern.empty() && path.find(subStringPattern) == std::string::npos) continue;
+    if (!subStringPattern.empty() && path.find(subStringPattern) == std::string::npos)
+    {
+      continue;
+    }
     safe_add_to_list(path, lst);
   }
 }
@@ -112,7 +115,10 @@ MolaLauncherApp::MolaLauncherApp() : mrpt::system::COutputLogger("MolaLauncherAp
 
 MolaLauncherApp::~MolaLauncherApp()
 {
-  if (running_threads_.empty()) return;
+  if (running_threads_.empty())
+  {
+    return;
+  }
   this->shutdown();
 }
 
@@ -238,7 +244,10 @@ void MolaLauncherApp::setup(
       ENSURE_YAML_ENTRY_EXISTS(ds, "params");
 
       // Allow quickly disabling sections:
-      if (!ds.getOrDefault("enabled", true)) continue;
+      if (!ds.getOrDefault("enabled", true))
+      {
+        continue;
+      }
 
       const auto ds_label = ds["name"].as<std::string>();
       ASSERTMSG_(!ds_label.empty(), "`name` cannot be empty!");
@@ -273,7 +282,10 @@ void MolaLauncherApp::setup(
         mola::Yaml old = mola::Yaml::Map();
         for (const auto& [k, v] : info.yaml_cfg_block.asMap())
         {
-          if (k.as<std::string>() == "params") continue;
+          if (k.as<std::string>() == "params")
+          {
+            continue;
+          }
           old[k.as<std::string>()] = v;
         }
 
@@ -400,7 +412,10 @@ void MolaLauncherApp::executor_thread(InfoPerRunningThread& rds)
 {
   try
   {
-    if (threads_must_end_) return;
+    if (threads_must_end_)
+    {
+      return;
+    }
 
     // Initilize:
     MRPT_LOG_DEBUG_STREAM(
@@ -530,7 +545,10 @@ std::map<MolaLauncherApp::module_name_t, MolaLauncherApp::module_shared_path_t>
     direxpl::explore(path, FILE_ATTRIB_DIRECTORY, lst);
     for (const auto& dir : lst)
     {
-      if (!mrpt::system::fileExists(dir.wholePath + "/mola-module.yml"s)) continue;
+      if (!mrpt::system::fileExists(dir.wholePath + "/mola-module.yml"s))
+      {
+        continue;
+      }
 
       found.emplace(dir.name, dir.wholePath);
     }

--- a/mola_metric_maps/src/HashedVoxelPointCloud.cpp
+++ b/mola_metric_maps/src/HashedVoxelPointCloud.cpp
@@ -196,7 +196,10 @@ std::string HashedVoxelPointCloud::asString() const
 void HashedVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
 {
   MRPT_START
-  if (!genericMapParams.enableSaveAs3DObject) return;
+  if (!genericMapParams.enableSaveAs3DObject)
+  {
+    return;
+  }
 
   if (renderOptions.colormap == mrpt::img::cmNONE)
   {
@@ -535,7 +538,10 @@ double HashedVoxelPointCloud::internal_computeObservationLikelihoodPointCloud3D(
     const auto gPt = pc_in_map.composePoint({xs[i], ys[i], zs[i]});
 
     const bool found = nn_single_search(gPt, closest, closest_err, closest_id);
-    if (!found) continue;
+    if (!found)
+    {
+      continue;
+    }
 
     // Put a limit:
     mrpt::keep_min(closest_err, max_sqr_err);
@@ -613,7 +619,10 @@ void HashedVoxelPointCloud::insertPoint(const mrpt::math::TPoint3Df& pt)
     const float minDistSqr = mrpt::square(insertionOptions.min_distance_between_points);
 
     // Skip if the point is too close to existing ones:
-    if (curClosestDistSqr.value() < minDistSqr) return;
+    if (curClosestDistSqr.value() < minDistSqr)
+    {
+      return;
+    }
   }
 
   v.insertPoint(pt);
@@ -718,7 +727,10 @@ void HashedVoxelPointCloud::nn_multiple_search_impl(
     {
       if (sqrDist < matches[i].sqrDist) break;
     }
-    if (i >= MAX_KNN) return;
+    if (i >= MAX_KNN)
+    {
+      return;
+    }
 
     // insert new one at [i], shift [i+1:end] one position.
     const size_t last = std::min(foundMatches + 1, MAX_KNN);
@@ -770,7 +782,10 @@ void HashedVoxelPointCloud::nn_radius_search(
   out_dists_sqr.clear();
   resultIndicesOrIDs.clear();
 
-  if (search_radius_sqr <= 0) return;
+  if (search_radius_sqr <= 0)
+  {
+    return;
+  }
 
   const float radius   = std::sqrt(search_radius_sqr);
   const auto  diagonal = mrpt::math::TPoint3Df(1.0f, 1.0f, 1.0f) * radius;
@@ -799,7 +814,10 @@ void HashedVoxelPointCloud::nn_radius_search(
     {
       if (sqrDist < matches[i].sqrDist) break;
     }
-    if (i >= HARD_MAX_MATCHES) return;
+    if (i >= HARD_MAX_MATCHES)
+    {
+      return;
+    }
 
     // insert new one at [i], shift [i+1:end] one position.
     const size_t last = std::min(foundMatches + 1, HARD_MAX_MATCHES);
@@ -821,7 +839,10 @@ void HashedVoxelPointCloud::nn_radius_search(
       {
         const auto& pt      = pts[i];
         float       distSqr = (pt - query).sqrNorm();
-        if (distSqr > search_radius_sqr) continue;
+        if (distSqr > search_radius_sqr)
+        {
+          continue;
+        }
 
         const auto id = g2plain(p, i);
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -1193,11 +1193,13 @@ std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFra
     obj->setAllPointsAlpha(alpha_u8);
   }
 
+#if MRPT_VERSION >= 0x020f03
   mrpt::obs::PointCloudRecoloringParameters pcdCol;
   pcdCol.colorMap        = ro.colormap;
   pcdCol.colorizeByField = ro.recolorByPointField;
 
   mrpt::obs::recolorize3Dpc(obj, pointcloud().get(), pcdCol);
+#endif
 
   cached_viz_ = obj;
   return cached_viz_;

--- a/mola_metric_maps/src/NDT.cpp
+++ b/mola_metric_maps/src/NDT.cpp
@@ -767,7 +767,10 @@ void NDT::insertPoint(const mrpt::math::TPoint3Df& pt, const mrpt::math::TPoint3
     const float minDistSqr = mrpt::square(insertionOptions.min_distance_between_points);
 
     // Skip if the point is too close to existing ones:
-    if (curClosestDistSqr.value() < minDistSqr) return;
+    if (curClosestDistSqr.value() < minDistSqr)
+    {
+      return;
+    }
   }
 
   v.insertPoint(pt, sensorPose);

--- a/mola_metric_maps/src/SparseVoxelPointCloud.cpp
+++ b/mola_metric_maps/src/SparseVoxelPointCloud.cpp
@@ -178,7 +178,10 @@ void SparseVoxelPointCloud::serializeFrom(mrpt::serialization::CArchive& in, uin
 void SparseVoxelPointCloud::VoxelData::insertPoint(
     const mrpt::math::TPoint3Df& p, InnerGrid& parent)
 {
-  if (numPoints_ >= HARDLIMIT_MAX_POINTS_PER_VOXEL) return;
+  if (numPoints_ >= HARDLIMIT_MAX_POINTS_PER_VOXEL)
+  {
+    return;
+  }
 
   mean_ = (numPoints_ * mean_ + p);
 
@@ -219,7 +222,10 @@ std::string SparseVoxelPointCloud::asString() const
 void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
 {
   MRPT_START
-  if (!genericMapParams.enableSaveAs3DObject) return;
+  if (!genericMapParams.enableSaveAs3DObject)
+  {
+    return;
+  }
 
   if (renderOptions.colormap == mrpt::img::cmNONE)
   {
@@ -273,7 +279,10 @@ void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
                                          const outer_index3d_t&, const inner_plain_index_t,
                                          const VoxelData& v, const InnerGrid& parentGrid)
       {
-        if (v.points(parentGrid).empty()) return;
+        if (v.points(parentGrid).empty())
+        {
+          return;
+        }
         const auto& m = v.mean();
         obj->insertPoint({m.x, m.y, m.z, 0, 0, 0});
         for (int i = 0; i < 3; i++) hists[i].add(m[i]);
@@ -558,7 +567,10 @@ double SparseVoxelPointCloud::internal_computeObservationLikelihoodPointCloud3D(
     const auto gPt = pc_in_map.composePoint({xs[i], ys[i], zs[i]});
 
     const bool found = nn_single_search(gPt, closest, closest_err, closest_id);
-    if (!found) continue;
+    if (!found)
+    {
+      continue;
+    }
 
     // Put a limit:
     mrpt::keep_min(closest_err, max_sqr_err);
@@ -700,7 +712,10 @@ void SparseVoxelPointCloud::nn_radius_search(
   out_dists_sqr.clear();
   resultIndicesOrIDs.clear();
 
-  if (search_radius_sqr <= 0) return;
+  if (search_radius_sqr <= 0)
+  {
+    return;
+  }
 
   const float radius   = std::sqrt(search_radius_sqr);
   const auto  diagonal = mrpt::math::TPoint3Df(1.0f, 1.0f, 1.0f) * radius;
@@ -733,7 +748,10 @@ void SparseVoxelPointCloud::nn_radius_search(
       {
         const auto& m       = v->mean();
         const float distSqr = (m - query).sqrNorm();
-        if (distSqr > search_radius_sqr) return;
+        if (distSqr > search_radius_sqr)
+        {
+          return;
+        }
         //  Unique ID for each global index triplet
         const auto id = g2plain(p);
         lmbAddCandidate(distSqr, m, id);
@@ -745,7 +763,10 @@ void SparseVoxelPointCloud::nn_radius_search(
         {
           const auto& pt      = pts[i];
           float       distSqr = (pt - query).sqrNorm();
-          if (distSqr > search_radius_sqr) continue;
+          if (distSqr > search_radius_sqr)
+          {
+            continue;
+          }
 
           lmbAddCandidate(distSqr, pt, g2plain(p, i));
         }

--- a/mola_relocalization/src/RelocalizationICP_SE2.cpp
+++ b/mola_relocalization/src/RelocalizationICP_SE2.cpp
@@ -101,7 +101,10 @@ mola::RelocalizationICP_SE2::Output mola::RelocalizationICP_SE2::run(const Input
                 in.on_progress_callback(p);
               }
 
-              if (icpResult.quality < in.icp_minimum_quality) return;
+              if (icpResult.quality < in.icp_minimum_quality)
+              {
+                return;
+              }
 
               // accept result:
               auto lck2 = mrpt::lockHelper(resultMtx);

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -219,7 +219,10 @@ void recursiveParseNodeForIncludes(yaml::node_t& n, const mola::YAMLParseOptions
     std::string text = n.as<std::string>();
 
     const auto start = text.find("$include{");
-    if (start == std::string::npos) return;
+    if (start == std::string::npos)
+    {
+      return;
+    }
 
     const std::string pre  = text.substr(0, start);
     const std::string post = text.substr(start + 9);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point clouds now expose per-point timestamps and ring IDs when the runtime supports them.

* **Bug Fixes**
  * Improved stability and safety in dataset loading and point‑cloud processing; intensity clamping/normalization applied.

* **Chores**
  * CI matrix expanded to cover additional ROS distributions.
  * Compatibility guards and widespread style/consistency updates across dataset and point‑cloud modules.

* **Documentation**
  * Updated dataset and point‑cloud docs to reflect field names and normalized intensity handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->