### PR TITLE
Add param 'odometry_as_robot_pose_observation' to switch OdometryMsg …

### DIFF
--- a/docs/source/ros2api.rst
+++ b/docs/source/ros2api.rst
@@ -235,9 +235,68 @@ Definition of the frames above:
 
 |
 
+.. _ros2api_subscribed_topics:
+
+5. Subscribed topics (``subscribe`` YAML block)
+---------------------------------------------------
+
+``BridgeROS2`` subscribes to ROS 2 sensor topics listed under the ``subscribe``
+key in its YAML parameters.  Each entry in the sequence must contain at least
+the following fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``topic``
+     - Yes
+     - ROS 2 topic name (e.g. ``/imu``).  **If empty, the entry is silently
+       skipped**, which allows defining optional subscription slots controlled
+       via environment variables (e.g. ``topic: ${ODOM2_TOPIC|}``).
+   * - ``msg_type``
+     - Yes
+     - One of: ``PointCloud2``, ``LaserScan``, ``Imu``, ``NavSatFix``,
+       ``Odometry``, ``Image``.
+   * - ``output_sensor_label``
+     - Yes
+     - Label assigned to the MOLA observation forwarded to front-ends.
+   * - ``fixed_sensor_pose``
+     - No
+     - ``"x y z yaw pitch roll"`` — if present together with
+       ``use_fixed_sensor_pose: true``, the sensor-on-vehicle pose is taken from
+       this value instead of querying ``/tf``.
+   * - ``use_fixed_sensor_pose``
+     - No
+     - Boolean (default ``false``).  When ``false``, the sensor pose is looked up
+       via ``/tf`` at runtime.
+
+Example:
+
+.. code-block:: yaml
+
+    subscribe:
+      # Slot always active:
+      - topic: /imu
+        msg_type: Imu
+        output_sensor_label: "imu"
+
+      # Optional slot — disabled when ODOM2_TOPIC is unset:
+      - topic: ${ODOM2_TOPIC|}
+        msg_type: Odometry
+        output_sensor_label: "${ODOM2_LABEL|odom2}"
+
+|
+
+----
+
+|
+
 .. _ros2api_topics:
 
-5. Published topics
+6. Published topics
 --------------------------------------
 Write me!
 
@@ -247,7 +306,7 @@ Write me!
 
 |
 
-6. Map publishing
+7. Map publishing
 --------------------------------------
 There are three ways of publishing maps to ROS:
 
@@ -288,7 +347,7 @@ if mapping is enabled and the map has changed since the last publication.
 
 .. _ros2api_runtime_params:
 
-7. Runtime dynamic reconfiguration
+8. Runtime dynamic reconfiguration
 ----------------------------------------
 MOLA modules may expose a subset of their parameters through an interface that allows
 runtime reconfiguration via ROS 2 service requests:
@@ -392,10 +451,10 @@ Documented parameters:
 
 .. _mola_ros2_initial_localization:
 
-8. Initial localization
+9. Initial localization
 --------------------------------------
 
-8.1. Lidar-Odometry (LO)
+9.1. Lidar-Odometry (LO)
 ============================================
 When the LO system is started, there are different situations: 
 

--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -210,6 +210,13 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
     std::string georef_map_reference_frame = "map";
     std::string georef_map_utm_frame       = "utm";
     std::string georef_map_enu_frame       = "enu";
+
+    /// If true (default), subscribed nav_msgs/Odometry messages are converted to
+    /// mrpt::obs::CObservationRobotPose (full SE(3) pose + 6x6 covariance), suitable for
+    /// multi-source fusion in the state estimation smoother.
+    /// If false, they are converted to mrpt::obs::CObservationOdometry (2D pose, no covariance),
+    /// which is more appropriate for 2D SLAM/mapping pipelines.
+    bool odometry_as_robot_pose_observation = true;
   };
 
   Params params_;

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1925,8 +1925,8 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
     // controlled via env vars, e.g. ${ODOM1_TOPIC|}):
     if (topic_name.empty())
     {
-      MRPT_LOG_DEBUG_STREAM("Skipping subscribe entry with empty topic name (label='"
-                            << output_sensor_label << "')");
+      MRPT_LOG_DEBUG_STREAM(
+          "Skipping subscribe entry with empty topic name (label='" << output_sensor_label << "')");
       continue;
     }
 

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1921,6 +1921,15 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
     const auto type                = topic["msg_type"].as<std::string>();
     const auto output_sensor_label = topic["output_sensor_label"].as<std::string>();
 
