### PR TITLE
perf(mola_metric_maps): pre-warm global-frame submap data in icp_get_prepared_as_global

### DIFF
--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -499,6 +499,24 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
   }
 
   cached_.icp_search_submap->buildCache();
+
+  // Pre-warm the *global-frame* structures used by NearestPointWithCovCapable
+  // matchers (nn_search_cov2cov).  buildCache() above only builds:
+  //   - bbox, KD-tree on pointcloud_  (local frame)
+  //   - per-point covariances in local frame
+  //
+  // But the matcher accesses, on the submap, all of these instead:
+  //   - pointcloud_global()      -> deep copy of pointcloud_ rotated to global
+  //   - kdTreeEnsureIndexBuilt3D -> KD-tree on the *global* cloud
+  //   - covariancesGlobal()      -> rotated covariances
+  //
+  // Without warming these here, the first ICP align() pays the cost on the
+  // lidar worker thread, which can stall the very first scan for several
+  // seconds on large maps - even when icp_get_prepared_as_global() has
+  // already been called.
+  const auto& globalPoints = cached_.icp_search_submap->pointcloud_global();
+  globalPoints->kdTreeEnsureIndexBuilt3D();
+  cached_.icp_search_submap->covariancesGlobal();
 }
 
 void KeyframePointCloudMap::icp_cleanup() const


### PR DESCRIPTION
## Summary

- `KeyframePointCloudMap::icp_get_prepared_as_global()` only pre-builds the *local-frame* data on the search submap (bbox, KD-tree on `pointcloud_`, per-point covariances), via `KeyFrame::buildCache()`.
- The matchers, however, call `nn_search_cov2cov()`, which then lazily materializes the *global-frame* counterparts on the caller thread on the very first call: `pointcloud_global()` (a deep copy of `pointcloud_` rotated by `pose()`), the KD-tree on that global cloud, and `covariancesGlobal()`.
- For non-trivial preloaded local maps this stalls the first `ICP::align()` by several seconds (~6s on a typical localization map in our setup), which defeats the point of having a `prepare_global` hook in the first place — front-ends that explicitly pre-warm via `icp_get_prepared_as_global()` at startup hit it hardest, since the remaining lazy work then surfaces on the first scan instead of being amortized at startup.

This PR pre-triggers the same three calls at the end of `icp_get_prepared_as_global()` so the submap is fully ready by the time `ICP::align()` / `nn_search_cov2cov()` runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the initialization process of the point cloud mapping system to proactively prepare critical components, reducing latency and improving overall system responsiveness during subsequent mapping and alignment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->