### PR TITLE
feat: BridgeROS2 now have configurable QoS

### DIFF
--- a/docs/source/mola_ros2_configurations.rst
+++ b/docs/source/mola_ros2_configurations.rst
@@ -140,6 +140,23 @@ A MOLA ROS 2 deployment is defined by five independent choices:
    * - ``/tf_static`` topic in bag
      - ``/tf_static``
      - ``MOLA_TF_STATIC_TOPIC`` (rosbag2 YAML ``tf_static_topic``)
+   * - LiDAR/IMU subscription QoS
+     - ``best_effort`` / depth ``50``
+     - ``lidar_qos_reliability:=`` / ``MOLA_LIDAR_QOS_RELIABILITY``,
+       ``lidar_qos_depth:=`` / ``MOLA_LIDAR_QOS_DEPTH``,
+       ``imu_qos_reliability:=`` / ``MOLA_IMU_QOS_RELIABILITY``,
+       ``imu_qos_depth:=`` / ``MOLA_IMU_QOS_DEPTH``
+
+.. note::
+
+   Subscription QoS for sensor topics defaults to REP-2003 (``best_effort``,
+   ``volatile``) with a queue depth of 50. For high-rate sensors consumed
+   together with a heavy SLAM pipeline (e.g. a 640 Hz IMU), set
+   ``imu_qos_reliability:=reliable`` and increase ``imu_qos_depth`` (e.g.
+   ``1000``) so the bridge subscription matches the publisher and can
+   absorb executor stalls. See the launch arguments documented in
+   :ref:`mola_lo_ros_node` and the per-topic ``qos:`` block accepted by
+   ``BridgeROS2``'s ``subscribe`` list.
 
 |
 

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -103,6 +103,7 @@ rclcpp::QoS buildSubscriptionQoS(const mrpt::containers::yaml& topicCfg)
   size_t      depth       = kDefaultSubscriptionDepth;
   std::string durability  = "volatile";
 
+  bool depthExplicitlySet = false;
   if (topicCfg.has("qos"))
   {
     const auto qosCfg = topicCfg["qos"];
@@ -116,7 +117,8 @@ rclcpp::QoS buildSubscriptionQoS(const mrpt::containers::yaml& topicCfg)
     }
     if (qosCfg.has("depth"))
     {
-      depth = qosCfg["depth"].as<uint64_t>();
+      depth              = qosCfg["depth"].as<uint64_t>();
+      depthExplicitlySet = true;
     }
     if (qosCfg.has("durability"))
     {
@@ -124,8 +126,24 @@ rclcpp::QoS buildSubscriptionQoS(const mrpt::containers::yaml& topicCfg)
     }
   }
 
