### PR TITLE
mola_metric_maps: per-KF pose plumbing for online gravity rebake

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <optional>
+#include <vector>
 
 namespace mola
 {
@@ -71,6 +72,28 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
   KeyframePointCloudMap() = default;
 
   ~KeyframePointCloudMap();
+
+  /** The KF id that will be assigned to the next inserted key-frame. */
+  [[nodiscard]] KeyFrameID nextFreeKeyFrameID_public() const;
+
+  /** Snapshot of all key-frame poses, keyed by KF id. Cheap. Thread-safe. */
+  [[nodiscard]] std::map<KeyFrameID, mrpt::poses::CPose3D> cloneKFPoses() const;
+
+  /** Overwrites the pose of one KF in the map, invalidating its caches.
+   *  No-op if `id` is not present. Thread-safe.
+   */
+  void setKeyframePose(KeyFrameID id, const mrpt::poses::CPose3D& new_pose);
+
+  /** The id of the last key-frame successfully inserted, or nullopt if none
+   *  has been inserted since the map was created/cleared.
+   */
+  [[nodiscard]] std::optional<KeyFrameID> lastInsertedKeyFrameID() const;
+
+  /** Returns and clears the list of KF ids evicted since the last call (or
+   *  since map construction). Used by callers that maintain per-KF
+   *  auxiliary state and need to drop it on eviction.
+   */
+  [[nodiscard]] std::vector<KeyFrameID> drainEvictedKeyFrameIDs();
 
   /** @} */
 
@@ -457,6 +480,12 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
 
   std::map<KeyFrameID, KeyFrame> keyframes_;
 
+  /// Last key-frame id successfully inserted (nullopt if none since creation/clear).
+  std::optional<KeyFrameID> last_inserted_kf_id_;
+
+  /// KF ids evicted since the last call to drainEvictedKeyFrameIDs().
+  std::vector<KeyFrameID> evicted_kf_ids_;
+
   /// for cached_ and _keyframes
   mutable mrpt::containers::NonCopiableData<std::recursive_mutex> state_mtx_;
 
@@ -529,3 +558,13 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
 };
 
 }  // namespace mola
+
+/** Feature macro: KeyframePointCloudMap exposes the per-KF pose plumbing
+ *  (`cloneKFPoses`, `setKeyframePose`, `lastInsertedKeyFrameID`,
+ *  `drainEvictedKeyFrameIDs`, `nextFreeKeyFrameID_public`) used by
+ *  online gravity rebake. Downstream packages should guard usage with
+ *  `#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING)` (combined with
+ *  `__has_include(<mola_metric_maps/KeyframePointCloudMap.h>)`) to remain
+ *  buildable against older `mola_metric_maps` checkouts.
+ */
+#define MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING 1

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -551,6 +551,7 @@ void KeyframePointCloudMap::merge_with(
     {
       new_kf.pose(*otherRelativePose + new_kf.pose());
     }
+    last_inserted_kf_id_ = it->first;
   }
 }
 
@@ -1158,7 +1159,50 @@ void KeyframePointCloudMap::internal_clear()
   auto lck = mrpt::lockHelper(*state_mtx_);
 
   keyframes_.clear();
+  last_inserted_kf_id_.reset();
+  evicted_kf_ids_.clear();
   cached_.reset();
