### PR TITLE
feat(bridge_ros2): align REP-105 TF with Nav2 conventions without regressing direct-publish mode

### DIFF
--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -199,6 +199,30 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
     /// Otherwise, the wallclock time will be used.
     bool publish_in_sim_time = false;
 
+    /// Future-dating offset [s] applied to the broadcast stamp of the
+    /// REP-105 localization /tf (``map -> odom``). The stamp is set to
+    /// ``rosNode->now() + transform_tolerance``, allowing downstream
+    /// consumers to ``lookupTransform(map, base_link, now())`` without
+    /// tf2 ``ExtrapolationException``s. Ignored in direct-publish mode
+    /// (``map -> base_link``), where the TF is stamped at the scan
+    /// acquisition time so consumers can correlate the pose with the
+    /// sensor data that produced it (and ``publish_in_sim_time`` is
+    /// honored).
+    double transform_tolerance = 0.1;  // [s]
+
+    /// Period [s] at which the latest computed REP-105 localization /tf
+    /// (``map -> odom``) is re-broadcast on a wall timer, independent of
+    /// localization update rate. This keeps the TF buffer always populated
+    /// for downstream consumers even when the localizer runs slower than
+    /// the consumer query rate. Set to ``0`` to disable the rebroadcast
+    /// loop (the TF is then only published when a new localization update
+    /// arrives). Only effective in REP-105 mode: in direct-publish mode
+    /// (``map -> base_link``) the rebroadcast is skipped to avoid
+    /// re-stamping a stale pose as "current" when the localizer stalls --
+    /// in that mode there is no ``odom -> base_link`` edge carrying real
+    /// motion, so the robot would silently appear frozen-but-fresh.
+    double transform_publish_period = 0.05;  // [s]
+
     double period_publish_new_map     = 5.0;  // [s]
     double period_publish_static_tfs  = 1.0;  // [s]
     double period_publish_diagnostics = 1.0;  // [s]
@@ -388,6 +412,33 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
   void publishLocalizationOdom(const LocalizationSourceBase::LocalizationUpdate& l);
   void publishLocalizationQuality(const LocalizationSourceBase::LocalizationUpdate& l);
   void publishLocalizationGeoRef(const LocalizationSourceBase::LocalizationUpdate& l);
+
+  /// Latest computed localization /tf (frame_ids + transform) plus the
+  /// metadata needed to re-stamp it correctly on each broadcast.
+  /// ``useRep105`` selects the stamping policy: REP-105 mode uses
+  /// ``rosNode->now() + transform_tolerance`` (Nav2-style, future-dated,
+  /// safe to rebroadcast because ``odom -> base_link`` carries real
+  /// motion); direct mode uses ``myNow(scan_timestamp)`` (stamped at scan
+  /// time, honoring ``publish_in_sim_time``). Empty until the first
+  /// localization update arrives.
+  struct CachedLocalizationTf
+  {
+    geometry_msgs::msg::TransformStamped tf;
+    bool                                 useRep105 = false;
+    mrpt::Clock::time_point              scan_timestamp;
+  };
+  std::mutex                          cachedLocalizationTfMtx_;
+  std::optional<CachedLocalizationTf> cachedLocalizationTf_;
+
+  /// Re-broadcasts the cached localization /tf with a freshly-computed
+  /// stamp (see ``CachedLocalizationTf`` for the stamping policy). Called
+  /// immediately on each new localization update, and from the rebroadcast
+  /// wall timer when the cached entry is in REP-105 mode. No-op until the
+  /// cache is populated. When ``onlyIfRep105`` is true (used from the
+  /// periodic timer), non-REP-105 cached entries are skipped to avoid
+  /// re-stamping a stale ``map -> base_link`` as "current" while the
+  /// localizer is stalled.
+  void broadcastCachedLocalizationTf(bool onlyIfRep105 = false);
 
   // Different publish map parts:
   void timerPubMap();

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -231,6 +231,30 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
           }
         });
 
