### PR TITLE
feat(bridge_ros2): align REP-105 TF publishing with Nav2 conventions

### DIFF
--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -199,6 +199,22 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
     /// Otherwise, the wallclock time will be used.
     bool publish_in_sim_time = false;
 
+    /// Future-dating offset [s] applied to the broadcast stamp of the
+    /// localization /tf (``map -> odom`` in REP-105 mode, or
+    /// ``map -> base_link`` in direct mode). The stamp is set to
+    /// ``rosNode->now() + transform_tolerance``, allowing downstream
+    /// consumers to ``lookupTransform(map, base_link, now())`` without
+    /// tf2 ``ExtrapolationException``s.
+    double transform_tolerance = 0.1;  // [s]
+
+    /// Period [s] at which the latest computed localization /tf is
+    /// re-broadcast on a wall timer, independent of localization update
+    /// rate. This keeps the TF buffer always populated for downstream
+    /// consumers even when the localizer runs slower than the consumer
+    /// query rate. Set to ``0`` to disable the rebroadcast loop (the TF
+    /// is then only published when a new localization update arrives).
+    double transform_publish_period = 0.05;  // [s]
+
     double period_publish_new_map     = 5.0;  // [s]
     double period_publish_static_tfs  = 1.0;  // [s]
     double period_publish_diagnostics = 1.0;  // [s]
@@ -389,6 +405,18 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
   void publishLocalizationOdom(const LocalizationSourceBase::LocalizationUpdate& l);
   void publishLocalizationQuality(const LocalizationSourceBase::LocalizationUpdate& l);
   void publishLocalizationGeoRef(const LocalizationSourceBase::LocalizationUpdate& l);
+
+  /// Latest computed localization /tf (frame_ids + transform). The stamp
+  /// field is overwritten on every broadcast with ``now() + tolerance``.
+  /// Empty until the first localization update arrives.
+  std::mutex                                          cachedLocalizationTfMtx_;
+  std::optional<geometry_msgs::msg::TransformStamped> cachedLocalizationTf_;
+
+  /// Re-broadcasts the cached localization /tf with stamp
+  /// ``rosNode->now() + transform_tolerance``. Called both immediately on
+  /// each new localization update and from the rebroadcast wall timer.
+  /// No-op until the cache is populated.
+  void broadcastCachedLocalizationTf();
 
   // Different publish map parts:
   void timerPubMap();

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -231,6 +231,28 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
           }
         });
 
+    // Re-broadcast the cached localization /tf at a fixed rate so the buffer
+    // stays populated for downstream consumers regardless of localization
+    // update rate. Set to 0 to disable.
+    rclcpp::TimerBase::SharedPtr timerRebroadcastLocTf;
+    if (params_.transform_publish_period > 0.0)
+    {
+      timerRebroadcastLocTf = rosNode_->create_wall_timer(
+          std::chrono::microseconds(
+              static_cast<unsigned int>(1e6 * params_.transform_publish_period)),
+          [this]()
+          {
+            try
+            {
+              broadcastCachedLocalizationTf();
+            }
+            catch (const std::exception& e)
+            {
+              MRPT_LOG_ERROR(e.what());
+            }
+          });
+    }
+
     //
     if (!params_.relocalize_from_topic.empty())
     {
@@ -316,6 +338,8 @@ void BridgeROS2::initialize_rds(const Yaml& c)
   YAML_LOAD_OPT(params_, publish_geo_referenced_poses_from_slam, bool);
 
   YAML_LOAD_OPT(params_, publish_in_sim_time, bool);
+  YAML_LOAD_OPT(params_, transform_tolerance, double);
+  YAML_LOAD_OPT(params_, transform_publish_period, double);
   YAML_LOAD_OPT(params_, period_publish_new_map, double);
   YAML_LOAD_OPT(params_, period_publish_static_tfs, double);
   YAML_LOAD_OPT(params_, period_publish_diagnostics, double);
@@ -1554,7 +1578,6 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
   const tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(l.pose);
 
   geometry_msgs::msg::TransformStamped tf;
-  tf.header.stamp = myNow(l.timestamp);
 
   // Follow REP105 only if we are publishing "map" -> "base_link" poses.
   const bool useRep105 = params_.publish_localization_following_rep105 &&
@@ -1563,27 +1586,32 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
 
   if (useRep105)
   {
-    // Compose map -> odom = (map -> base_link) * (base_link -> odom):
-    mrpt::poses::CPose3D T_base_to_odom;
-    const bool           base_to_odom_ok = this->waitForTransform(
-                  T_base_to_odom,
-                  params_.odom_frame,  // Look for this frame
-                  l.child_frame,  // as seen from this frame
-                  true);
-    // Note: this wait above typ takes ~50 μs
-
-    if (!base_to_odom_ok)
+    // Compose map -> odom = (map -> base_link)(t_scan) * (base_link -> odom)(t_scan).
+    // Both factors must be sampled at the same instant for the result to be a
+    // mathematically exact REP-105 correction, so look up base_link -> odom at
+    // l.timestamp (the data acquisition time the localizer just processed),
+    // not at "latest" -- otherwise the published correction is biased by the
+    // odom-frame motion accumulated during the localizer's processing latency.
+    tf2::Transform odomOnBase_tf;
+    try
+    {
+      const rclcpp::Time   scan_stamp = mrpt::ros2bridge::toROS(l.timestamp);
+      const tf2::TimePoint scan_tp{std::chrono::nanoseconds(scan_stamp.nanoseconds())};
+      const auto           ref_to_trgFrame =
+          tf_buffer_->lookupTransform(l.child_frame, params_.odom_frame, scan_tp);
+      tf2::fromMsg(ref_to_trgFrame.transform, odomOnBase_tf);
+    }
+    catch (const tf2::TransformException& ex)
     {
       // Skip publishing entirely: broadcasting a default-constructed
       // TransformStamped here would inject empty frame_ids into every
       // subscriber's tf2 buffer (TF_NO_FRAME_ID / TF_SELF_TRANSFORM spam).
       MRPT_LOG_THROTTLE_ERROR_STREAM(
           5.0, "publish_localization_following_rep105=true but could not resolve tf '"
-                   << params_.odom_frame << "' -> '" << l.child_frame << "'; skipping TF publish.");
+                   << params_.odom_frame << "' -> '" << l.child_frame << "' at scan stamp ("
+                   << ex.what() << "); skipping TF publish.");
       return;
     }
-
-    const tf2::Transform odomOnBase_tf = mrpt::ros2bridge::toROS_tfTransform(T_base_to_odom);
 
     tf.transform       = tf2::toMsg(transform * odomOnBase_tf);
     tf.child_frame_id  = params_.odom_frame;
@@ -1595,6 +1623,35 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
     tf.child_frame_id  = l.child_frame;
     tf.header.frame_id = l.reference_frame;
   }
