### PR TITLE
feat: Add keyframe map capable API

### DIFF
--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIB_SRCS
   src/interfaces/ExecutableBase.cpp
   src/interfaces/FilterBase.cpp
   src/interfaces/FrontEndBase.cpp
+  src/interfaces/KeyframeMapCapable.cpp
   src/interfaces/NavStateFilter.cpp
   src/interfaces/RawDataSourceBase.cpp
   src/interfaces/VizInterface.cpp
@@ -51,6 +52,7 @@ set(LIB_PUBLIC_HDRS
   include/mola_kernel/interfaces/OfflineDatasetSource.h
   include/mola_kernel/interfaces/RawDataConsumer.h
   include/mola_kernel/interfaces/RawDataSourceBase.h
+  include/mola_kernel/interfaces/KeyframeMapCapable.h
   include/mola_kernel/interfaces/Relocalization.h
   include/mola_kernel/interfaces/VizInterface.h
   include/mola_kernel/MinimalModuleContainer.h

--- a/mola_kernel/include/mola_kernel/interfaces/KeyframeMapCapable.h
+++ b/mola_kernel/include/mola_kernel/interfaces/KeyframeMapCapable.h
@@ -1,0 +1,83 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   KeyframeMapCapable.h
+ * @brief  Virtual interface for metric-map classes that hold keyframes with mutable SE(3) poses.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+#pragma once
+
+#include <mrpt/poses/CPose3D.h>
+
+#include <cstdint>
+#include <map>
+#include <optional>
+
+namespace mola
+{
+/** Mixin interface for keyframe-based metric maps that need to expose
+ *  per-KF pose plumbing to higher layers (e.g. LiDAR odometry online
+ *  gravity tilt correction).
+ *
+ *  A "keyframe map" is a metric map whose internal representation is a
+ *  finite, dynamic set of SE(3)-posed sub-clouds (keyframes), each
+ *  identified by a stable monotonic `KeyFrameID`.
+ *
+ *  All methods are required to be thread-safe with respect to the
+ *  implementing class' own internal state.
+ *
+ *  \ingroup mola_kernel_interfaces_grp
+ */
+class KeyframeMapCapable
+{
+ public:
+  using KeyFrameID = uint64_t;
+
+  KeyframeMapCapable()                                     = default;
+  KeyframeMapCapable(const KeyframeMapCapable&)            = default;
+  KeyframeMapCapable& operator=(const KeyframeMapCapable&) = default;
+  KeyframeMapCapable(KeyframeMapCapable&&)                 = default;
+  KeyframeMapCapable& operator=(KeyframeMapCapable&&)      = default;
+  virtual ~KeyframeMapCapable();
+
+  /** Returns a snapshot of all currently-active keyframe poses, keyed by
+   *  KF id. The returned map is a deep copy and is safe to hold
+   *  across subsequent map mutations.
+   */
+  [[nodiscard]] virtual std::map<KeyFrameID, mrpt::poses::CPose3D> keyframePoses() const = 0;
+
+  /** Returns the smallest currently-active KF id, or nullopt if the map
+   *  is empty. Used as the natural pivot for online tilt correction
+   *  (oldest active KF stays put).
+   */
+  [[nodiscard]] virtual std::optional<KeyFrameID> oldestActiveKeyframeID() const = 0;
+
+  /** Overwrites the pose of one keyframe. No-op if `id` is not present.
+   *  Any internal caches dependent on KF poses must be invalidated by
+   *  the implementation.
+   */
+  virtual void setKeyframePose(KeyFrameID id, const mrpt::poses::CPose3D& new_pose) = 0;
+
+  /** Applies a pivot-based rigid SE(3) transform to all currently-active KFs.
+   *
+   *  Implementations are encouraged to delegate to their existing
+   *  `transform_map_left_multiply()` after computing:
+   *    T_correct = T_pivot + delta_at_pivot + (-T_pivot)
+   *  No-op if `pivot_id` is not present in the active set.
+   */
+  virtual void applyPivotTransform(
+      KeyFrameID pivot_id, const mrpt::poses::CPose3D& delta_at_pivot) = 0;
+};
+
+}  // namespace mola

--- a/mola_kernel/src/interfaces/KeyframeMapCapable.cpp
+++ b/mola_kernel/src/interfaces/KeyframeMapCapable.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0
+// See LICENSE for full license information.
+#include <mola_kernel/interfaces/KeyframeMapCapable.h>
+
+mola::KeyframeMapCapable::~KeyframeMapCapable() = default;

--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -21,6 +21,7 @@ project(mola_metric_maps LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
+find_package(mola_kernel REQUIRED)
 find_package(mrpt-maps REQUIRED)
 find_package(mp2p_icp_map REQUIRED)
 
@@ -62,8 +63,10 @@ mola_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::maps
     tsl::robin_map
+    mola::mola_kernel
     mola::mp2p_icp_map
   CMAKE_DEPENDENCIES
+    mola_kernel
     mrpt-maps
     mp2p_icp_map
     robin_map

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <mola_kernel/interfaces/KeyframeMapCapable.h>
 #include <mp2p_icp/IcpPrepareCapable.h>
 #include <mp2p_icp/MetricMapMergeCapable.h>
 #include <mp2p_icp/NearestPointWithCovCapable.h>
@@ -51,7 +52,8 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
                               public mrpt::maps::NearestNeighborsCapable,
                               public mp2p_icp::IcpPrepareCapable,
                               public mp2p_icp::NearestPointWithCovCapable,
-                              public mp2p_icp::MetricMapMergeCapable
+                              public mp2p_icp::MetricMapMergeCapable,
+                              public mola::KeyframeMapCapable
 {
   DEFINE_SERIALIZABLE(KeyframePointCloudMap, mola)
  public:
@@ -82,7 +84,13 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
   /** Overwrites the pose of one KF in the map, invalidating its caches.
    *  No-op if `id` is not present. Thread-safe.
    */
-  void setKeyframePose(KeyFrameID id, const mrpt::poses::CPose3D& new_pose);
+  void setKeyframePose(KeyFrameID id, const mrpt::poses::CPose3D& new_pose) override;
+
+  // mola::KeyframeMapCapable overrides:
+  [[nodiscard]] std::map<KeyFrameID, mrpt::poses::CPose3D> keyframePoses() const override;
+  [[nodiscard]] std::optional<KeyFrameID>                  oldestActiveKeyframeID() const override;
+  void                                                     applyPivotTransform(
+                                                          KeyFrameID pivot_id, const mrpt::poses::CPose3D& delta_at_pivot) override;
 
   /** The id of the last key-frame successfully inserted, or nullopt if none
    *  has been inserted since the map was created/cleared.
@@ -182,6 +190,7 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
       const MetricMapMergeCapable&               source,
       const std::optional<mrpt::poses::CPose3D>& otherRelativePose = std::nullopt) override;
 
+  /** Transform all KF poses left-multiplying with this transform. Thread safe. */
   void transform_map_left_multiply(const mrpt::poses::CPose3D& b) override;
 
   /** @} */
@@ -556,14 +565,19 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
   /// consumed by this call; callers must use it as the key for the new KF
   /// and then bump `next_free_kf_id_`.
   [[nodiscard]] KeyFrameID nextFreeKeyFrameID() const { return next_free_kf_id_; }
+
+  /** Non-thread safe version of transform_map_left_multiply() */
+  void transform_map_left_multiply_impl(const mrpt::poses::CPose3D& b);
 };
 
 }  // namespace mola
 
 /** Feature macro: KeyframePointCloudMap exposes the per-KF pose plumbing
  *  (`cloneKFPoses`, `setKeyframePose`, `lastInsertedKeyFrameID`,
- *  `drainEvictedKeyFrameIDs`, `nextFreeKeyFrameID_public`) used by
- *  online gravity rebake. Downstream packages should guard usage with
+ *  `drainEvictedKeyFrameIDs`, `nextFreeKeyFrameID_public`) and inherits
+ *  from `mola::KeyframeMapCapable` (providing `keyframePoses()`,
+ *  `oldestActiveKeyframeID()`, `setKeyframePose()`, `applyPivotTransform()`).
+ *  Downstream packages should guard usage with
  *  `#if defined(MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING)` (combined with
  *  `__has_include(<mola_metric_maps/KeyframePointCloudMap.h>)`) to remain
  *  buildable against older `mola_metric_maps` checkouts.

--- a/mola_metric_maps/package.xml
+++ b/mola_metric_maps/package.xml
@@ -15,6 +15,7 @@
 
 
   <depend>mola_common</depend>
+  <depend>mola_kernel</depend>
 
   <depend>mrpt_libmaps</depend>
   <depend>mp2p_icp</depend>  <!-- actually, just the mp2p_icp_map library -->

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -567,6 +567,11 @@ void KeyframePointCloudMap::transform_map_left_multiply(const mrpt::poses::CPose
 {
   auto lck = mrpt::lockHelper(*state_mtx_);
 
+  transform_map_left_multiply_impl(b);
+}
+
+void KeyframePointCloudMap::transform_map_left_multiply_impl(const mrpt::poses::CPose3D& b)
+{
   for (auto& [id, kf] : keyframes_)
   {
     kf.pose(b + kf.pose());
@@ -1212,6 +1217,40 @@ std::vector<KeyframePointCloudMap::KeyFrameID> KeyframePointCloudMap::drainEvict
   std::vector<KeyFrameID> out;
   out.swap(evicted_kf_ids_);
   return out;
+}
+
+// mola::KeyframeMapCapable overrides:
+
+std::map<KeyframePointCloudMap::KeyFrameID, mrpt::poses::CPose3D>
+    KeyframePointCloudMap::keyframePoses() const
+{
+  return cloneKFPoses();
+}
+
+std::optional<KeyframePointCloudMap::KeyFrameID> KeyframePointCloudMap::oldestActiveKeyframeID()
+    const
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+  if (keyframes_.empty())
+  {
+    return std::nullopt;
+  }
+  return keyframes_.begin()->first;
+}
+
+void KeyframePointCloudMap::applyPivotTransform(
+    KeyFrameID pivot_id, const mrpt::poses::CPose3D& delta_at_pivot)
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+  auto it  = keyframes_.find(pivot_id);
+  if (it == keyframes_.end())
+  {
+    return;
+  }
+  const mrpt::poses::CPose3D T_pivot   = it->second.pose();
+  const mrpt::poses::CPose3D T_correct = T_pivot + delta_at_pivot + (-T_pivot);
+
+  transform_map_left_multiply_impl(T_correct);
 }
 
 bool KeyframePointCloudMap::internal_insertObservation(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public keyframe-map interface for pose queries and updates on keyframe-based metric maps.
  * Keyframe point-cloud maps now implement this interface: retrieve all active keyframe poses, get the oldest active keyframe, set individual keyframe poses, and apply pivot-based pose transforms across keyframes.

* **Chores**
  * Map package updated to expose and link the new interface publicly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->