+    // Re-broadcast the cached localization /tf at a fixed rate so the buffer
+    // stays populated for downstream consumers regardless of localization
+    // update rate. Set to 0 to disable.
+    rclcpp::TimerBase::SharedPtr timerRebroadcastLocTf;
+    if (params_.transform_publish_period > 0.0)
+    {
+      timerRebroadcastLocTf = rosNode_->create_wall_timer(
+          std::chrono::microseconds(
+              static_cast<unsigned int>(1e6 * params_.transform_publish_period)),
+          [this]()
+          {
+            try
+            {
+              // onlyIfRep105=true: direct-mode (map -> base_link) is not
+              // rebroadcast periodically -- see CachedLocalizationTf docs.
+              broadcastCachedLocalizationTf(/*onlyIfRep105=*/true);
+            }
+            catch (const std::exception& e)
+            {
+              MRPT_LOG_ERROR(e.what());
+            }
+          });
+    }
+
     //
     if (!params_.relocalize_from_topic.empty())
     {
@@ -316,6 +340,8 @@ void BridgeROS2::initialize_rds(const Yaml& c)
   YAML_LOAD_OPT(params_, publish_geo_referenced_poses_from_slam, bool);
 
   YAML_LOAD_OPT(params_, publish_in_sim_time, bool);
+  YAML_LOAD_OPT(params_, transform_tolerance, double);
+  YAML_LOAD_OPT(params_, transform_publish_period, double);
   YAML_LOAD_OPT(params_, period_publish_new_map, double);
   YAML_LOAD_OPT(params_, period_publish_static_tfs, double);
   YAML_LOAD_OPT(params_, period_publish_diagnostics, double);
@@ -1550,7 +1576,6 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
   const tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(l.pose);
 
   geometry_msgs::msg::TransformStamped tf;
-  tf.header.stamp = myNow(l.timestamp);
 
   // Follow REP105 only if we are publishing "map" -> "base_link" poses.
   const bool useRep105 = params_.publish_localization_following_rep105 &&
@@ -1559,26 +1584,32 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
 
   if (useRep105)
   {
-    // Compose map -> odom = (map -> base_link) * (base_link -> odom):
-    mrpt::poses::CPose3D T_base_to_odom;
-    const bool           base_to_odom_ok = this->waitForTransform(
-                  T_base_to_odom,
-                  params_.odom_frame,  // Look for this frame
-                  l.child_frame);  // as seen from this frame
-    // Note: this wait above typ takes ~50 μs
-
-    if (!base_to_odom_ok)
+    // Compose map -> odom = (map -> base_link)(t_scan) * (base_link -> odom)(t_scan).
+    // Both factors must be sampled at the same instant for the result to be a
+    // mathematically exact REP-105 correction, so look up base_link -> odom at
+    // l.timestamp (the data acquisition time the localizer just processed),
+    // not at "latest" -- otherwise the published correction is biased by the
+    // odom-frame motion accumulated during the localizer's processing latency.
+    tf2::Transform odomOnBase_tf;
+    try
+    {
+      const rclcpp::Time   scan_stamp = mrpt::ros2bridge::toROS(l.timestamp);
+      const tf2::TimePoint scan_tp{std::chrono::nanoseconds(scan_stamp.nanoseconds())};
+      const auto           ref_to_trgFrame =
+          tf_buffer_->lookupTransform(l.child_frame, params_.odom_frame, scan_tp);
+      tf2::fromMsg(ref_to_trgFrame.transform, odomOnBase_tf);
+    }
+    catch (const tf2::TransformException& ex)
     {
       // Skip publishing entirely: broadcasting a default-constructed
       // TransformStamped here would inject empty frame_ids into every
       // subscriber's tf2 buffer (TF_NO_FRAME_ID / TF_SELF_TRANSFORM spam).
       MRPT_LOG_THROTTLE_ERROR_STREAM(
           5.0, "publish_localization_following_rep105=true but could not resolve tf '"
-                   << params_.odom_frame << "' -> '" << l.child_frame << "'; skipping TF publish.");
+                   << params_.odom_frame << "' -> '" << l.child_frame << "' at scan stamp ("
+                   << ex.what() << "); skipping TF publish.");
       return;
     }
-
-    const tf2::Transform odomOnBase_tf = mrpt::ros2bridge::toROS_tfTransform(T_base_to_odom);
 
     tf.transform       = tf2::toMsg(transform * odomOnBase_tf);
     tf.child_frame_id  = params_.odom_frame;
@@ -1591,10 +1622,57 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
     tf.header.frame_id = l.reference_frame;
   }
 