+    // Skip entries with empty topic name (allows optional subscribe slots
+    // controlled via env vars, e.g. ${ODOM1_TOPIC|}):
+    if (topic_name.empty())
+    {
+      MRPT_LOG_DEBUG_STREAM("Skipping subscribe entry with empty topic name (label='"
+                            << output_sensor_label << "')");
+      continue;
+    }
+
     MRPT_LOG_DEBUG_STREAM(
         "Creating ros2 subscriber for topic='" << topic_name << "' (" << type << ")");
 

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -276,6 +276,7 @@ void BridgeROS2::initialize_rds(const Yaml& c)
   YAML_LOAD_OPT(params_, base_footprint_frame, std::string);
 
   YAML_LOAD_OPT(params_, forward_ros_tf_as_mola_odometry_observations, bool);
+  YAML_LOAD_OPT(params_, odometry_as_robot_pose_observation, bool);
   YAML_LOAD_OPT(params_, wait_for_tf_timeout_milliseconds, int);
 
   YAML_LOAD_OPT(params_, georef_map_reference_frame, std::string);
@@ -509,18 +510,44 @@ void BridgeROS2::callbackOnOdometry(
   MRPT_START
   const ProfilerEntry tle(profiler_, "callbackOnOdometry");
 
-  auto obs         = mrpt::obs::CObservationOdometry::Create();
-  obs->timestamp   = mrpt::ros2bridge::fromROS(o.header.stamp);
-  obs->sensorLabel = outSensorLabel;
-  obs->odometry    = mrpt::poses::CPose2D(mrpt::ros2bridge::fromROS(o.pose.pose));
+  if (params_.odometry_as_robot_pose_observation)
+  {
+    // 3D mode: CObservationRobotPose with full SE(3) pose + 6x6 covariance.
+    // This is suitable for multi-source fusion in the state estimation smoother.
+    auto obs         = mrpt::obs::CObservationRobotPose::Create();
+    obs->timestamp   = mrpt::ros2bridge::fromROS(o.header.stamp);
+    obs->sensorLabel = outSensorLabel;
+    obs->sensorPose  = mrpt::poses::CPose3D::Identity();
 
-  obs->hasVelocities       = true;
-  obs->velocityLocal.vx    = o.twist.twist.linear.x;
-  obs->velocityLocal.vy    = o.twist.twist.linear.y;
-  obs->velocityLocal.omega = o.twist.twist.angular.z;
+    // Uses mrpt::ros2bridge::fromROS(PoseWithCovariance) which handles the
+    // ROS [x,y,z,rotX,rotY,rotZ] <-> MRPT [x,y,z,yaw,pitch,roll] reordering:
+    obs->pose = mrpt::ros2bridge::fromROS(o.pose);
 
-  // send it out:
-  this->sendObservationsToFrontEnds(obs);
+    // If covariance is all-zero (source doesn't provide it), use a sensible default:
+    if (obs->pose.cov == mrpt::math::CMatrixDouble66::Zero())
+    {
+      obs->pose.cov.setZero();
+      for (int k = 0; k < 3; k++) obs->pose.cov(k, k) = 0.10 * 0.10;  // 10 cm sigma
+      for (int k = 3; k < 6; k++) obs->pose.cov(k, k) = 0.035 * 0.035;  // ~2 deg sigma
+    }
+
+    this->sendObservationsToFrontEnds(obs);
+  }
+  else
+  {
+    // 2D mode: CObservationOdometry (legacy, for 2D SLAM/mapping pipelines).
+    auto obs         = mrpt::obs::CObservationOdometry::Create();
+    obs->timestamp   = mrpt::ros2bridge::fromROS(o.header.stamp);
+    obs->sensorLabel = outSensorLabel;
+    obs->odometry    = mrpt::poses::CPose2D(mrpt::ros2bridge::fromROS(o.pose.pose));
+
+    obs->hasVelocities       = true;
+    obs->velocityLocal.vx    = o.twist.twist.linear.x;
+    obs->velocityLocal.vy    = o.twist.twist.linear.y;
+    obs->velocityLocal.omega = o.twist.twist.angular.z;
+
+    this->sendObservationsToFrontEnds(obs);
+  }
 
   MRPT_END
 }