+
+  // Cache the latest computed TF so the rebroadcast timer (and any future
+  // calls) can re-emit it with a fresh stamp; the stamp itself is set at
+  // broadcast time inside broadcastCachedLocalizationTf().
+  {
+    auto lck              = mrpt::lockHelper(cachedLocalizationTfMtx_);
+    cachedLocalizationTf_ = tf;
+  }
+
+  // Immediate broadcast so consumers see the new pose without waiting for the
+  // next rebroadcast tick (matters when transform_publish_period is large).
+  broadcastCachedLocalizationTf();
+}
+
+void BridgeROS2::broadcastCachedLocalizationTf()
+{
+  geometry_msgs::msg::TransformStamped tf;
+  {
+    auto lck = mrpt::lockHelper(cachedLocalizationTfMtx_);
+    if (!cachedLocalizationTf_) return;
+    tf = *cachedLocalizationTf_;
+  }
+
+  // Stamp at "now + tolerance" so consumers can lookupTransform(map, base, now())
+  // without ExtrapolationException; Use the ROS clock so use_sim_time is honored automatically.
+  auto node = rosNode();
+  if (!node) return;
+  tf.header.stamp =
+      node->now() + rclcpp::Duration::from_seconds(params_.transform_tolerance);
 
   auto lckTfBc = mrpt::lockHelper(ros_tf_bc_mtx_);
   if (tf_bc_)


### PR DESCRIPTION
Brings the localization `/tf` publisher in line with what AMCL / slam_toolbox / RTAB-Map do, so MOLA is a drop-in REP-105 citizen for Nav2 consumers. Three things in one commit:

1. **REP-105 composition fix.** `(map -> base)(t_scan) * (base -> odom)(t)` was using `waitForTransform()` which only does "latest" — biases the correction by the localizer's processing latency. Now uses `tf_buffer_->lookupTransform(..., scan_tp)` so both factors share `l.timestamp`. (Skip-on-failure behavior from #130 preserved.)

2. **`transform_tolerance`** (default `0.1` s). Stamp = `node->now() + tolerance` so consumers can `lookupTransform(map, base, now())` without `ExtrapolationException`. Same convention as AMCL `transform_tolerance` / RTAB-Map `tf_tolerance`. Uses `rclcpp::Node::now()` so `use_sim_time` works automatically.

3. **`transform_publish_period`** (default `0.05` s = 20 Hz, `0` disables). Wall timer re-broadcasts the cached `map -> odom` independent of localizer rate. Same as slam_toolbox `transform_publish_period` / RTAB-Map `tf_delay`.

**Backwards-compat:** set both new params to `0` to recover prior stamping behavior (modulo the t_scan fix). `publish_in_sim_time` still controls all other publishers; only the localization `/tf` stamp source moved to `Node::now()`.

Companion PR for `mola_lidar_odometry` (env-var plumbing) follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transform caching and periodic rebroadcasting of localization updates
  * Introduced configurable parameters: `transform_tolerance` (timestamp offset in seconds) and `transform_publish_period` (rebroadcast interval, disabled when set to 0)
  * Enhanced timestamp handling for transform messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->