### PR TITLE
CI actions: build for arm64 too

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -3,9 +3,9 @@ name: CI Build colcon
 
 on:
   push:
-    branches: ['**']
+    branches: [ "**" ]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 # Minimal GITHUB_TOKEN permissions (principle of least privilege)
 permissions:
@@ -17,7 +17,8 @@ jobs:
   # including PRs from forks.
   # -----------------------------------------------------------------------
   build_github_hosted:
-    name: "x86_64 / ${{ matrix.ros_distribution }} (testing=${{ matrix.use_ros_testing }})"
+    name: "x86_64 / ${{ matrix.ros_distribution }} (testing=${{
+      matrix.use_ros_testing }})"
     runs-on: ubuntu-latest
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -87,13 +88,17 @@ jobs:
   # untrusted code.
   # -----------------------------------------------------------------------
   build_self_hosted:
-    name: "arm64 / ${{ matrix.ros_distribution }} (testing=${{ matrix.use_ros_testing }})"
+    name: "arm64 / ${{ matrix.ros_distribution }} (testing=${{
+      matrix.use_ros_testing }})"
     if: >
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: [ self-hosted, linux, arm64 ]
     env:
       DEBIAN_FRONTEND: noninteractive
+      http_proxy: http://host.docker.internal:3142 # apt-cacher-ng
+      https_proxy: http://host.docker.internal:3142 # apt-cacher-ng handles HTTPS too via CONNECT
+
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +132,7 @@ jobs:
 
     container:
       image: ${{ matrix.docker_image }}
+      options: --add-host=host.docker.internal:host-gateway # for apt-cacher-ng
 
     steps:
       - name: Install Git
@@ -136,6 +142,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          persist-credentials: false # safer
 
       - name: setup ROS environment
         uses: ros-tooling/setup-ros@v0.7

--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -1,23 +1,29 @@
 # Based on GTSAM file (by @ProfFan)
 name: CI Build colcon
 
-on: [push]
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Minimal GITHUB_TOKEN permissions (principle of least privilege)
+permissions:
+  contents: read
 
 jobs:
-  build_docker: # On Linux, iterates on all ROS 1 and ROS 2 distributions.
+  # -----------------------------------------------------------------------
+  # Job 1: GitHub-hosted runners (x86_64). Runs for all pushes and PRs,
+  # including PRs from forks.
+  # -----------------------------------------------------------------------
+  build_github_hosted:
+    name: "x86_64 / ${{ matrix.ros_distribution }} (testing=${{ matrix.use_ros_testing }})"
     runs-on: ubuntu-latest
     env:
       DEBIAN_FRONTEND: noninteractive
     strategy:
+      fail-fast: false
       matrix:
-        # Define the Docker image(s) associated with each ROS distribution.
-        # The include syntax allows additional variables to be defined, like
-        # docker_image in this case. See documentation:
-        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build
-        #
-        # Platforms are defined in REP 3 and REP 2000:
-        # https://ros.org/reps/rep-0003.html
-        # https://ros.org/reps/rep-2000.html
         include:
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
@@ -50,17 +56,13 @@ jobs:
       image: ${{ matrix.docker_image }}
 
     steps:
+      - name: Install Git
+        run: apt-get update && apt-get install -y git
+
       - name: Checkout
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          apt-get -y update
-          apt-get -y install git
-          git clone https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git --recursive "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          cd "$GITHUB_WORKSPACE"
-          git checkout $GITHUB_SHA
-          git submodule update --init --recursive
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: setup ROS environment
         uses: ros-tooling/setup-ros@v0.7