--- a/mola_demos/CMakeLists.txt
+++ b/mola_demos/CMakeLists.txt
@@ -29,6 +29,7 @@ install(DIRECTORY
   ros2-launchs
   ros2-params
   rviz2
+  demos
   DESTINATION
     share/${PROJECT_NAME}
 )

--- a/mola_demos/demos/fake_imu_publisher.py
+++ b/mola_demos/demos/fake_imu_publisher.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Publishes fake IMU data on /imu as sensor_msgs/Imu.
+
+Simulates gravity-aligned accelerometer + gyroscope readings consistent
+with the circular motion from the fake odometry publishers (vx=1 m/s, wz=0.2 rad/s).
+
+Usage:
+  python3 fake_imu_publisher.py
+"""
+
+import math
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Imu
+from geometry_msgs.msg import Quaternion, TransformStamped
+from tf2_ros import StaticTransformBroadcaster
+
+
+def yaw_to_quaternion(yaw: float) -> Quaternion:
+    q = Quaternion()
+    q.w = math.cos(yaw / 2.0)
+    q.z = math.sin(yaw / 2.0)
+    return q
+
+
+class FakeImuPublisher(Node):
+    def __init__(self):
+        super().__init__('fake_imu_publisher')
+
+        self.declare_parameter('topic', '/imu')
+        self.declare_parameter('rate_hz', 100.0)
+        self.declare_parameter('accel_noise', 0.05)    # m/s^2
+        self.declare_parameter('gyro_noise', 0.005)    # rad/s
+        self.declare_parameter('wz', 0.2)              # rad/s ground truth yaw rate
+        self.declare_parameter('vx', 1.0)              # m/s ground truth forward speed
+        self.declare_parameter('frame_id', 'imu_link')
+
+        topic = self.get_parameter('topic').value
+        rate = self.get_parameter('rate_hz').value
+        self.accel_noise = self.get_parameter('accel_noise').value
+        self.gyro_noise = self.get_parameter('gyro_noise').value
+        self.wz = self.get_parameter('wz').value
+        self.vx = self.get_parameter('vx').value
+        self.frame_id = self.get_parameter('frame_id').value
+
+        self.pub = self.create_publisher(Imu, topic, 10)
+        self.dt = 1.0 / rate
+        self.yaw = 0.0
+        self.step = 0
+
+        self.timer = self.create_timer(self.dt, self.timer_callback)
+
+        # Publish static transform base_link -> imu_link (identity)
+        self.static_tf_broadcaster = StaticTransformBroadcaster(self)
+        st = TransformStamped()
+        st.header.stamp = self.get_clock().now().to_msg()
+        st.header.frame_id = 'base_link'
+        st.child_frame_id = self.frame_id
+        st.transform.rotation.w = 1.0
+        self.static_tf_broadcaster.sendTransform(st)
+
+        self.get_logger().info(f'Publishing fake IMU on {topic} at {rate} Hz')
+
+    def timer_callback(self):
+        if self.step > 0:
+            self.yaw += self.wz * self.dt
+
+        msg = Imu()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.frame_id
+
+        # Orientation (gravity-aligned, yaw from integration)
+        msg.orientation = yaw_to_quaternion(self.yaw)
+        msg.orientation_covariance = [0.0] * 9
+        msg.orientation_covariance[0] = 0.001
+        msg.orientation_covariance[4] = 0.001
+        msg.orientation_covariance[8] = 0.01
+
+        # Angular velocity
+        msg.angular_velocity.x = np.random.normal(0, self.gyro_noise)
+        msg.angular_velocity.y = np.random.normal(0, self.gyro_noise)
+        msg.angular_velocity.z = self.wz + np.random.normal(0, self.gyro_noise)
+        msg.angular_velocity_covariance = [0.0] * 9
+        msg.angular_velocity_covariance[0] = self.gyro_noise ** 2
+        msg.angular_velocity_covariance[4] = self.gyro_noise ** 2
+        msg.angular_velocity_covariance[8] = self.gyro_noise ** 2
+
+        # Linear acceleration (centripetal + gravity)
+        # In body frame: centripetal accel = v * w (pointing towards center = -y in body frame)
+        centripetal = self.vx * self.wz
+        msg.linear_acceleration.x = np.random.normal(0, self.accel_noise)
+        msg.linear_acceleration.y = -centripetal + np.random.normal(0, self.accel_noise)
+        msg.linear_acceleration.z = 9.81 + np.random.normal(0, self.accel_noise)  # gravity
+        msg.linear_acceleration_covariance = [0.0] * 9
+        msg.linear_acceleration_covariance[0] = self.accel_noise ** 2
+        msg.linear_acceleration_covariance[4] = self.accel_noise ** 2
+        msg.linear_acceleration_covariance[8] = self.accel_noise ** 2
+
+        self.pub.publish(msg)
+        self.step += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = FakeImuPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/mola_demos/demos/fake_visual_odom_publisher.py
+++ b/mola_demos/demos/fake_visual_odom_publisher.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Publishes fake visual odometry on /visual_odom as nav_msgs/Odometry.
+
+Simulates a robot driving in a circle at 1 m/s with 0.2 rad/s yaw rate
+(same ground truth as the wheel odom publisher), but with different noise
+characteristics: lower white noise but a constant sideways (Y) drift.
+
+Usage:
+  ros2 run mola_state_estimation_smoother fake_visual_odom_publisher.py
+  # or directly:
+  python3 fake_visual_odom_publisher.py
+"""
+
+import math
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Quaternion
+
+
+def yaw_to_quaternion(yaw: float) -> Quaternion:
+    q = Quaternion()
+    q.w = math.cos(yaw / 2.0)
+    q.z = math.sin(yaw / 2.0)
+    return q
+
+
+class FakeVisualOdomPublisher(Node):
+    def __init__(self):
+        super().__init__('fake_visual_odom_publisher')
+
+        # Parameters
+        self.declare_parameter('topic', '/visual_odom')
+        self.declare_parameter('rate_hz', 30.0)
+        self.declare_parameter('noise_xyz', 0.005)      # m per step (more precise)
+        self.declare_parameter('noise_ang', 0.001)       # rad per step
+        self.declare_parameter('drift_y_per_step', 0.003)  # constant lateral drift
+        self.declare_parameter('vx', 1.0)                # m/s ground truth
+        self.declare_parameter('wz', 0.2)                # rad/s ground truth
+        self.declare_parameter('frame_id', 'odom_visual')
+        self.declare_parameter('child_frame_id', 'base_link')
+
+        topic = self.get_parameter('topic').value
+        rate = self.get_parameter('rate_hz').value
+        self.noise_xyz = self.get_parameter('noise_xyz').value
+        self.noise_ang = self.get_parameter('noise_ang').value
+        self.drift_y = self.get_parameter('drift_y_per_step').value
+        self.vx = self.get_parameter('vx').value
+        self.wz = self.get_parameter('wz').value
+        self.frame_id = self.get_parameter('frame_id').value
+        self.child_frame_id = self.get_parameter('child_frame_id').value
+
+        self.pub = self.create_publisher(Odometry, topic, 10)
+
+        self.dt = 1.0 / rate
+        self.x = 0.0
+        self.y = 0.0
+        self.z = 0.0
+        self.yaw = 0.0
+        self.step = 0
+
+        self.timer = self.create_timer(self.dt, self.timer_callback)
+        self.get_logger().info(
+            f'Publishing fake visual odom on {topic} at {rate} Hz '
+            f'(noise_xyz={self.noise_xyz}, drift_y={self.drift_y})')
+
+    def timer_callback(self):
+        if self.step > 0:
+            # Ground truth delta
+            dx_gt = self.vx * self.dt
+            dyaw_gt = self.wz * self.dt
+
+            # Visual odom: low noise but systematic Y drift
+            dx = dx_gt + np.random.normal(0, self.noise_xyz)
+            dy = self.drift_y + np.random.normal(0, self.noise_xyz)
+            dz = np.random.normal(0, self.noise_xyz)
+            dyaw = dyaw_gt + np.random.normal(0, self.noise_ang)
+
+            # Integrate in local frame
+            self.x += dx * math.cos(self.yaw) - dy * math.sin(self.yaw)
+            self.y += dx * math.sin(self.yaw) + dy * math.cos(self.yaw)
+            self.z += dz
+            self.yaw += dyaw
+
+        msg = Odometry()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.frame_id
+        msg.child_frame_id = self.child_frame_id
+
+        msg.pose.pose.position.x = self.x
+        msg.pose.pose.position.y = self.y
+        msg.pose.pose.position.z = self.z
+        msg.pose.pose.orientation = yaw_to_quaternion(self.yaw)
+
+        # Covariance (diagonal, tighter than wheel odom)
+        cov = [0.0] * 36
+        cov[0] = self.noise_xyz ** 2
+        cov[7] = self.noise_xyz ** 2
+        cov[14] = self.noise_xyz ** 2
+        cov[35] = self.noise_ang ** 2
+        msg.pose.covariance = cov
+
+        msg.twist.twist.linear.x = self.vx
+        msg.twist.twist.angular.z = self.wz
+
+        self.pub.publish(msg)
+        self.step += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = FakeVisualOdomPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/mola_demos/demos/fake_visual_odom_publisher.py
+++ b/mola_demos/demos/fake_visual_odom_publisher.py
@@ -34,9 +34,13 @@ class FakeVisualOdomPublisher(Node):
         # Parameters
         self.declare_parameter('topic', '/visual_odom')
         self.declare_parameter('rate_hz', 30.0)