+}
+
+KeyframePointCloudMap::KeyFrameID KeyframePointCloudMap::nextFreeKeyFrameID_public() const
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+  return nextFreeKeyFrameID();
+}
+
+std::map<KeyframePointCloudMap::KeyFrameID, mrpt::poses::CPose3D>
+    KeyframePointCloudMap::cloneKFPoses() const
+{
+  auto                                       lck = mrpt::lockHelper(*state_mtx_);
+  std::map<KeyFrameID, mrpt::poses::CPose3D> out;
+  for (const auto& [id, kf] : keyframes_) out.emplace(id, kf.pose());
+  return out;
+}
+
+void KeyframePointCloudMap::setKeyframePose(KeyFrameID id, const mrpt::poses::CPose3D& new_pose)
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+  auto it  = keyframes_.find(id);
+  if (it == keyframes_.end()) return;
+  it->second.pose(new_pose);
+  // KF-local caches are invalidated by KeyFrame::pose(). Top-level caches
+  // (bounding box, icp submap) also depend on KF poses, so invalidate them:
+  cached_.reset();
+}
+
+std::optional<KeyframePointCloudMap::KeyFrameID> KeyframePointCloudMap::lastInsertedKeyFrameID()
+    const
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+  return last_inserted_kf_id_;
+}
+
+std::vector<KeyframePointCloudMap::KeyFrameID> KeyframePointCloudMap::drainEvictedKeyFrameIDs()
+{
+  auto                    lck = mrpt::lockHelper(*state_mtx_);
+  std::vector<KeyFrameID> out;
+  out.swap(evicted_kf_ids_);
+  return out;
 }
 
 bool KeyframePointCloudMap::internal_insertObservation(
@@ -1181,6 +1225,7 @@ bool KeyframePointCloudMap::internal_insertObservation(
       const double dist = pc_in_map.distanceTo(it->second.pose());
       if (dist > insertionOptions.remove_frames_farther_than)
       {
+        evicted_kf_ids_.push_back(it->first);
         it = keyframes_.erase(it);
       }
       else
@@ -1206,6 +1251,8 @@ bool KeyframePointCloudMap::internal_insertObservation(
 
     new_kf.buildCache();
     cached_.reset();
+
+    last_inserted_kf_id_ = it->first;
 
     return true;
   }

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -28,6 +28,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <set>
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -627,7 +628,110 @@ void test_view_filter_with_rotated_local_frame()
   }
 }
 