+  // Cache the latest computed TF so the rebroadcast timer (and any future
+  // calls) can re-emit it with a fresh stamp; the stamp itself is set at
+  // broadcast time inside broadcastCachedLocalizationTf().
+  {
+    auto lck              = mrpt::lockHelper(cachedLocalizationTfMtx_);
+    cachedLocalizationTf_ = CachedLocalizationTf{tf, useRep105, l.timestamp};
+  }
+
+  // Immediate broadcast so consumers see the new pose without waiting for the
+  // next rebroadcast tick (matters when transform_publish_period is large).
+  // onlyIfRep105=false: always broadcast on new updates, in both modes.
+  broadcastCachedLocalizationTf(/*onlyIfRep105=*/false);
+}
+
+void BridgeROS2::broadcastCachedLocalizationTf(bool onlyIfRep105)
+{
+  CachedLocalizationTf entry;
+  {
+    auto lck = mrpt::lockHelper(cachedLocalizationTfMtx_);
+    if (!cachedLocalizationTf_) return;
+    if (onlyIfRep105 && !cachedLocalizationTf_->useRep105) return;
+    entry = *cachedLocalizationTf_;
+  }
+
+  if (entry.useRep105)
+  {
+    // REP-105 (map -> odom): stamp at "now + tolerance" so consumers can
+    // lookupTransform(map, base, now()) without ExtrapolationException.
+    // Safe to rebroadcast with advancing stamps because odom -> base_link
+    // carries the real motion; the correction staying constant just means
+    // "no new localization update yet", which is the expected semantics.
+    auto node = rosNode();
+    if (!node) return;
+    entry.tf.header.stamp =
+        node->now() + rclcpp::Duration::from_seconds(params_.transform_tolerance);
+  }
+  else
+  {
+    // Direct mode (map -> base_link): stamp at the scan acquisition time
+    // (honors publish_in_sim_time) so downstream consumers can correlate
+    // the pose with the sensor data that produced it. We do NOT future-date
+    // here, and the periodic timer skips this branch entirely, so a stalled
+    // localizer produces stale-looking TFs (correct) rather than a frozen
+    // pose silently re-stamped as "current".
+    entry.tf.header.stamp = myNow(entry.scan_timestamp);
+  }
+
   auto lckTfBc = mrpt::lockHelper(ros_tf_bc_mtx_);
   if (tf_bc_)
   {
-    tf_bc_->sendTransform(tf);
+    tf_bc_->sendTransform(entry.tf);
   }
 }
 


### PR DESCRIPTION
Supersedes / revises #132. Keeps the three Nav2/REP-105 improvements from the original PR, but scopes them so they no longer change behavior (or introduce new failure modes) for users who do **not** use REP-105.
                                                                                                                                                                                                                  
MOLA supports two TF publishing modes for the localization result:                                                                                                                                               
  
1. **REP-105 mode** — `publish_localization_following_rep105:=True`. The bridge publishes `map → odom` and an external source (wheel odometry, robot_state_publisher, …) provides `odom → base_link`. Used by    
AMCL, Nav2, slam_toolbox, etc.
2. **Direct mode** — `publish_localization_following_rep105:=False` (default for the Smoother, and the documented choice for handheld / drone / no-external-odometry setups). The bridge publishes `map →        
base_link` directly; there is no second TF edge carrying motion.                                                                                                                                                 
  
PR #132 improved REP-105 mode but applied the same logic to both modes, which regressed direct mode in two ways:                                                                                                 
                                                                                                                                                                                                                  
- The new `node->now() + transform_tolerance` stamping replaced the former `myNow(l.timestamp)` (scan-time) stamping for *both* modes. Direct-mode consumers that correlate the pose with the scan that produced
it (offline post-processing, sensor fusion, visualization against recorded bags) started getting future-dated stamps and `publish_in_sim_time` was silently bypassed.                                            
- The 20 Hz rebroadcast timer runs in both modes. In REP-105 that is benign: if the localizer stalls, `map → odom` staying constant is exactly the right semantics because `odom → base_link` still moves. In
direct mode there is no `odom → base_link`: a stalled localizer produces a *frozen pose repeatedly re-stamped as "current"*, which downstream planners / RViz cannot distinguish from a robot that is actually   
stationary and healthy.
                                                                                                                                                                                                                  
## Changes vs #132

