### PR TITLE
Support gps_msgs data types too for ROS2

### DIFF
--- a/mola_bridge_ros2/CMakeLists.txt
+++ b/mola_bridge_ros2/CMakeLists.txt
@@ -26,21 +26,23 @@ endif()
 # MOLA core dependencies:
 # MOLA CMake scripts: "mola_xxx()"
 find_package(mola_common REQUIRED)
-find_mola_package(mola_kernel REQUIRED)
+find_mola_package(mola_kernel)
 
 # Find ROS 2 pkgs:
-mola_find_package_or_return(ament_cmake REQUIRED)
-mola_find_package_or_return(geometry_msgs REQUIRED)
-mola_find_package_or_return(nav_msgs REQUIRED)
-mola_find_package_or_return(rclcpp REQUIRED)
-mola_find_package_or_return(sensor_msgs REQUIRED)
-mola_find_package_or_return(geographic_msgs REQUIRED)
-mola_find_package_or_return(tf2 REQUIRED)
-mola_find_package_or_return(tf2_geometry_msgs REQUIRED)
+mola_find_package_or_return(ament_cmake)
+mola_find_package_or_return(geometry_msgs)
+mola_find_package_or_return(nav_msgs)
+mola_find_package_or_return(rclcpp)
+mola_find_package_or_return(sensor_msgs)
+mola_find_package_or_return(geographic_msgs)
+mola_find_package_or_return(tf2)
+mola_find_package_or_return(tf2_geometry_msgs)
+
+find_package(gps_msgs QUIET) # optional
 
 # MOLA ROS2 services:
-mola_find_package_or_return(mola_msgs REQUIRED)
-mola_find_package_or_return(mrpt_nav_interfaces REQUIRED)
+mola_find_package_or_return(mola_msgs)
+mola_find_package_or_return(mrpt_nav_interfaces)
 
 # -----------------------
 # define lib:
@@ -65,6 +67,7 @@ mola_add_library(
     ${tf2_geometry_msgs_TARGETS}
     ${mrpt_nav_interfaces_TARGETS}
     ${mola_msgs_TARGETS}
+    ${gps_msgs_TARGETS}
   CMAKE_DEPENDENCIES
     mola_kernel
     mrpt-maps
@@ -74,6 +77,11 @@ mola_add_library(
 mola_version_to_hexadecimal(mrpt_libros_bridge_VERSION_HEX ${mrpt_libros_bridge_VERSION})
 target_compile_definitions(${PROJECT_NAME} PRIVATE MRPT_ROS2_BRIDGE_VERSION=${mrpt_libros_bridge_VERSION_HEX})
 message(STATUS "Found: mrpt_libros_bridge_VERSION: ${mrpt_libros_bridge_VERSION} (${mrpt_libros_bridge_VERSION_HEX})")
+
+if (gps_msgs_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_GPS_MSGS)
+endif()
+
 
 ament_export_dependencies()
 # Export modern CMake targets

--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -50,6 +50,10 @@
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#if defined(HAS_GPS_MSGS)
+#include <gps_msgs/msg/gps_fix.hpp>
+#endif
+
 // MOLA <-> ROS services:
 #include <mola_msgs/srv/map_load.hpp>
 #include <mola_msgs/srv/map_save.hpp>
@@ -238,15 +242,13 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
     return rosNode_;
   }
   std::vector<rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr> subsPointCloud_;
-
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr> subsLaserScan_;
-
-  std::vector<rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr> subsOdometry_;
-
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr> subsImu_;
-
-  std::vector<rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr> subsGNSS_;
-
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr>   subsLaserScan_;
+  std::vector<rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr>       subsOdometry_;
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr>         subsImu_;
+  std::vector<rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr>   subsGNSS_;
+#if defined(HAS_GPS_MSGS)
+  std::vector<rclcpp::Subscription<gps_msgs::msg::GPSFix>::SharedPtr> subsGPSMsg_;
+#endif
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr subInitPose_;
 
   void callbackOnPointCloud2(
@@ -264,6 +266,12 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
   void callbackOnNavSatFix(
       const sensor_msgs::msg::NavSatFix& o, const std::string& outSensorLabel,
       const std::optional<mrpt::poses::CPose3D>& fixedSensorPose);
+
+#if defined(HAS_GPS_MSGS)
+  void callbackOnGpsMsg(
+      const gps_msgs::msg::GPSFix& o, const std::string& outSensorLabel,
+      const std::optional<mrpt::poses::CPose3D>& fixedSensorPose);
+#endif
 
   void callbackOnOdometry(const nav_msgs::msg::Odometry& o, const std::string& outSensorLabel);
 

--- a/mola_bridge_ros2/package.xml
+++ b/mola_bridge_ros2/package.xml
@@ -33,6 +33,7 @@
   <depend>mrpt_nav_interfaces</depend>
   <depend>nav_msgs</depend>
   <depend>geographic_msgs</depend>
+  <depend>gps_msgs</depend>  <!-- optional -->
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -706,6 +706,58 @@ void BridgeROS2::callbackOnNavSatFix(
   MRPT_END
 }
 
+#if defined(HAS_GPS_MSGS)
+void BridgeROS2::callbackOnGpsMsg(
+    const gps_msgs::msg::GPSFix& o, const std::string& outSensorLabel,
+    const std::optional<mrpt::poses::CPose3D>& fixedSensorPose)
+{
+  MRPT_START
+
+  MRPT_LOG_DEBUG_STREAM(
+      "BridgeROS2::callbackOnGpsMsg: received GpsMsg on topic '" << outSensorLabel << "'.");
+
+  const ProfilerEntry tle(profiler_, "callbackOnGpsMsg");
+
+  // Sensor pose wrt robot base:
+  mrpt::poses::CPose3D sensorPose;
+  if (fixedSensorPose)
+  {
+    // use a fixed, user-provided sensor pose:
+    sensorPose = fixedSensorPose.value();
+  }
+  else
+  {
+    // Get pose from tf:
+    bool ok = waitForTransform(
+        sensorPose, o.header.frame_id, params_.base_link_frame, true /*print errors*/);
+    if (!ok)
+    {
+      MRPT_LOG_ERROR_FMT(
+          "Could not forward ROS2 observation to MOLA due to timeout "
+          "waiting for /tf transform '%s'->'%s' for timestamp=%f.",
+          params_.base_link_frame.c_str(), o.header.frame_id.c_str(),
+          o.header.stamp.sec + o.header.stamp.nanosec * 1e-9);
+      return;
+    }
+  }
+
+  auto obs = mrpt::obs::CObservationGPS::Create();
+#if MRPT_ROS2_BRIDGE_VERSION >= 0x030300
+  mrpt::ros2bridge::fromROS(o, *obs);
+#else
+  THROW_EXCEPTION("Using gps_msgs requires mrpt_ros_bridge>=3.3.0");
+#endif
+
+  obs->sensorPose  = sensorPose;
+  obs->sensorLabel = outSensorLabel;
+
+  // send it out:
+  this->sendObservationsToFrontEnds(obs);
+
+  MRPT_END
+}
+#endif
+
 void BridgeROS2::onNewObservation(const CObservation::ConstPtr& o)
 {
   using namespace mrpt::obs;
@@ -1882,6 +1934,13 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
           topic_name, qos,
           [this, output_sensor_label, fixedSensorPose](const sensor_msgs::msg::NavSatFix& o)
           { this->callbackOnNavSatFix(o, output_sensor_label, fixedSensorPose); }));
+    }
+    else if (type == "GpsFix")
+    {
+      subsGPSMsg_.emplace_back(rosNode_->create_subscription<gps_msgs::msg::GPSFix>(
+          topic_name, qos,
+          [this, output_sensor_label, fixedSensorPose](const gps_msgs::msg::GPSFix& o)
+          { this->callbackOnGpsMsg(o, output_sensor_label, fixedSensorPose); }));
     }
     else if (type == "Odometry")
     {

--- a/mola_input_lidar_bin_dataset/CMakeLists.txt
+++ b/mola_input_lidar_bin_dataset/CMakeLists.txt
@@ -22,8 +22,8 @@ find_package(mrpt-obs REQUIRED)     # For CObservationPointCloud
 find_package(mrpt-system REQUIRED)  # For file system utilities
 find_package(mrpt-core REQUIRED)    # For mrpt::Clock
 
-find_mola_package(mola_kernel REQUIRED)
-find_mola_package(mola_yaml REQUIRED) # For parameter parsing
+find_mola_package(mola_kernel)
+find_mola_package(mola_yaml) # For parameter parsing
 
 # -----------------------
 # define lib:

--- a/mola_input_rosbag2/CMakeLists.txt
+++ b/mola_input_rosbag2/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(gps_msgs QUIET) # optional
 
 find_mola_package(mola_kernel)
 
@@ -47,6 +48,7 @@ mola_add_library(
     tf2_msgs::tf2_msgs__rosidl_typesupport_cpp
     sensor_msgs::sensor_msgs_library
     cv_bridge::cv_bridge
+    ${gps_msgs_TARGETS}
   CMAKE_DEPENDENCIES
     mola_kernel
     mrpt-obs
@@ -63,3 +65,7 @@ message(STATUS "Found: cv_bridge_VERSION: ${cv_bridge_VERSION} (${cv_bridge_VERS
 mola_version_to_hexadecimal(mrpt_libros_bridge_VERSION_HEX ${mrpt_libros_bridge_VERSION})
 target_compile_definitions(${PROJECT_NAME} PRIVATE MRPT_ROS2_BRIDGE_VERSION=${mrpt_libros_bridge_VERSION_HEX})
 message(STATUS "Found: mrpt_libros_bridge_VERSION: ${mrpt_libros_bridge_VERSION} (${mrpt_libros_bridge_VERSION_HEX})")
+
+if (gps_msgs_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_GPS_MSGS)
+endif()

--- a/mola_input_rosbag2/package.xml
+++ b/mola_input_rosbag2/package.xml
@@ -14,6 +14,7 @@
   <url type="website">https://github.com/MOLAorg/mola/tree/develop/mola_input_rosbag2</url>
 
   <depend>cv_bridge</depend>
+  <depend>gps_msgs</depend>  <!-- optional -->
   <depend>mola_kernel</depend>
   <depend>mrpt_libobs</depend>
   <depend>mrpt_libros_bridge</depend>

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -97,7 +97,8 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
       {"sensor_msgs/msg/Image", "CObservationImage"},
       {"sensor_msgs/msg/PointCloud2", "CObservationPointCloud"},
       {"sensor_msgs/msg/LaserScan", "CObservation2DRangeScan"},
-      {"sensor_msgs/msg/NavSatFix", "CObservationGPS"},
+      {"sensor_msgs/msg/NavSatFix", "CObservationGPS_NavSatFix"},
+      {"gps_msgs/msg/GPSFix", "CObservationGPS_GpsFix"},
   };
 
   MRPT_START
@@ -139,11 +140,8 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
       else
       {
         THROW_EXCEPTION_FMT(
-            "Argument 'rosbag_storage_id' was not provided and could "
-            "not "
-            "determine the rosbag2 format from unknown extension of "
-            "file "
-            "'%s'",
+            "Argument 'rosbag_storage_id' was not provided and could not determine the rosbag2 "
+            "format from unknown extension of file '%s'",
             rosbag_filename_.c_str());
       }
     }
@@ -268,22 +266,39 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
     }
     else
     {
-      ASSERTMSG_(
-          topic2type.count(topic), mrpt::format(
-                                       "'sensors' contains topic '%s' which is not found in the "
-                                       "rosbag!",
-                                       topic.c_str()));
-
-      auto itType = mapTopic2Class.find(topic2type.at(topic));
-      if (itType == mapTopic2Class.end())
+      bool topic_is_optional = false;
+      if (sensor.count("is_optional") != 0 && sensor.at("is_optional").as<bool>())
       {
-        THROW_EXCEPTION_FMT(
-            "'sensors' contains topic '%s' without a 'type' entry, but "
-            "could not automatically determine its mapping to "
-            "mrpt::obs classes.",
-            topic.c_str());
+        topic_is_optional = true;
       }
-      sensorType = itType->second;
+
+      if (topic2type.count(topic) == 0)
+      {
+        if (!topic_is_optional)
+        {
+          THROW_EXCEPTION_FMT(
+              "'sensors' contains topic '%s' which is not found in the rosbag and is not marked as "
+              "'is_optional'!",
+              topic.c_str());
+        }
+      }
+      else
+      {
+        auto itType = mapTopic2Class.find(topic2type.at(topic));
+        if (itType == mapTopic2Class.end())
+        {
+          THROW_EXCEPTION_FMT(
+              "'sensors' contains topic '%s' without a 'type' entry, but "
+              "could not automatically determine its mapping to "
+              "mrpt::obs classes.",
+              topic.c_str());
+        }
+        sensorType = itType->second;
+
+        MRPT_LOG_INFO_FMT(
+            "Topic '%s' listed in 'sensors' with automatic mapping, determined to be '%s'",
+            topic.c_str(), sensorType.c_str());
+      }
     }
 
     // Optional: fixed sensorPose (then ignores/don't need "tf" data):