-// ── 16. Default filter parameters are sane ────────────────────────────────
+// ── 17. Per-KF pose plumbing for online gravity rebake ────────────────────
+//
+// Covers the additions used by mola_lidar_odometry's TrajectoryRebaker:
+//   - cloneKFPoses
+//   - setKeyframePose (existing id, missing id is a no-op)
+//   - lastInsertedKeyFrameID (none / after insert / after clear)
+//   - drainEvictedKeyFrameIDs (returns then clears)
+//   - nextFreeKeyFrameID_public
+//   - eviction tracking via insertionOptions.remove_frames_farther_than
+void test_kf_pose_plumbing()
+{
+  using mrpt::literals::operator""_deg;
+  using mrpt::poses::CPose3D;
+  using KFID = mola::KeyframePointCloudMap::KeyFrameID;
+
+  mola::KeyframePointCloudMap m;
+  m.creationOptions.k_correspondences_for_cov = 5;
+  m.creationOptions.max_search_keyframes      = 3;
+
+  // Fresh map: no last id, next id is 0.
+  ASSERT_(!m.lastInsertedKeyFrameID().has_value());
+  ASSERT_EQUAL_(m.nextFreeKeyFrameID_public(), KFID{0});
+  ASSERT_(m.cloneKFPoses().empty());
+  ASSERT_(m.drainEvictedKeyFrameIDs().empty());
+
+  // Insert 3 KFs at distinct positions.
+  std::vector<CPose3D> seedPoses = {
+      CPose3D::FromXYZYawPitchRoll(0.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg),
+      CPose3D::FromXYZYawPitchRoll(2.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg),
+      CPose3D::FromXYZYawPitchRoll(4.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg)};
+
+  for (size_t i = 0; i < seedPoses.size(); ++i)
+  {
+    auto obs        = mrpt::obs::CObservationPointCloud::Create();
+    obs->pointcloud = makeCloudWithViews(makeGridPts(static_cast<float>(i) * 10.f));
+    const auto next = m.nextFreeKeyFrameID_public();
+    ASSERT_EQUAL_(next, static_cast<KFID>(i));
+    m.insertObservation(*obs, seedPoses[i]);
+    ASSERT_(m.lastInsertedKeyFrameID().has_value());
+    ASSERT_EQUAL_(*m.lastInsertedKeyFrameID(), static_cast<KFID>(i));
+  }
+
+  // cloneKFPoses returns a snapshot keyed by id.
+  auto snap = m.cloneKFPoses();
+  ASSERT_EQUAL_(snap.size(), seedPoses.size());
+  for (size_t i = 0; i < seedPoses.size(); ++i)
+  {
+    ASSERT_NEAR_(snap.at(static_cast<KFID>(i)).x(), seedPoses[i].x(), 1e-9);
+  }
+
+  // Mutating the snapshot does not affect the map.
+  snap.at(KFID{0}) = CPose3D::FromXYZYawPitchRoll(99.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg);
+  ASSERT_NEAR_(m.cloneKFPoses().at(KFID{0}).x(), 0.0, 1e-9);
+
+  // setKeyframePose updates the stored pose.
+  const auto newPose1 = CPose3D::FromXYZYawPitchRoll(2.0, 0.0, 1.5, 0.0_deg, 5.0_deg, 0.0_deg);
+  m.setKeyframePose(KFID{1}, newPose1);
+  const auto poseAfter = m.cloneKFPoses().at(KFID{1});
+  ASSERT_NEAR_(poseAfter.x(), newPose1.x(), 1e-9);
+  ASSERT_NEAR_(poseAfter.z(), newPose1.z(), 1e-9);
+  double y, p, r;
+  poseAfter.getYawPitchRoll(y, p, r);
+  ASSERT_NEAR_(p, 5.0 * M_PI / 180.0, 1e-9);
+
+  // setKeyframePose on a missing id is a no-op (does not throw, does not add).
+  m.setKeyframePose(KFID{999}, CPose3D::Identity());
+  ASSERT_EQUAL_(m.cloneKFPoses().size(), seedPoses.size());
+
+  // No evictions yet.
+  ASSERT_(m.drainEvictedKeyFrameIDs().empty());
+
+  // Trigger partial eviction: insert a new KF at x=5, threshold=2.5 m.
+  // KF 0 (dist 5) and KF 1 (dist ~3.35, since z was raised to 1.5) fall
+  // outside the threshold; KF 2 at x=4 (dist 1) survives. Keeping at least
+  // one KF in place preserves id monotonicity (next id = 3).
+  m.insertionOptions.remove_frames_farther_than = 2.5;  // metres
+
+  auto obs            = mrpt::obs::CObservationPointCloud::Create();
+  obs->pointcloud     = makeCloudWithViews(makeGridPts(40.f));
+  const auto poseNear = CPose3D::FromXYZYawPitchRoll(5.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg);
+  m.insertObservation(*obs, poseNear);
+
+  ASSERT_(m.lastInsertedKeyFrameID().has_value());
+  ASSERT_EQUAL_(*m.lastInsertedKeyFrameID(), KFID{3});
+
+  // drainEvictedKeyFrameIDs returns the ids of KFs dropped during the
+  // last insertion(s), then clears its internal list.
+  const auto evicted1 = m.drainEvictedKeyFrameIDs();
+  ASSERT_EQUAL_(evicted1.size(), 2UL);
+  std::set<KFID> evictedSet(evicted1.begin(), evicted1.end());
+  ASSERT_(evictedSet.count(KFID{0}) == 1);
+  ASSERT_(evictedSet.count(KFID{1}) == 1);
+
+  // A second drain returns an empty vector.
+  ASSERT_(m.drainEvictedKeyFrameIDs().empty());
+
+  // After clear(), bookkeeping is reset.
+  m.clear();
+  ASSERT_(!m.lastInsertedKeyFrameID().has_value());
+  ASSERT_(m.drainEvictedKeyFrameIDs().empty());
+  ASSERT_EQUAL_(m.nextFreeKeyFrameID_public(), KFID{0});
+}
+
+// ── 18. Default filter parameters are sane ────────────────────────────────
 void test_default_creation_options()
 {
   mola::KeyframePointCloudMap m;
@@ -689,6 +793,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_view_filter_with_rotated_local_frame ...\n";
     test_view_filter_with_rotated_local_frame();
+
+    std::cout << "test_kf_pose_plumbing ...\n";
+    test_kf_pose_plumbing();
 
     std::cout << "test_default_creation_options ...\n";
     test_default_creation_options();

--- a/mola_pose_list/include/mola_pose_list/SearchablePoseList.h
+++ b/mola_pose_list/include/mola_pose_list/SearchablePoseList.h
@@ -20,17 +20,31 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/poses/CPose3D.h>
 
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <optional>
+#include <vector>
+
 namespace mola
 {
 /** Data structure to search for nearby SE(3) poses.
  *
  *  It uses a KD-tree for the search.
  *
+ *  Optionally, each inserted pose can be tagged with an external ID
+ *  (e.g. a keyframe ID) so that callers can later update its stored
+ *  pose in place via setPoseById(). This is used by the online
+ *  gravity-rebake feature to keep distance-checkers in sync with
+ *  per-KF pose corrections without rebuilding from scratch.
+ *
  * \ingroup mola_pose_list_grp
  */
 class SearchablePoseList
 {
  public:
+  using KFID = uint64_t;
+
   SearchablePoseList() = default;
 
   SearchablePoseList(bool measure_from_last_kf_only) : from_last_only_(measure_from_last_kf_only) {}
@@ -57,8 +71,34 @@ class SearchablePoseList
     {
       kf_points_.insertPoint(p.translation());
       kf_poses_.push_back(p);
+      kf_ids_.push_back(std::nullopt);
     }
   }
+
+  /** Same as insert(p), but tags the stored entry with `id` so that the
+   *  pose can later be updated in place via setPoseById(). No-op in
+   *  `from_last_only_` mode (the single tracked pose has no id).
+   */
+  void insert(const mrpt::poses::CPose3D& p, KFID id)
+  {
+    if (from_last_only_)
+    {
+      last_kf_ = p;
+      return;
+    }
+    const size_t idx = kf_poses_.size();
+    kf_points_.insertPoint(p.translation());
+    kf_poses_.push_back(p);
+    kf_ids_.push_back(id);
+    id_to_idx_[id] = idx;
+  }
+
+  /** Updates the stored pose for an entry previously inserted with an id.
+   *  No-op if `from_last_only_` is set or `id` is unknown.
+   *  The internal KD-tree point is updated in place; subsequent NN queries
+   *  reflect the new pose.
+   */
+  void setPoseById(KFID id, const mrpt::poses::CPose3D& new_pose);
 
   [[nodiscard]] std::tuple<bool /*isFirst*/, mrpt::poses::CPose3D /*distanceToClosest*/> check(
       const mrpt::poses::CPose3D& p) const;
@@ -72,7 +112,21 @@ class SearchablePoseList
   // if from_last_only_==false
   std::deque<mrpt::poses::CPose3D> kf_poses_;
   mrpt::maps::CSimplePointsMap     kf_points_;
+  /// Optional KFID for each entry, parallel to kf_poses_.
+  std::deque<std::optional<KFID>> kf_ids_;
+  /// Inverse lookup: KFID -> index into kf_poses_/kf_points_/kf_ids_.
+  std::map<KFID, size_t> id_to_idx_;
 
   bool from_last_only_ = false;
 };
 }  // namespace mola
