### PR TITLE
Clean up: remove old mrpt version fallback code sections

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -50,7 +50,7 @@
 #include <mrpt/ros2bridge/time.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/topography/conversions.h>
-#include <mrpt/version.h>
+#include <mrpt/version.h>  // For MRPT_VERSION
 
 #if MRPT_ROS2_BRIDGE_VERSION >= 0x030400
 #include <mrpt/ros2bridge/ros_to_mrpt_obs.h>

--- a/mola_input_kitti360_dataset/src/Kitti360Dataset.cpp
+++ b/mola_input_kitti360_dataset/src/Kitti360Dataset.cpp
@@ -37,7 +37,6 @@
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/system/CDirectoryExplorer.h>
 #include <mrpt/system/filesystem.h>  //ASSERT_DIRECTORY_EXISTS_()
-#include <mrpt/version.h>
 
 #include <Eigen/Dense>
 #include <regex>
@@ -686,11 +685,7 @@ void Kitti360Dataset::load_lidar(timestep_t step) const
 
     for (size_t i = 0; i < xs.size(); i++)
     {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
       newPts->insertPointFrom(i, ctx);
-#else
-      newPts->insertPointFrom(*obs->pointcloud, i, ctx);
-#endif
 
       const auto  azimuth = std::atan2(ys[i], xs[i]);
       const float ptTime  = -0.05f * (azimuth + M_PIf) / (2.0f * M_PIf);

--- a/mola_input_mulran_dataset/src/MulranDataset.cpp
+++ b/mola_input_mulran_dataset/src/MulranDataset.cpp
@@ -27,6 +27,7 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRobotPose.h>
@@ -34,14 +35,6 @@
 #include <mrpt/obs/gnss_messages_ascii_nmea.h>
 #include <mrpt/system/CDirectoryExplorer.h>
 #include <mrpt/system/filesystem.h>  //ASSERT_DIRECTORY_EXISTS_()
-#include <mrpt/version.h>
-
-#if MRPT_VERSION >= 0x020f04
-#include <mrpt/maps/CGenericPointsMap.h>
-#else
-#include <mrpt/maps/CPointsMapXYZI.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#endif
 
 #include <Eigen/Dense>
 
@@ -506,30 +499,18 @@ void MulranDataset::load_lidar(timestep_t step) const
   auto obs         = mrpt::obs::CObservationPointCloud::Create();
   obs->sensorLabel = "lidar";
 
-#if MRPT_VERSION >= 0x020f04
-  auto pts = mrpt::maps::CGenericPointsMap::Create();
-#else
-  auto pts = mrpt::maps::CPointsMapXYZIRT::Create();
-#endif
+  auto pts        = mrpt::maps::CGenericPointsMap::Create();
   obs->pointcloud = pts;
 
   // Load XYZI from kitti-like file:
   {
-#if MRPT_VERSION >= 0x020f04
     mrpt::maps::CGenericPointsMap kittiData;
-#else
-    mrpt::maps::CPointsMapXYZI kittiData;
-#endif
 
     bool loadOk = kittiData.loadFromKittiVelodyneFile(f);
     ASSERTMSG_(loadOk, mrpt::format("Error loading kitti scan file: '%s'", f.c_str()));
 
     // Normalize intensity data so it's maximum 1.0
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     auto* Is = kittiData.getPointsBufferRef_float_field("intensity");
-#else
-    auto*                      Is = kittiData.getPointsBufferRef_intensity();
-#endif
     ASSERT_(Is && !Is->empty());
     const float max_intensity_inv = 1.0f / normalize_intensity_channel_maximum_;
     for (float& intensity : *Is)
@@ -545,7 +526,6 @@ void MulranDataset::load_lidar(timestep_t step) const
   const size_t nPts = pts->size();
   ASSERT_EQUAL_(nPts, static_cast<size_t>(1024U) * 64U);
 
-#if MRPT_VERSION >= 0x020f04
   // Intensity already exists.
   pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
   pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
@@ -556,9 +536,6 @@ void MulranDataset::load_lidar(timestep_t step) const
   auto* Rs = pts->getPointsBufferRef_uint16_field(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
   ASSERT_(Ts);
   ASSERT_(Rs);
-#else
-  pts->resize_XYZIRT(nPts, true /*i*/, true /*R*/, true /*t*/);
-#endif
 
   // Fixed to 10 Hz rotation in this dataset:
   const float sweepDuration = 0.1f;  //  [s]
@@ -568,13 +545,8 @@ void MulranDataset::load_lidar(timestep_t step) const
   {
     const int row = static_cast<int>(i) % 64;
     const int col = static_cast<int>(i) / 64;
-#if MRPT_VERSION >= 0x020f04
-    (*Ts)[i] = At + sweepDuration * static_cast<float>(col) / 1024.0f;
-    (*Rs)[i] = row;
-#else
-    pts->setPointTime(i, At + sweepDuration * static_cast<float>(col) / 1024.0f);
-    pts->setPointRing(i, row);
-#endif
+    (*Ts)[i]      = At + sweepDuration * static_cast<float>(col) / 1024.0f;
+    (*Rs)[i]      = row;
   }
 
   // Pose:

--- a/mola_input_paris_luco_dataset/src/ParisLucoDataset.cpp
+++ b/mola_input_paris_luco_dataset/src/ParisLucoDataset.cpp
@@ -27,19 +27,13 @@
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
 #include <mrpt/core/round.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationImage.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRobotPose.h>
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/system/CDirectoryExplorer.h>
 #include <mrpt/system/filesystem.h>  //ASSERT_DIRECTORY_EXISTS_()
-#include <mrpt/version.h>
-
-#if MRPT_VERSION >= 0x020f04  // 2.15.4
-#include <mrpt/maps/CGenericPointsMap.h>
-#else
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#endif
 
 #include <Eigen/Dense>
 
@@ -271,13 +265,9 @@ void ParisLucoDataset::load_lidar(timestep_t step) const
   // Load velodyne pointcloud:
   const auto f = mrpt::system::pathJoin({seq_dir_, "frames", lstLidarFiles_[step]});
 
-#if MRPT_VERSION >= 0x020f04  // 2.15.4
   auto pts = mrpt::maps::CGenericPointsMap::Create();
   pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
   pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
-#else
-  auto  pts = mrpt::maps::CPointsMapXYZIRT::Create();
-#endif
 
   bool ok = pts->loadFromPlyFile(f);
   if (!ok)
@@ -290,17 +280,9 @@ void ParisLucoDataset::load_lidar(timestep_t step) const
   obs->sensorLabel = "lidar";
   obs->pointcloud  = pts;
 
-#if MRPT_VERSION >= 0x020f04  // 2.15.4
   auto* Ts = pts->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
   auto* Rs = pts->getPointsBufferRef_uint16_field(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-  auto* Ts =
-      pts->getPointsBufferRef_float_field(mrpt::maps::CPointsMapXYZIRT::POINT_FIELD_TIMESTAMP);
-  auto* Rs = pts->getPointsBufferRef_uint_field(mrpt::maps::CPointsMapXYZIRT::POINT_FIELD_RING_ID);
-#else
-  auto* Ts = pts->getPointsBufferRef_timestamp();
-  auto* Rs = pts->getPointsBufferRef_ring();
-#endif
+
   ASSERT_(Ts);
   const float earliestTime = *std::min_element(Ts->cbegin(), Ts->cend());
   const float shiftTime    = -earliestTime - 0.5f * static_cast<float>(lidarPeriod_);

--- a/mola_input_rawlog/include/mola_input_rawlog/RawlogDataset.h
+++ b/mola_input_rawlog/include/mola_input_rawlog/RawlogDataset.h
@@ -25,7 +25,7 @@
 #include <mrpt/serialization/CArchive.h>
 
 //
-#include <mrpt/version.h>
+#include <mrpt/version.h>  // MRPT_VERSION
 #if MRPT_VERSION >= 0x020f07
 #include <mrpt/io/CCompressedInputStream.h>
 #else

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -801,15 +801,8 @@ Rosbag2Dataset::Obs Rosbag2Dataset::toPointCloud2(
 
     // Fix timestamps for Livox driver:
     // It uses doubles for timestamps, but they are actually nanoseconds!
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
     auto* ts =
         mrptPts->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-    auto ts = mrptPts->getPointsBufferRef_float_field(
-        mrpt::maps::CPointsMapXYZIRT::POINT_FIELD_TIMESTAMP);
-#else
-    auto ts = mrptPts->getPointsBufferRef_timestamp();
-#endif
     if (ts && !ts->empty())
     {
       const auto [minIt, maxIt] = std::minmax_element(ts->begin(), ts->end());

--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(mola_common REQUIRED)
 find_package(mola_yaml REQUIRED)
 
 # find dependencies:
-find_package(MRPT 2.1.0 REQUIRED COMPONENTS gui obs maps topography)
+find_package(MRPT 2.15.0 REQUIRED COMPONENTS gui obs maps topography)
 
 # define lib:
 set(LIB_SRCS

--- a/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
+++ b/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
@@ -25,7 +25,7 @@
 #include <mrpt/core/initializer.h>
 #include <mrpt/core/pimpl.h>
 #include <mrpt/obs/CObservation.h>
-#include <mrpt/version.h>
+#include <mrpt/version.h>  // MRPT_VERSION
 
 #if MRPT_VERSION >= 0x020f07
 #include <mrpt/io/CCompressedOutputStream.h>
@@ -100,6 +100,7 @@ class RawDataSourceBase : public mola::ExecutableBase
 #else
   mrpt::io::CFileGZOutputStream export_to_rawlog_out_;
 #endif
+
   mrpt::WorkerThreadsPool worker_pool_export_rawlog_{
       1, mrpt::WorkerThreadsPool::POLICY_FIFO, "worker_pool_export_rawlog"};
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -30,7 +30,7 @@
 #include <mrpt/poses/Lie/SO.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/system/string_utils.h>  // unitsFormat()
-#include <mrpt/version.h>
+#include <mrpt/version.h>  // For MRPT_VERSION
 
 #include <numeric>  // std::accumulate
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized point-cloud handling and removed version-dependent code paths for more consistent lidar loading and timestamp/ring field management.
  * Cleaned up includes, whitespace, and legacy fallbacks for consistency.

* **Bug Fixes**
  * Fixed Livox timestamp handling so per-point times are read and scaled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->