- New `CachedLocalizationTf` struct carries the cached TF **plus** `useRep105` and the original scan timestamp, so the broadcaster knows how to stamp each entry.
- `broadcastCachedLocalizationTf(bool onlyIfRep105 = false)`:                                                                                                                                                    
  - REP-105 entries → stamp `node->now() + transform_tolerance` (unchanged Nav2 behavior from #132).                                                                                                             
  - Direct-mode entries → stamp `myNow(scan_timestamp)` (restores pre-#132 semantics and honors `publish_in_sim_time`).                                                                                          
- Periodic rebroadcast timer calls it with `onlyIfRep105=true`, skipping direct-mode entries entirely. Immediate broadcast on a new localization update still fires in both modes.                               
- Parameter documentation for `transform_tolerance` and `transform_publish_period` updated to state they apply to REP-105 mode only, and to explain *why* direct mode is excluded.                               
                                                                                                                                                                                                                  
## Behavior matrix                                                                                                                                                                                               
                                                                                                                                                                                                                  
| Mode | Stamp on new update | Periodic rebroadcast | `publish_in_sim_time` honored |                                                                                                                            
|------|--------------------|----------------------|-------------------------------|                                                                                                                             
| REP-105 (`map → odom`) | `now() + tolerance` | yes, every `transform_publish_period` | n/a (uses ROS clock, which already respects `use_sim_time`) |                                                           
| Direct (`map → base_link`) | `myNow(scan_timestamp)` | **no** | yes |
                                                                                                                                                                                                                  
## Compatibility                                                                                                                                                                                                 
                                                                                                                                                                                                                  
- REP-105 users: no behavior change vs #132.                                                                                                                                                                     
- Direct-mode users (cookbook §4.2, §4.4–4.6, all live-node Smoother setups): behavior matches `develop` before #132 — scan-time stamping, no hidden rebroadcast, `publish_in_sim_time` respected.               
- No parameter renames or removals; defaults unchanged.                                                                                                                                                          
                                                                                                                                                                                                                
## Test plan                                                                                                                                                                                                     
                                                                                                                                                                                                                  
- [ ] REP-105 LO setup with wheel odometry: confirm `map → odom` is future-dated and rebroadcast at 20 Hz (unchanged from #132).                                                                                 
- [x] Direct-mode Smoother + wheel odom topic (cookbook §4.4): confirm `map → base_link` is stamped at scan time and `tf2_echo` shows stamps stop advancing when the localizer is paused.                        
- [ ] Direct-mode LIO with `publish_in_sim_time:=True` replaying a bag: confirm TF stamps track the bag clock, not wallclock.                                                                                    
- [ ] REP-105 mode with `transform_publish_period:=0`: confirm TFs are only emitted on new localization updates.   

---

Original PR

---

This brings the localization /tf publisher in line with the convention used by AMCL, slam_toolbox, RTAB-Map and Cartographer, addressing three issues observed when MOLA is consumed by Nav2-style downstream nodes:

1. REP-105 composition bug (fix). The inner factor of map -> odom = (map -> base)(t_scan) * (base -> odom)(t) was sampled at "latest" via waitForTransform(), which only supports tf2::TimePoint{}. The two factors must be sampled at the same instant or the published correction is biased by the odom-frame motion accumulated during the localizer's processing latency. Switch to tf_buffer_->lookupTransform(..., scan_tp). On lookup failure the publish is skipped (an empty default-constructed TransformStamped would inject TF_NO_FRAME_ID into every consumer's tf2 buffer).

2. transform_tolerance (new param, default 0.1s). The published stamp is now node->now() + transform_tolerance so consumers can do lookupTransform(map, base_link, now()) without ExtrapolationException. Mirrors AMCL's transform_tolerance and RTAB-Map's tf_tolerance. Uses the ROS clock so use_sim_time is honored automatically.

3. transform_publish_period (new param, default 0.05s = 20 Hz). A wall timer re-broadcasts the cached map -> odom independent of localization update rate, keeping the TF buffer continuously fresh even when the localizer runs slower than the consumer query rate. Set to 0 to disable. Mirrors slam_toolbox's transform_publish_period and RTAB-Map's tf_delay.

Backwards compat: to exactly preserve the prior (post-bugfix) stamping behavior set transform_tolerance: 0 and transform_publish_period: 0. publish_in_sim_time retains its meaning for all other publishers (sensor TFs, odom messages, etc.); only the localization /tf stamp source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic rebroadcasting of the latest localization transform via a configurable transform_publish_period.
  * Configurable transform_tolerance to control future-dating of rebroadcasted transforms for TF lookup stability.
  * Caching of the latest localization transform to support reliable periodic rebroadcasts.

* **Bug Fixes**
  * More robust REP-105 correction and timestamp handling with clearer failure logging; avoids re-stamping stale direct-mode poses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->