+
+/** Feature macro: SearchablePoseList exposes the id-keyed API
+ *  (`insert(pose, id)`, `setPoseById`) used by the online gravity-rebake
+ *  feature to keep distance-checkers in sync with per-KF pose corrections.
+ *  Downstream packages in separate repos should guard usage with
+ *  `#if defined(MOLA_POSE_LIST_HAS_ID_KEYED_API)` (combined with
+ *  `__has_include(<mola_pose_list/SearchablePoseList.h>)`) to remain
+ *  buildable against older `mola_pose_list` checkouts.
+ */
+#define MOLA_POSE_LIST_HAS_ID_KEYED_API 1

--- a/mola_pose_list/src/SearchablePoseList.cpp
+++ b/mola_pose_list/src/SearchablePoseList.cpp
@@ -82,8 +82,10 @@ void SearchablePoseList::removeAllFartherThan(
     return;  // not applicable
   }
 
-  std::deque<mrpt::poses::CPose3D> new_kf_poses;
-  mrpt::maps::CSimplePointsMap     new_kf_points;
+  std::deque<mrpt::poses::CPose3D>                    new_kf_poses;
+  mrpt::maps::CSimplePointsMap                        new_kf_points;
+  std::deque<std::optional<SearchablePoseList::KFID>> new_kf_ids;
+  std::map<SearchablePoseList::KFID, size_t>          new_id_to_idx;
 
   const double maxSqrDist = mrpt::square(maxTranslation);
   const auto   c          = p.translation();