@@ -324,8 +339,36 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
         {"CObservation2DRangeScan", &mrpt::ros2bridge::rosbag2ToLidar2D},
         {"CObservationRotatingScan", &mrpt::ros2bridge::rosbag2ToRotatingScan},
         {"CObservationIMU", &mrpt::ros2bridge::rosbag2ToIMU},
-        {"CObservationGPS", &mrpt::ros2bridge::rosbag2ToGPS},
+        {
+            "CObservationGPS_NavSatFix",
+            static_cast<ConvFunc>(
+                [](std::string_view                             sensor_label,
+                   const rosbag2_storage::SerializedBagMessage& rosmsg, tf2::BufferCore& tfBuffer,
+                   const std::string&                         base_link_frame,
+                   const std::optional<mrpt::poses::CPose3D>& fixed_sensor_pose)
+                {
+                  return mrpt::ros2bridge::rosbag2ToGPS(
+                      sensor_label, rosmsg, tfBuffer, base_link_frame, fixed_sensor_pose);
+                }),
+        },
+        {
+            "CObservationGPS_GpsFix",
+            static_cast<ConvFunc>(
+                [](std::string_view                             sensor_label,
+                   const rosbag2_storage::SerializedBagMessage& rosmsg, tf2::BufferCore& tfBuffer,
+                   const std::string&                         base_link_frame,
+                   const std::optional<mrpt::poses::CPose3D>& fixed_sensor_pose) -> Obs
+                {
+#if MRPT_ROS2_BRIDGE_VERSION >= 0x030500
+                  return mrpt::ros2bridge::rosbag2ToGPS(
+                      sensor_label, rosmsg, tfBuffer, base_link_frame, fixed_sensor_pose, true);
+#else
+                  THROW_EXCEPTION("mrpt_ros_bridge >=3.5.0 required for GpsFix messages");
+#endif
+                }),
+        },
     };