-        self.declare_parameter('noise_xyz', 0.005)      # m per step (more precise)
+        # m per step (more precise)
+        self.declare_parameter('noise_xyz', 0.005)
         self.declare_parameter('noise_ang', 0.001)       # rad per step
-        self.declare_parameter('drift_y_per_step', 0.003)  # constant lateral drift
+        self.declare_parameter('initial_pose_noise_xyz', 1.0)    # m
+        self.declare_parameter('initial_pose_noise_yaw', 1.0)   # rad
+        # constant lateral drift
+        self.declare_parameter('drift_y_per_step', 0.003)
         self.declare_parameter('vx', 1.0)                # m/s ground truth
         self.declare_parameter('wz', 0.2)                # rad/s ground truth
         self.declare_parameter('frame_id', 'odom_visual')
@@ -46,6 +50,10 @@ class FakeVisualOdomPublisher(Node):
         rate = self.get_parameter('rate_hz').value
         self.noise_xyz = self.get_parameter('noise_xyz').value
         self.noise_ang = self.get_parameter('noise_ang').value
+        self.initial_pose_noise_xyz = self.get_parameter(
+            'initial_pose_noise_xyz').value
+        self.initial_pose_noise_yaw = self.get_parameter(
+            'initial_pose_noise_yaw').value
         self.drift_y = self.get_parameter('drift_y_per_step').value
         self.vx = self.get_parameter('vx').value
         self.wz = self.get_parameter('wz').value
