### PR TITLE
feat: pose lists now support multiple nearby poses (Useful for non-repetitive scanners)

### DIFF
--- a/mola_pose_list/include/mola_pose_list/SearchablePoseList.h
+++ b/mola_pose_list/include/mola_pose_list/SearchablePoseList.h
@@ -53,19 +53,20 @@ class SearchablePoseList
   {
     if (from_last_only_)
     {
-      return last_kf_ == mrpt::poses::CPose3D::Identity();
+      return !has_last_kf_;
     }
 
     return kf_poses_.empty();
   }
 
-  size_t size() const { return from_last_only_ ? 1 : kf_poses_.size(); }
+  size_t size() const { return from_last_only_ ? (has_last_kf_ ? 1 : 0) : kf_poses_.size(); }
 
   void insert(const mrpt::poses::CPose3D& p)
   {
     if (from_last_only_)
     {
-      last_kf_ = p;
+      last_kf_     = p;
+      has_last_kf_ = true;
     }
     else
     {
@@ -83,7 +84,8 @@ class SearchablePoseList
   {
     if (from_last_only_)
     {
-      last_kf_ = p;
+      last_kf_     = p;
+      has_last_kf_ = true;
       return;
     }
     ASSERTMSG_(
@@ -106,11 +108,20 @@ class SearchablePoseList
   [[nodiscard]] std::tuple<bool /*isFirst*/, mrpt::poses::CPose3D /*distanceToClosest*/> check(
       const mrpt::poses::CPose3D& p) const;
 
+  /** Returns the count of stored poses that are within both the given
+   *  translation and rotation distance from \a p.
+   *  The check is: translation(p - candidate).norm() <= maxTranslation
+   *             && SO3_log(rotation(p - candidate)).norm() <= maxRotationRad
+   */
+  [[nodiscard]] uint32_t countNearby(
+      const mrpt::poses::CPose3D& p, double maxTranslation, double maxRotationRad) const;
+
   void removeAllFartherThan(const mrpt::poses::CPose3D& p, double maxTranslation);
 
  private:
   // if from_last_only_==true
-  mrpt::poses::CPose3D last_kf_ = mrpt::poses::CPose3D::Identity();
+  mrpt::poses::CPose3D last_kf_     = mrpt::poses::CPose3D::Identity();
+  bool                 has_last_kf_ = false;
 
   // if from_last_only_==false
   std::deque<mrpt::poses::CPose3D> kf_poses_;
@@ -123,6 +134,13 @@ class SearchablePoseList
   bool from_last_only_ = false;
 };
 }  // namespace mola
+
+/** Feature macro: SearchablePoseList exposes countNearby() and the
+ *  sensor-pose-as-key plumbing used by mola_lidar_odometry.
+ *  Downstream packages should guard usage with
+ *  `#if defined(MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING)`.
+ */
+#define MOLA_POSE_LIST_HAS_KFM_POSE_PLUMBING 1
 
 /** Feature macro: SearchablePoseList exposes the id-keyed API
  *  (`insert(pose, id)`, `setPoseById`) used by the online gravity-rebake

--- a/mola_pose_list/src/SearchablePoseList.cpp
+++ b/mola_pose_list/src/SearchablePoseList.cpp
@@ -79,6 +79,46 @@ std::tuple<bool /*isFirst*/, mrpt::poses::CPose3D /*distanceToClosest*/> Searcha
   return {isFirst, distanceToClosest};
 }
 
+uint32_t SearchablePoseList::countNearby(
+    const mrpt::poses::CPose3D& p, const double maxTranslation, const double maxRotationRad) const
+{
+  if (empty())
+  {
+    return 0;
+  }
+
+  if (from_last_only_)
+  {
+    if (!has_last_kf_) return 0;
+    const mrpt::poses::CPose3D diff  = p - last_kf_;
+    const double               trans = diff.translation().norm();
+    if (trans > maxTranslation)
+    {
+      return 0;
+    }
+    const double rot = mrpt::poses::Lie::SO<3>::log(diff.getRotationMatrix()).norm();
+    return (rot <= maxRotationRad) ? 1u : 0u;
+  }
+
+  ASSERT_EQUAL_(kf_poses_.size(), kf_points_.size());
+
+  uint32_t count = 0;
+  for (const auto& candidate : kf_poses_)
+  {
+    const mrpt::poses::CPose3D diff = p - candidate;
+    if (diff.translation().norm() > maxTranslation)
+    {
+      continue;
+    }
+    const double rot = mrpt::poses::Lie::SO<3>::log(diff.getRotationMatrix()).norm();
+    if (rot <= maxRotationRad)
+    {
+      ++count;
+    }
+  }
+  return count;
+}
+
 void SearchablePoseList::removeAllFartherThan(
     const mrpt::poses::CPose3D& p, const double maxTranslation)
 {

--- a/mola_pose_list/tests/test-searchable-pose-list.cpp
+++ b/mola_pose_list/tests/test-searchable-pose-list.cpp
@@ -150,6 +150,73 @@ void test_from_last_only_is_noop_for_id_api()
   ASSERT_(!isFirst);
   ASSERT_NEAR_(dist.translation().norm(), 0.0, 1e-9);
 }
+// ── 6. countNearby: basic translation-only counting ───────────────────────
+void test_count_nearby_translation()
+{
+  mola::SearchablePoseList list(false);
+
+  // KFs at x = 0, 1, 2, 3, 4 m
+  for (int i = 0; i < 5; ++i)
+  {
+    list.insert(xyz(static_cast<double>(i), 0, 0));
+  }
+
+  // Query at (2, 0, 0), threshold 1.5 m trans, large rot.
+  // Expected: x=1,2,3 are within 1.5 m => count=3
+  const uint32_t count = list.countNearby(xyz(2, 0, 0), 1.5, M_PI);
+  ASSERT_EQUAL_(count, 3u);
+
+  // Tight threshold: only the exact match
+  const uint32_t count2 = list.countNearby(xyz(2, 0, 0), 0.1, M_PI);
+  ASSERT_EQUAL_(count2, 1u);
+
+  // No matches
+  const uint32_t count3 = list.countNearby(xyz(100, 0, 0), 1.0, M_PI);
+  ASSERT_EQUAL_(count3, 0u);
+}
+
+// ── 7. countNearby: rotation threshold is applied ─────────────────────────
+void test_count_nearby_rotation()
+{
+  mola::SearchablePoseList list(false);
+
+  // Two KFs at the same translation but different yaw
+  list.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0, 0, 0));
+  list.insert(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, M_PI, 0, 0));
+
+  // Large rot threshold: both match
+  const uint32_t both = list.countNearby(
+      mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, M_PI / 2, 0, 0), 0.1, M_PI);
+  ASSERT_EQUAL_(both, 2u);
+
+  // Tight rot threshold: only the one with yaw=pi/2 should survive...
+  // but none of the stored poses is within pi/4 of pi/2; let's use yaw=0:
+  // query at yaw=0.1, threshold=0.2 rad => only stored yaw=0 is within 0.2 rad.
+  const uint32_t one =
+      list.countNearby(mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0.1, 0, 0), 0.1, 0.2);
+  ASSERT_EQUAL_(one, 1u);
+}
+
+// ── 8. countNearby: from_last_only mode ───────────────────────────────────
+void test_count_nearby_from_last_only()
+{
+  mola::SearchablePoseList list(true /*from_last_only*/);
+  list.insert(xyz(5, 0, 0));
+
+  // Within threshold
+  ASSERT_EQUAL_(list.countNearby(xyz(5.05, 0, 0), 0.1, M_PI), 1u);
+
+  // Outside threshold
+  ASSERT_EQUAL_(list.countNearby(xyz(10, 0, 0), 0.1, M_PI), 0u);
+}
+
+// ── 9. countNearby: empty list returns 0 ─────────────────────────────────
+void test_count_nearby_empty()
+{
+  mola::SearchablePoseList list(false);
+  ASSERT_EQUAL_(list.countNearby(xyz(0, 0, 0), 100.0, M_PI), 0u);
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -170,6 +237,18 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_from_last_only_is_noop_for_id_api ...\n";
     test_from_last_only_is_noop_for_id_api();
+
+    std::cout << "test_count_nearby_translation ...\n";
+    test_count_nearby_translation();
+
+    std::cout << "test_count_nearby_rotation ...\n";
+    test_count_nearby_rotation();
+
+    std::cout << "test_count_nearby_from_last_only ...\n";
+    test_count_nearby_from_last_only();
+
+    std::cout << "test_count_nearby_empty ...\n";
+    test_count_nearby_empty();
 
     std::cout << "Test successful."
               << "\n";


### PR DESCRIPTION
…scanners)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to count stored poses within specified translation and rotation bounds relative to a reference pose.

* **Bug Fixes**
  * Empty/size now correctly reflect whether a "last keyframe" pose exists when running in last-only mode (no longer treats a placeholder pose as present).

* **Tests**
  * Added unit tests covering distance/rotation thresholds, last-only behavior, and empty-list cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->