@@ -97,11 +99,29 @@ void SearchablePoseList::removeAllFartherThan(
       continue;  // remove
     }
     // pass:
+    const size_t newIdx = new_kf_poses.size();
     new_kf_points.insertPoint(pt);
     new_kf_poses.push_back(kf_poses_.at(i));
+    new_kf_ids.push_back(kf_ids_.at(i));
+    if (kf_ids_.at(i)) new_id_to_idx[*kf_ids_.at(i)] = newIdx;
   }
   // replace:
   kf_poses_  = std::move(new_kf_poses);
   kf_points_ = std::move(new_kf_points);  // NOLINT
+  kf_ids_    = std::move(new_kf_ids);
+  id_to_idx_ = std::move(new_id_to_idx);
   ASSERT_EQUAL_(kf_poses_.size(), kf_points_.size());
+  ASSERT_EQUAL_(kf_poses_.size(), kf_ids_.size());
+}
+
+void SearchablePoseList::setPoseById(KFID id, const mrpt::poses::CPose3D& new_pose)
+{
+  if (from_last_only_) return;
+  auto it = id_to_idx_.find(id);
+  if (it == id_to_idx_.end()) return;
+  const size_t idx  = it->second;
+  kf_poses_.at(idx) = new_pose;
+  const auto t      = new_pose.translation();
+  // Update the kd-tree point in place. setPoint() invalidates the kd-tree.
+  kf_points_.setPoint(idx, t.x, t.y, t.z);
 }

--- a/mola_pose_list/src/SearchablePoseList.cpp
+++ b/mola_pose_list/src/SearchablePoseList.cpp
@@ -43,8 +43,13 @@ std::tuple<bool /*isFirst*/, mrpt::poses::CPose3D /*distanceToClosest*/> Searcha
     std::vector<float>                 closestSqrDist;
     std::vector<uint64_t>              closestID;
 
+    // Cap k at the actual cloud size: nn_multiple_search resizes its output
+    // vectors to k regardless of how many neighbours it finds, leaving
+    // trailing entries uninitialized when fewer than k points exist. Reading
+    // those garbage entries would corrupt the best-match selection below.
+    const size_t k = std::min<size_t>(20, kf_points_.size());
     kf_points_.nn_multiple_search(
-        p.translation().cast<float>(), 20, closest, closestSqrDist, closestID);
+        p.translation().cast<float>(), k, closest, closestSqrDist, closestID);
     ASSERT_(!closest.empty());  // empty()==false from check above
 
     // Check for both, rotation and translation.

--- a/mola_pose_list/tests/test-searchable-pose-list.cpp
+++ b/mola_pose_list/tests/test-searchable-pose-list.cpp
@@ -12,7 +12,7 @@
 
 /**
  * @file   test-searchable-pose-list.cpp
- * @brief  Unit tests for mola_pose_list
+ * @brief  Unit tests for mola_pose_list / SearchablePoseList
  * @author Jose Luis Blanco Claraco
  * @date   Mar 5, 2024
  */
@@ -20,18 +20,135 @@
 #include <mola_pose_list/SearchablePoseList.h>
 #include <mrpt/poses/Lie/SE.h>
 
+#include <cmath>
 #include <iostream>
 