-  rclcpp::QoS qos = (history == "keep_all") ? rclcpp::QoS(rclcpp::KeepAll())
-                                            : rclcpp::QoS(rclcpp::KeepLast(depth));
+  rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(kDefaultSubscriptionDepth));
+  if (history == "keep_all")
+  {
+    qos = rclcpp::QoS(rclcpp::KeepAll());
+  }
+  else if (history == "keep_last")
+  {
+    if (depthExplicitlySet && depth == 0)
+    {
+      THROW_EXCEPTION("Invalid qos.depth=0 with history='keep_last' (must be >0)");
+    }
+    qos = rclcpp::QoS(rclcpp::KeepLast(depth));
+  }
+  else
+  {
+    THROW_EXCEPTION_FMT(
+        "Invalid qos.history='%s' (expected 'keep_last' or 'keep_all')", history.c_str());
+  }
 
   if (reliability == "reliable")
   {
@@ -2088,8 +2106,6 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
     const auto type                = topic["msg_type"].as<std::string>();
     const auto output_sensor_label = topic["output_sensor_label"].as<std::string>();
 
-    const rclcpp::QoS qos = buildSubscriptionQoS(topic);
-
     // Skip entries with empty topic name (allows optional subscribe slots
     // controlled via env vars, e.g. ${ODOM1_TOPIC|}):
     if (topic_name.empty())
@@ -2101,6 +2117,8 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
 
     MRPT_LOG_DEBUG_STREAM(
         "Creating ros2 subscriber for topic='" << topic_name << "' (" << type << ")");
+
+    const rclcpp::QoS qos = buildSubscriptionQoS(topic);
 
     // Optional: fixed sensorPose (then ignores/don't need "tf" data):
     std::optional<mrpt::poses::CPose3D> fixedSensorPose;

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -77,6 +77,89 @@
 
 using namespace mola;
 
+namespace
+{
+// Default subscription queue depth for sensor topics. ROS 2's
+// SensorDataQoS defaults to keep_last(5), which is too shallow for
+// high-rate sensors (e.g. 640 Hz IMU) when the executor is under
+// load: the queue overflows and best-effort drops are silent.
+constexpr size_t kDefaultSubscriptionDepth = 50;
+
+// Build an rclcpp::QoS for a sensor subscription, optionally
+// overridden per-topic via a YAML `qos:` block:
+//
+//   qos:
+//     reliability: best_effort | reliable     (default: best_effort)
+//     history:     keep_last   | keep_all     (default: keep_last)
+//     depth:       <int>                      (default: 50)
+//     durability:  volatile    | transient_local (default: volatile)
+//
+// Defaults match `rclcpp::SensorDataQoS()` (REP-2003) but with a
+// deeper queue (50 instead of 5) to absorb executor stalls.
+rclcpp::QoS buildSubscriptionQoS(const mrpt::containers::yaml& topicCfg)
+{
+  std::string reliability = "best_effort";
+  std::string history     = "keep_last";
+  size_t      depth       = kDefaultSubscriptionDepth;
+  std::string durability  = "volatile";
+
+  if (topicCfg.has("qos"))
+  {
+    const auto qosCfg = topicCfg["qos"];
+    if (qosCfg.has("reliability"))
+    {
+      reliability = qosCfg["reliability"].as<std::string>();
+    }
+    if (qosCfg.has("history"))
+    {
+      history = qosCfg["history"].as<std::string>();
+    }
+    if (qosCfg.has("depth"))
+    {
+      depth = qosCfg["depth"].as<uint64_t>();
+    }
+    if (qosCfg.has("durability"))
+    {
+      durability = qosCfg["durability"].as<std::string>();
+    }
+  }
+
+  rclcpp::QoS qos = (history == "keep_all") ? rclcpp::QoS(rclcpp::KeepAll())
+                                            : rclcpp::QoS(rclcpp::KeepLast(depth));
+
+  if (reliability == "reliable")
+  {
+    qos.reliable();
+  }
+  else if (reliability == "best_effort")
+  {
+    qos.best_effort();
+  }
+  else
+  {
+    THROW_EXCEPTION_FMT(
+        "Invalid qos.reliability='%s' (expected 'reliable' or 'best_effort')", reliability.c_str());
+  }
+
+  if (durability == "transient_local")
+  {
+    qos.transient_local();
+  }
+  else if (durability == "volatile")
+  {
+    qos.durability_volatile();
+  }
+  else
+  {
+    THROW_EXCEPTION_FMT(
+        "Invalid qos.durability='%s' (expected 'volatile' or 'transient_local')",
+        durability.c_str());
+  }
+
+  return qos;
+}
+}  // namespace
+
 // arguments: class_name, parent_class, class namespace
 IMPLEMENTS_MRPT_OBJECT(BridgeROS2, RawDataSourceBase, mola)
 
@@ -1988,9 +2071,10 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
 {
   using namespace std::string_literals;
 
-  // Should be used to subscribe to sensor topics, per REP-2003:
+  // Default subscription QoS follows REP-2003 (best-effort, volatile)
+  // but with a deeper queue. Each topic entry may override it via an
+  // optional `qos:` block; see buildSubscriptionQoS().
   // https://ros.org/reps/rep-2003.html
-  const rclcpp::QoS qos = rclcpp::SensorDataQoS();
 
   for (const auto& topicItem : ds_subscribe.asSequence())
   {
@@ -2003,6 +2087,8 @@ void BridgeROS2::internalAnalyzeTopicsToSubscribe(const mrpt::containers::yaml& 
     const auto topic_name          = topic["topic"].as<std::string>();
     const auto type                = topic["msg_type"].as<std::string>();
     const auto output_sensor_label = topic["output_sensor_label"].as<std::string>();
+
+    const rclcpp::QoS qos = buildSubscriptionQoS(topic);
 
     // Skip entries with empty topic name (allows optional subscribe slots
     // controlled via env vars, e.g. ${ODOM1_TOPIC|}):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-topic QoS for sensor subscriptions, allowing independent reliability and queue-depth settings for LiDAR and IMU.
  * Subscriptions now honor per-topic QoS instead of a single global profile.
  * Invalid QoS values are reported as configuration errors to catch misconfigurations early.

* **Documentation**
  * Added guidance on defaults, launch/environment settings, and when to override QoS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->