@@ -77,5 +79,77 @@ jobs:
       - name: Build with colcon
         run: |
           . /opt/ros/*/setup.sh
-          env
+          MAKEFLAGS="-j2" colcon build --symlink-install --parallel-workers 2 --event-handlers console_direct+
+
+  # -----------------------------------------------------------------------
+  # Job 2: Self-hosted runner (arm64). Only runs for pushes or PRs from
+  # the same repository — never for fork PRs — to protect the runner from
+  # untrusted code.
+  # -----------------------------------------------------------------------
+  build_self_hosted:
+    name: "arm64 / ${{ matrix.ros_distribution }} (testing=${{ matrix.use_ros_testing }})"
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, arm64]
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
+            use_ros_testing: false
+
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
+            use_ros_testing: true
+
+          # Jazzy (2024 - 2029)
+          - docker_image: ubuntu:noble
+            ros_distribution: jazzy
+            use_ros_testing: false
+
+          - docker_image: ubuntu:noble
+            ros_distribution: jazzy
+            use_ros_testing: true
+
+          # Rolling Ridley (No End-Of-Life)
+          - docker_image: ubuntu:noble
+            ros_distribution: rolling
+            use_ros_testing: false
+
+          - docker_image: ubuntu:noble
+            ros_distribution: rolling
+            use_ros_testing: true
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    steps:
+      - name: Install Git
+        run: apt-get update && apt-get install -y git
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: setup ROS environment
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ matrix.ros_distribution }}
+          use-ros2-testing: ${{ matrix.use_ros_testing }}
+
+      - name: Install rosdep dependencies
+        run: |
+          . /opt/ros/*/setup.sh
+          rosdep update
+          rosdep install --from-paths . --ignore-src -r -y
+
+      - name: Build with colcon
+        run: |
+          . /opt/ros/*/setup.sh
           MAKEFLAGS="-j2" colcon build --symlink-install --parallel-workers 2 --event-handlers console_direct+

--- a/.github/workflows/check-clang-format.yml
+++ b/.github/workflows/check-clang-format.yml
@@ -1,6 +1,15 @@
 name: CI clang-format
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Safe to run on all PRs (including forks): uses ubuntu-latest only,
+# no secrets, no self-hosted runners.
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -22,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Git submodule
         run: |

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -979,23 +979,22 @@ void BridgeROS2::internalOn(
       mrpt::ros2bridge::toROS(*xyzgen, msg_header, msg_pts);
     }
 #if MRPT_VERSION < 0x030000  // older than v3.0.0, support deprecated classes
-    else if (
-        const auto* xyzIRT =
-            dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(obs.pointcloud.get());
-        xyzIRT)
+    else if (const auto* xyzIRT =
+                 dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(obs.pointcloud.get());
+             xyzIRT)
     {
       mrpt::ros2bridge::toROS(*xyzIRT, msg_header, msg_pts);
     }
-    else if (
-        const auto* xyzi = dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(obs.pointcloud.get());
-        xyzi)
+    else if (const auto* xyzi =
+                 dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(obs.pointcloud.get());
+             xyzi)
     {
       mrpt::ros2bridge::toROS(*xyzi, msg_header, msg_pts);
     }
 #endif
-    else if (
-        const auto* sPts = dynamic_cast<const mrpt::maps::CSimplePointsMap*>(obs.pointcloud.get());
-        sPts)
+    else if (const auto* sPts =
+                 dynamic_cast<const mrpt::maps::CSimplePointsMap*>(obs.pointcloud.get());
+             sPts)
     {
       mrpt::ros2bridge::toROS(*sPts, msg_header, msg_pts);
     }
@@ -1567,10 +1566,10 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
     // Compose map -> odom = (map -> base_link) * (base_link -> odom):
     mrpt::poses::CPose3D T_base_to_odom;
     const bool           base_to_odom_ok = this->waitForTransform(
-        T_base_to_odom,
-        params_.odom_frame,  // Look for this frame
-        l.child_frame,  // as seen from this frame
-        true);
+                  T_base_to_odom,
+                  params_.odom_frame,  // Look for this frame
+                  l.child_frame,  // as seen from this frame
+                  true);
     // Note: this wait above typ takes ~50 μs
 
     if (!base_to_odom_ok)
@@ -1755,8 +1754,8 @@ void BridgeROS2::timerPubMapLayer(const std::string& layerName, const MapSourceB
     internalOn(obs, false /*no tf*/, mu.reference_frame);
   }
   // Is it a grid map?
-  else if (
-      auto grid = std::dynamic_pointer_cast<const mrpt::maps::COccupancyGridMap2D>(mu.map); grid)
+  else if (auto grid = std::dynamic_pointer_cast<const mrpt::maps::COccupancyGridMap2D>(mu.map);
+           grid)
   {
     internalPublishGridMap(*grid, mapTopic, mu.reference_frame, mu.timestamp);
   }
@@ -1991,7 +1990,8 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
     else if (type == "Odometry")
     {
       subsOdometry_.emplace_back(rosNode_->create_subscription<nav_msgs::msg::Odometry>(
-          topic_name, qos, [this, output_sensor_label](const nav_msgs::msg::Odometry& o)
+          topic_name, qos,
+          [this, output_sensor_label](const nav_msgs::msg::Odometry& o)
           { this->callbackOnOdometry(o, output_sensor_label); }));
     }
     else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs on all branch pushes and on pull request events (opened, synchronize, reopened); workflow permissions scoped and checkout action versioned.
  * Builds split into GitHub-hosted and self-hosted (ARM64) jobs with distribution matrix; self-hosted runner adds apt caching/proxy options.
  * Added Git install, ROS setup, dependency installation, and standardized build steps across jobs.

* **Style**
  * Small modernizations and formatting tweaks in native code (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->