-static void test1()
+namespace
 {
-  // write me!
+using mrpt::poses::CPose3D;
+
+CPose3D xyz(double x, double y, double z) { return CPose3D::FromXYZYawPitchRoll(x, y, z, 0, 0, 0); }
+
+// Populate a list with 25 KFs spaced 1 m along x, ids = id_base..id_base+24.
+// Returns the id of the KF whose x is targetX.
+mola::SearchablePoseList::KFID populateLine(
+    mola::SearchablePoseList& list, mola::SearchablePoseList::KFID id_base = 100)
+{
+  for (mola::SearchablePoseList::KFID i = 0; i < 25; ++i)
+  {
+    list.insert(xyz(static_cast<double>(i), 0, 0), id_base + i);
+  }
+  return id_base;
 }
+
+// ── 1. id-keyed insertion + setPoseById updates the NN search ──────────────
+void test_insert_with_id_and_set_pose()
+{
+  mola::SearchablePoseList list(false /*from_last_only*/);
+  const auto               idBase = populateLine(list);  // KFs at x=0..24
+
+  ASSERT_EQUAL_(list.size(), 25UL);
+
+  // Query at (5.1, 0, 0): nearest is KF (idBase+5) at (5,0,0).
+  {
+    auto [isFirst, dist] = list.check(xyz(5.1, 0, 0));
+    ASSERT_(!isFirst);
+    ASSERT_NEAR_(dist.translation().norm(), 0.1, 1e-5);
+  }
+
+  // Move that KF to (1000, 0, 0): query at (5.1,0,0) now snaps to KF at (4,0,0)
+  // or (6,0,0); both are at distance ~1.1 / ~0.9. Closest is (6,0,0): dist 0.9.
+  list.setPoseById(idBase + 5, xyz(1000, 0, 0));
+  {
+    auto [isFirst, dist] = list.check(xyz(5.1, 0, 0));
+    ASSERT_(!isFirst);
+    ASSERT_NEAR_(dist.translation().norm(), 0.9, 1e-5);
+  }
+
+  // setPoseById on an unknown id is a no-op.
+  list.setPoseById(999999, xyz(0, 0, 0));
+  ASSERT_EQUAL_(list.size(), 25UL);
+}
+
+// ── 2. removeAllFartherThan preserves the id->index mapping ────────────────
+void test_remove_preserves_ids()
+{
+  mola::SearchablePoseList list(false);
+  const auto               idBase = populateLine(list);  // KFs at x=0..24
+
+  // Drop everything farther than 10 m from (12,0,0): keeps KFs at x=2..22
+  // (21 KFs).
+  list.removeAllFartherThan(xyz(12, 0, 0), 10.0);
+  ASSERT_EQUAL_(list.size(), 21UL);
+
+  // Surviving id (idBase+12) is still addressable: move it to (1000,0,0),
+  // confirm the query no longer snaps to it.
+  list.setPoseById(idBase + 12, xyz(1000, 0, 0));
+  {
+    auto [isFirst, dist] = list.check(xyz(11.5, 0, 0));
+    ASSERT_(!isFirst);
+    // Closest is now (11,0,0) → 0.5
+    ASSERT_NEAR_(dist.translation().norm(), 0.5, 1e-5);
+  }
+
+  // An evicted id (idBase+0 was at x=0, distance 12 from anchor → removed)
+  // is silently a no-op.
+  list.setPoseById(idBase + 0, xyz(0, 0, 0));
+  ASSERT_EQUAL_(list.size(), 21UL);
+}
+
+// ── 3. legacy insert(p) (no id) keeps working alongside id-tagged inserts ──
+void test_legacy_insert_no_id()
+{
+  mola::SearchablePoseList list(false);
+  // 24 untagged + 1 tagged
+  for (int i = 0; i < 24; ++i)
+  {
+    list.insert(xyz(static_cast<double>(i), 0, 0));  // no id
+  }
+  list.insert(xyz(50, 0, 0), 42);
+
+  ASSERT_EQUAL_(list.size(), 25UL);
+
+  // Move the tagged one far away: query at (50.1,0,0) used to snap there.
+  list.setPoseById(42, xyz(1000, 0, 0));
+  auto [isFirst, dist] = list.check(xyz(50.1, 0, 0));
+  ASSERT_(!isFirst);
+  // Closest among the untagged line (max x = 23) is (23, 0, 0): dist ≈ 27.1
+  ASSERT_NEAR_(dist.translation().norm(), 50.1 - 23.0, 1e-3);
+}
+
+// ── 4. from_last_only mode: id-keyed APIs are no-ops ──────────────────────
+void test_from_last_only_is_noop_for_id_api()
+{
+  mola::SearchablePoseList list(true /*from_last_only*/);
+
+  list.insert(xyz(1, 2, 3), 7);  // id ignored, behaves like insert(p)
+  ASSERT_EQUAL_(list.size(), 1UL);
+
+  // setPoseById is a no-op; the stored last-pose is unchanged.
+  list.setPoseById(7, xyz(99, 99, 99));
+  auto [isFirst, dist] = list.check(xyz(1, 2, 3));
+  ASSERT_(!isFirst);
+  ASSERT_NEAR_(dist.translation().norm(), 0.0, 1e-9);
+}
+}  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
   try
   {
-    test1();
+    std::cout << "test_insert_with_id_and_set_pose ...\n";
+    test_insert_with_id_and_set_pose();
+
+    std::cout << "test_remove_preserves_ids ...\n";
+    test_remove_preserves_ids();
+
+    std::cout << "test_legacy_insert_no_id ...\n";
+    test_legacy_insert_no_id();
+
+    std::cout << "test_from_last_only_is_noop_for_id_api ...\n";
+    test_from_last_only_is_noop_for_id_api();
 
     std::cout << "Test successful."
               << "\n";

--- a/mola_pose_list/tests/test-searchable-pose-list.cpp
+++ b/mola_pose_list/tests/test-searchable-pose-list.cpp
@@ -118,7 +118,25 @@ void test_legacy_insert_no_id()
   ASSERT_NEAR_(dist.translation().norm(), 50.1 - 23.0, 1e-3);
 }
 