@@ -55,10 +63,10 @@ class FakeVisualOdomPublisher(Node):
         self.pub = self.create_publisher(Odometry, topic, 10)
 
         self.dt = 1.0 / rate
-        self.x = 0.0
-        self.y = 0.0
-        self.z = 0.0
-        self.yaw = 0.0
+        self.x = np.random.normal(0, self.initial_pose_noise_xyz)
+        self.y = np.random.normal(0, self.initial_pose_noise_xyz)
+        self.z = np.random.normal(0, self.initial_pose_noise_xyz)
+        self.yaw = np.random.normal(0, self.initial_pose_noise_yaw)
         self.step = 0
 
         self.timer = self.create_timer(self.dt, self.timer_callback)
@@ -99,7 +107,9 @@ class FakeVisualOdomPublisher(Node):
         cov[0] = self.noise_xyz ** 2
         cov[7] = self.noise_xyz ** 2
         cov[14] = self.noise_xyz ** 2
-        cov[35] = self.noise_ang ** 2
+        cov[21] = self.noise_ang ** 2  # rotX
+        cov[28] = self.noise_ang ** 2  # rotY
+        cov[35] = self.noise_ang ** 2  # rotZ
         msg.pose.covariance = cov
 
         msg.twist.twist.linear.x = self.vx

