### PR TITLE
fix(mola_kernel): replay latched MapUpdates to late subscribers

### DIFF
--- a/mola_kernel/include/mola_kernel/interfaces/MapSourceBase.h
+++ b/mola_kernel/include/mola_kernel/interfaces/MapSourceBase.h
@@ -23,6 +23,7 @@
 
 #include <functional>
 #include <iostream>
+#include <map>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -80,10 +81,32 @@ class MapSourceBase
 
   using map_updates_callback_t = std::function<void(const MapUpdate&)>;
 
+  /** Subscribe to map updates.
+   *
+   * Behaves analogously to ROS' `transient_local` durability: any prior
+   * `advertiseUpdatedMap()` call made with `keep_last_one_only=true` is
+   * cached (one entry per `map_name`) and replayed once into the new
+   * callback at subscription time. This avoids losing the initial state
+   * when the producer advertises before the consumer has had a chance
+   * to subscribe (e.g. on startup, when modules come up in arbitrary
+   * order).
+   */
   void subscribeToMapUpdates(const map_updates_callback_t& callback)
   {
     auto lck = mrpt::lockHelper(mapUpdSubsMtx_);
     mapUpdSubs_.push_back(callback);
+
+    for (const auto& [name, mu] : lastUpdates_)
+    {
+      try
+      {
+        callback(mu);
+      }
+      catch (const std::exception& e)
+      {
+        std::cerr << "[MapSourceBase] Exception in callback: " << e.what();
+      }
+    }
   }
 
  protected:
@@ -96,6 +119,12 @@ class MapSourceBase
   void advertiseUpdatedMap(const MapUpdate& l)
   {
     auto lck = mrpt::lockHelper(mapUpdSubsMtx_);
+
+    if (l.keep_last_one_only)
+    {
+      lastUpdates_[l.map_name] = l;
+    }
+
     for (const auto& callback : mapUpdSubs_)
     {
       try
@@ -111,7 +140,10 @@ class MapSourceBase
 
  private:
   std::vector<map_updates_callback_t> mapUpdSubs_;
-  std::mutex                          mapUpdSubsMtx_;
+  /// Cache of last latched update per `map_name`; replayed to late
+  /// subscribers. Only populated when `keep_last_one_only=true`.
+  std::map<std::string, MapUpdate> lastUpdates_;
+  std::mutex                       mapUpdSubsMtx_;
 };
 
 }  // namespace mola


### PR DESCRIPTION
## Summary

- `MapSourceBase::subscribeToMapUpdates()` now caches the most recent `MapUpdate` per `map_name` whenever the producer advertised it with `keep_last_one_only=true`, and replays it once into any callback registered later. This gives MOLA-internal map subscriptions transient_local-like durability, mirroring the QoS the ROS bridge already uses one layer up.
- Updates flagged with `keep_last_one_only=false` (e.g. deskewed scans) are intentionally not cached — their fire-and-forget semantics are preserved.

## Why

Today, when a producer advertises a map before a consumer has had a chance to subscribe, the update is silently lost. A concrete example is `mola_lidar_odometry` publishing the loaded `.mm` on its very first scan, before `mola_bridge_ros2::doLookForNewMolaSubs()` has run for the first time. The race is more visible with small maps, where the LO `initialize()` (notably the ICP search-structure pre-warm) is fast enough that the worker thread fires `advertiseUpdatedMap()` before the bridge's first sub-discovery poll. The result is that the localization map never appears on the ROS topic, while a larger map (slower init) makes the same setup work as expected.

With this change the late subscriber receives the cached update on registration; the ROS publisher created downstream then keeps it available to ROS subscribers via its existing `transient_local` QoS, end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map source updates now support latched delivery. New subscribers automatically receive a replay of the most recent map updates upon subscribing, ensuring immediate access to the latest map state.

* **Bug Fixes / Reliability**
  * Replay of cached updates is performed safely with error handling and logging to prevent subscriber crashes during update delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->