-// ── 4. from_last_only mode: id-keyed APIs are no-ops ──────────────────────
+// ── 4. Regression: check() works correctly when fewer than k=20 KFs exist.
+// Before the fix, nn_multiple_search returned sized-20 vectors with trailing
+// garbage when the cloud had fewer points, corrupting the best-match pick.
+void test_check_with_few_kfs()
+{
+  mola::SearchablePoseList list(false);
+
+  // Just 3 KFs along x.
+  list.insert(xyz(0, 0, 0), 1);
+  list.insert(xyz(5, 0, 0), 2);
+  list.insert(xyz(10, 0, 0), 3);
+
+  // Query near (5,0,0) must select the (5,0,0) KF.
+  auto [isFirst, dist] = list.check(xyz(4.9, 0, 0));
+  ASSERT_(!isFirst);
+  ASSERT_NEAR_(dist.translation().norm(), 0.1, 1e-5);
+}
+
+// ── 5. from_last_only mode: id-keyed APIs are no-ops ──────────────────────
 void test_from_last_only_is_noop_for_id_api()
 {
   mola::SearchablePoseList list(true /*from_last_only*/);
@@ -146,6 +164,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_legacy_insert_no_id ...\n";
     test_legacy_insert_no_id();
+
+    std::cout << "test_check_with_few_kfs ...\n";
+    test_check_with_few_kfs();
 
     std::cout << "test_from_last_only_is_noop_for_id_api ...\n";
     test_from_last_only_is_noop_for_id_api();


### PR DESCRIPTION
Add the KeyframePointCloudMap APIs needed by mola_lidar_odometry's online gravity-rebake feature:
- cloneKFPoses: snapshot of all KF poses keyed by id
- setKeyframePose: per-KF pose overwrite with cache invalidation
- lastInsertedKeyFrameID / nextFreeKeyFrameID_public: id introspection
- drainEvictedKeyFrameIDs: pull-then-clear list of KFs dropped during remove_frames_farther_than-driven evictions inside insertObservation

Also exports the MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING feature macro so downstream packages in separate repos (mola_lidar_odometry) can guard usage with __has_include + this macro and stay buildable against older mola_metric_maps checkouts.

Adds unit-test coverage for the new APIs in
test-mola_metric_maps_keyframemap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed APIs to query/manage keyframe IDs and snapshot or update keyframe poses; ability to retrieve recently inserted and evicted keyframe IDs.
  * Searchable pose list now supports optional per-pose external IDs and in-place pose updates by ID.

* **Bug Fixes**
  * Neighbor-search logic corrected to avoid incorrect matches when the list contains fewer entries; removals now preserve ID mappings.

* **Tests**
  * Expanded unit tests covering keyframe pose/ID plumbing and pose-list behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->