--- a/mola_demos/demos/fake_wheel_odom_publisher.py
+++ b/mola_demos/demos/fake_wheel_odom_publisher.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Publishes fake wheel odometry on /wheel_odom as nav_msgs/Odometry.
+
+Simulates a robot driving in a circle at 1 m/s with 0.2 rad/s yaw rate,
+with configurable Gaussian noise and systematic drift.
+
+Usage:
+  ros2 run mola_state_estimation_smoother fake_wheel_odom_publisher.py
+  # or directly:
+  python3 fake_wheel_odom_publisher.py
+"""
+
+import math
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Quaternion, TransformStamped
+from tf2_ros import TransformBroadcaster
+
+
+def yaw_to_quaternion(yaw: float) -> Quaternion:
+    q = Quaternion()
+    q.w = math.cos(yaw / 2.0)
+    q.z = math.sin(yaw / 2.0)
+    return q
+
+
+class FakeWheelOdomPublisher(Node):
+    def __init__(self):
+        super().__init__('fake_wheel_odom_publisher')
+
+        # Parameters
+        self.declare_parameter('topic', '/wheel_odom')
+        self.declare_parameter('rate_hz', 50.0)
+        self.declare_parameter('noise_xy', 0.02)       # m per step
+        self.declare_parameter('noise_yaw', 0.005)     # rad per step
+        self.declare_parameter('drift_scale_x', 1.02)  # 2% systematic drift
+        self.declare_parameter('vx', 1.0)              # m/s ground truth
+        self.declare_parameter('wz', 0.2)              # rad/s ground truth
+        self.declare_parameter('frame_id', 'odom_wheels')
+        self.declare_parameter('child_frame_id', 'base_link')
+        self.declare_parameter('publish_tf', False)
+
+        topic = self.get_parameter('topic').value
+        rate = self.get_parameter('rate_hz').value
+        self.noise_xy = self.get_parameter('noise_xy').value
+        self.noise_yaw = self.get_parameter('noise_yaw').value
+        self.drift_scale_x = self.get_parameter('drift_scale_x').value
+        self.vx = self.get_parameter('vx').value
+        self.wz = self.get_parameter('wz').value
+        self.frame_id = self.get_parameter('frame_id').value
+        self.child_frame_id = self.get_parameter('child_frame_id').value
+        self.do_publish_tf = self.get_parameter('publish_tf').value
+
+        self.pub = self.create_publisher(Odometry, topic, 10)
+        if self.do_publish_tf:
+            self.tf_broadcaster = TransformBroadcaster(self)
+
+        self.dt = 1.0 / rate
+        self.x = 0.0
+        self.y = 0.0
+        self.yaw = 0.0
+        self.step = 0
+
+        self.timer = self.create_timer(self.dt, self.timer_callback)
+        self.get_logger().info(
+            f'Publishing fake wheel odom on {topic} at {rate} Hz '
+            f'(noise_xy={self.noise_xy}, drift={self.drift_scale_x})')
+
+    def timer_callback(self):
+        if self.step > 0:
+            # Ground truth delta
+            dx_gt = self.vx * self.dt
+            dyaw_gt = self.wz * self.dt
+
+            # Apply systematic drift + noise
+            dx = dx_gt * self.drift_scale_x + np.random.normal(0, self.noise_xy)
+            dy = np.random.normal(0, self.noise_xy)
+            dyaw = dyaw_gt + np.random.normal(0, self.noise_yaw)
+
+            # Integrate in local frame
+            self.x += dx * math.cos(self.yaw) - dy * math.sin(self.yaw)
+            self.y += dx * math.sin(self.yaw) + dy * math.cos(self.yaw)
+            self.yaw += dyaw
+
+        msg = Odometry()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.frame_id
+        msg.child_frame_id = self.child_frame_id
+
+        msg.pose.pose.position.x = self.x
+        msg.pose.pose.position.y = self.y
+        msg.pose.pose.position.z = 0.0
+        msg.pose.pose.orientation = yaw_to_quaternion(self.yaw)
+
+        # Covariance (diagonal)
+        cov = [0.0] * 36
+        cov[0] = self.noise_xy ** 2   # xx
+        cov[7] = self.noise_xy ** 2   # yy
+        cov[35] = self.noise_yaw ** 2  # yaw-yaw
+        msg.pose.covariance = cov
+
+        msg.twist.twist.linear.x = self.vx
+        msg.twist.twist.angular.z = self.wz
+
+        self.pub.publish(msg)
+
+        if self.do_publish_tf:
+            t = TransformStamped()
+            t.header = msg.header
+            t.child_frame_id = self.child_frame_id
+            t.transform.translation.x = self.x
+            t.transform.translation.y = self.y
+            t.transform.rotation = yaw_to_quaternion(self.yaw)
+            self.tf_broadcaster.sendTransform(t)
+
+        self.step += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = FakeWheelOdomPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/mola_demos/demos/fake_wheel_odom_publisher.py
+++ b/mola_demos/demos/fake_wheel_odom_publisher.py
@@ -36,6 +36,8 @@ class FakeWheelOdomPublisher(Node):
         self.declare_parameter('rate_hz', 50.0)
         self.declare_parameter('noise_xy', 0.02)       # m per step
         self.declare_parameter('noise_yaw', 0.005)     # rad per step
+        self.declare_parameter('initial_pose_noise_xy', 1.0)    # m
+        self.declare_parameter('initial_pose_noise_yaw', 1.0)   # rad
         self.declare_parameter('drift_scale_x', 1.02)  # 2% systematic drift
         self.declare_parameter('vx', 1.0)              # m/s ground truth
         self.declare_parameter('wz', 0.2)              # rad/s ground truth
@@ -47,6 +49,10 @@ class FakeWheelOdomPublisher(Node):
         rate = self.get_parameter('rate_hz').value
         self.noise_xy = self.get_parameter('noise_xy').value
         self.noise_yaw = self.get_parameter('noise_yaw').value
+        self.initial_pose_noise_xy = self.get_parameter(
+            'initial_pose_noise_xy').value
+        self.initial_pose_noise_yaw = self.get_parameter(
+            'initial_pose_noise_yaw').value
         self.drift_scale_x = self.get_parameter('drift_scale_x').value
         self.vx = self.get_parameter('vx').value
         self.wz = self.get_parameter('wz').value
@@ -59,9 +65,9 @@ class FakeWheelOdomPublisher(Node):
             self.tf_broadcaster = TransformBroadcaster(self)
 
         self.dt = 1.0 / rate
-        self.x = 0.0
-        self.y = 0.0
-        self.yaw = 0.0
+        self.x = np.random.normal(0, self.initial_pose_noise_xy)
+        self.y = np.random.normal(0, self.initial_pose_noise_xy)
+        self.yaw = np.random.normal(0, self.initial_pose_noise_yaw)
         self.step = 0
 
         self.timer = self.create_timer(self.dt, self.timer_callback)
@@ -76,7 +82,8 @@ class FakeWheelOdomPublisher(Node):
             dyaw_gt = self.wz * self.dt
 
             # Apply systematic drift + noise
-            dx = dx_gt * self.drift_scale_x + np.random.normal(0, self.noise_xy)
+            dx = dx_gt * self.drift_scale_x + \
+                np.random.normal(0, self.noise_xy)
             dy = np.random.normal(0, self.noise_xy)
             dyaw = dyaw_gt + np.random.normal(0, self.noise_yaw)
 
@@ -99,6 +106,9 @@ class FakeWheelOdomPublisher(Node):
         cov = [0.0] * 36
         cov[0] = self.noise_xy ** 2   # xx
         cov[7] = self.noise_xy ** 2   # yy
+        cov[14] = self.noise_xy ** 2  # zz
+        cov[21] = self.noise_yaw ** 2  # rotX
+        cov[28] = self.noise_yaw ** 2  # rotY
         cov[35] = self.noise_yaw ** 2  # yaw-yaw
         msg.pose.covariance = cov
 

--- a/mola_launcher/src/MolaLauncherApp.cpp
+++ b/mola_launcher/src/MolaLauncherApp.cpp
@@ -478,15 +478,11 @@ void MolaLauncherApp::executor_thread(InfoPerRunningThread& rds)
     threads_must_end_ = true;
   }
 
-  // make sure dtor is called now:
-  if (rds.impl)
-  {
-    MRPT_LOG_DEBUG_STREAM(
-        "About to destruct module '" << rds.name << "', shared_ptr with " << rds.impl.use_count()
-                                     << " references.");
-    rds.impl.reset();
-    MRPT_LOG_DEBUG_STREAM("Done with dtor of module '" << rds.name << "'");
-  }
+  // Note: Do NOT destroy rds.impl here. Module destruction must be
+  // deferred to shutdown(), which runs after ALL threads have been
+  // joined. Destroying modules here races with other threads that
+  // may still hold raw pointers (e.g. RawDataSourceBase::rdc_) to
+  // the module being destroyed.
 }
 
 ExecutableBase::Ptr MolaLauncherApp::nameServerImpl(const std::string& name)


### PR DESCRIPTION
…mapping to MRPT types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New config to choose odometry import format—defaults to converting incoming odometry into full 3D robot-pose observations (with covariance).
  * Added three demo ROS 2 publisher tools: synthetic IMU, visual-odometry, and wheel-odometry; demos now included in the installed package.

* **Bug Fixes**
  * Improved shutdown stability by deferring module destruction until after threads are joined to avoid races.

* **Documentation**
  * Added docs for topic subscription configuration and noted empty-topic entries are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->