### PR TITLE
fix(bridge_ros2): skip TF publish when REP-105 odom lookup fails

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1545,53 +1545,59 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
   // Send TF with localization result
   // 1) Direct mode:    reference_frame ("map") -> base_link ("base_link")
   // 2) Indirect mode:  map -> odom  (such as "map -> odom -> base_link" = "map -> base_link")
-  if (params_.publish_tf_from_slam && (params_.publish_tf_from_slam_source.empty() ||
-                                       params_.publish_tf_from_slam_source == l.method))
+  if (!params_.publish_tf_from_slam ||
+      (!params_.publish_tf_from_slam_source.empty() &&
+       params_.publish_tf_from_slam_source != l.method))
   {
-    tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(l.pose);
+    return;
+  }
 
-    geometry_msgs::msg::TransformStamped tf;
-    tf.header.stamp = myNow(l.timestamp);
+  const tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(l.pose);
 
-    // Follow REP105 only if we are publishing "map" -> "base_link" poses.
-    if (params_.publish_localization_following_rep105 && l.child_frame == params_.base_link_frame &&
-        l.reference_frame == params_.reference_frame)
+  geometry_msgs::msg::TransformStamped tf;
+  tf.header.stamp = myNow(l.timestamp);
+
+  // Follow REP105 only if we are publishing "map" -> "base_link" poses.
+  const bool useRep105 = params_.publish_localization_following_rep105 &&
+                         l.child_frame == params_.base_link_frame &&
+                         l.reference_frame == params_.reference_frame;
+
+  if (useRep105)
+  {
+    // Compose map -> odom = (map -> base_link) * (base_link -> odom):
+    mrpt::poses::CPose3D T_base_to_odom;
+    const bool           base_to_odom_ok =
+        this->waitForTransform(T_base_to_odom, params_.odom_frame, l.child_frame, true);
+    // Note: this wait above typ takes ~50 us
+
+    if (!base_to_odom_ok)
     {
-      // Recompute:
-      mrpt::poses::CPose3D T_base_to_odom;
-      bool                 base_to_odom_ok =
-          this->waitForTransform(T_base_to_odom, params_.odom_frame, l.child_frame, true);
-      // Note: this wait above typ takes ~50 us
-
-      if (!base_to_odom_ok)
-      {
-        MRPT_LOG_ERROR_STREAM(
-            "publish_localization_following_rep105=true but could not resolve tf odom -> "
-            "base_link");
-      }
-      else
-      {
-        const tf2::Transform& baseOnMap_tf = transform;
-
-        const tf2::Transform odomOnBase_tf = mrpt::ros2bridge::toROS_tfTransform(T_base_to_odom);
-
-        tf.transform       = tf2::toMsg(baseOnMap_tf * odomOnBase_tf);
-        tf.child_frame_id  = params_.odom_frame;
-        tf.header.frame_id = l.reference_frame;
-      }
-    }
-    else
-    {
-      tf.transform       = tf2::toMsg(transform);
-      tf.child_frame_id  = l.child_frame;
-      tf.header.frame_id = l.reference_frame;
+      // Skip publishing entirely: broadcasting a default-constructed
+      // TransformStamped here would inject empty frame_ids into every
+      // subscriber's tf2 buffer (TF_NO_FRAME_ID / TF_SELF_TRANSFORM spam).
+      MRPT_LOG_ERROR_STREAM(
+          "publish_localization_following_rep105=true but could not resolve tf '"
+          << params_.odom_frame << "' -> '" << l.child_frame << "'; skipping TF publish.");
+      return;
     }
 
-    auto lckTfBc = mrpt::lockHelper(ros_tf_bc_mtx_);
-    if (tf_bc_)
-    {
-      tf_bc_->sendTransform(tf);
-    }
+    const tf2::Transform odomOnBase_tf = mrpt::ros2bridge::toROS_tfTransform(T_base_to_odom);
+
+    tf.transform       = tf2::toMsg(transform * odomOnBase_tf);
+    tf.child_frame_id  = params_.odom_frame;
+    tf.header.frame_id = l.reference_frame;
+  }
+  else
+  {
+    tf.transform       = tf2::toMsg(transform);
+    tf.child_frame_id  = l.child_frame;
+    tf.header.frame_id = l.reference_frame;
+  }
+
+  auto lckTfBc = mrpt::lockHelper(ros_tf_bc_mtx_);
+  if (tf_bc_)
+  {
+    tf_bc_->sendTransform(tf);
   }
 }
 


### PR DESCRIPTION
## Problem

In `BridgeROS2::publishLocalizationTf`, when `publish_localization_following_rep105` is enabled, the bridge needs to look up `odom_frame -> base_link_frame` to compose `map -> odom`. If that lookup fails (e.g. wheel odometry hasn't started publishing yet during system bring-up), the previous code logged the error but still fell through to `tf_bc_->sendTransform(tf)` with a default-constructed `TransformStamped` (empty `frame_id` and `child_frame_id`).

This is broadcast at the localization rate, so every subscriber's `tf2` buffer is continuously hit with:

```
TF_NO_FRAME_ID: Ignoring transform with child_frame_id ""  from authority "Authority undetectable" because frame_id not set
TF_NO_CHILD_FRAME_ID: Ignoring transform from authority "Authority undetectable" because child_frame_id not set
TF_SELF_TRANSFORM: Ignoring transform from authority "Authority undetectable" with frame_id and child_frame_id "" because they are the same
```

…across every node in the system until the odom TF becomes available.

## Fix

Return early on lookup failure so no broadcast happens. Behavior in the success path is unchanged.

While here, restructured the function with an early-return guard for `publish_tf_from_slam` to flatten the nesting, and included the actual frame names being looked up in the error message.

## Test

Reproduced the spam on a real robot during bring-up (wheel odometry comes up a few seconds after MOLA starts publishing localization). With this patch the `TF_NO_FRAME_ID` / `TF_SELF_TRANSFORM` cascade is gone; only the (legitimate) lookup-failure error is logged until the odom TF appears, at which point publishing resumes normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization transform publishing with better early-exit handling when publishing is disabled.
  * Enhanced error handling for transform operations, including proper error logging when operations fail.
  * Improved REP105 standard compliance for transform frame relationship handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->