+
     if (auto it = converters.find(sensorType); it != converters.end())
     {
       auto convFn   = it->second;
@@ -336,6 +379,7 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
             [this, sensorLabel, fixedSensorPose, convFn, m]() -> Obs
             { return convFn(sensorLabel, m, *tfBuffer_, base_link_frame_id_, fixedSensorPose); });
       };
+      MRPT_LOG_INFO_STREAM("Installing callback for topic '" << topic << "'");
       lookup_[topic].emplace_back(callback);
     }
 
@@ -348,6 +392,7 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
             [sensorLabel, fixedSensorPose, m]() -> Obs
             { return mrpt::ros2bridge::rosbag2ToOdometry(sensorLabel, m); });
       };
+      MRPT_LOG_INFO_STREAM("Installing callback for topic '" << topic << "'");
       lookup_[topic].emplace_back(callback);
     }
 #else
@@ -384,7 +429,7 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
       { return catchExceptions([=]() { return toIMU(sensorLabel, m, fixedSensorPose); }); };
       lookup_[topic].emplace_back(callback);
     }
-    else if (sensorType == "CObservationGPS")
+    else if (sensorType == "CObservationGPS_NavSatFix")
     {
       auto callback = [=](const rosbag2_storage::SerializedBagMessage& m)
       { return catchExceptions([=]() { return toGPS(sensorLabel, m, fixedSensorPose); }); };

--- a/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
+++ b/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
@@ -24,9 +24,14 @@
 #include <mrpt/core/WorkerThreadsPool.h>
 #include <mrpt/core/initializer.h>
 #include <mrpt/core/pimpl.h>
-#include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/obs/CObservation.h>
 #include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/CCompressedOutputStream.h>
+#else
+#include <mrpt/io/CFileGZOutputStream.h>
+#endif
 
 namespace mola
 {
@@ -90,8 +95,12 @@ class RawDataSourceBase : public mola::ExecutableBase
   std::vector<RawDataConsumer*> rdc_;
 
   /** used to optionally export captured observations to an MRPT rawlog */
+#if MRPT_VERSION >= 0x020f07
+  mrpt::io::CCompressedOutputStream export_to_rawlog_out_;
+#else
   mrpt::io::CFileGZOutputStream export_to_rawlog_out_;
-  mrpt::WorkerThreadsPool       worker_pool_export_rawlog_{
+#endif
+  mrpt::WorkerThreadsPool worker_pool_export_rawlog_{
       1, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_pool_export_rawlog"};
 
   mrpt::WorkerThreadsPool gui_updater_threadpool_{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GPS message support across bridge and rosbag2 with conditional handling and new GPS-to-observation mappings.
  * Rosbag2 reader: optional topic handling and improved logging when topics are auto-mapped and callbacks installed.

* **Chores**
  * Made gps-related and several build dependencies optional; updated package manifests and link handling.
  * Improved compatibility across MRPT versions, including conditional selection of compressed output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->