### PR TITLE
bump min req cmake version to 3.22

### DIFF
--- a/kitti_metrics_eval/CMakeLists.txt
+++ b/kitti_metrics_eval/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(kitti_metrics_eval LANGUAGES CXX)

--- a/mola/CMakeLists.txt
+++ b/mola/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 project(mola)
 

--- a/mola_bridge_ros2/CMakeLists.txt
+++ b/mola_bridge_ros2/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_bridge_ros2 LANGUAGES CXX)

--- a/mola_demos/CMakeLists.txt
+++ b/mola_demos/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 if("$ENV{ROS_VERSION}" STREQUAL "2")
   set(DETECTED_ROS2 TRUE)

--- a/mola_input_euroc_dataset/CMakeLists.txt
+++ b/mola_input_euroc_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_euroc_dataset LANGUAGES CXX)

--- a/mola_input_kitti360_dataset/CMakeLists.txt
+++ b/mola_input_kitti360_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_kitti360_dataset LANGUAGES CXX)

--- a/mola_input_kitti_dataset/CMakeLists.txt
+++ b/mola_input_kitti_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_kitti_dataset LANGUAGES CXX)

--- a/mola_input_lidar_bin_dataset/CMakeLists.txt
+++ b/mola_input_lidar_bin_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_bin_dataset LANGUAGES CXX)

--- a/mola_input_mulran_dataset/CMakeLists.txt
+++ b/mola_input_mulran_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_mulran_dataset LANGUAGES CXX)

--- a/mola_input_paris_luco_dataset/CMakeLists.txt
+++ b/mola_input_paris_luco_dataset/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_paris_luco_dataset LANGUAGES CXX)

--- a/mola_input_rawlog/CMakeLists.txt
+++ b/mola_input_rawlog/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_rawlog LANGUAGES CXX)

--- a/mola_input_rosbag2/CMakeLists.txt
+++ b/mola_input_rosbag2/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_rosbag2 LANGUAGES CXX)

--- a/mola_input_video/CMakeLists.txt
+++ b/mola_input_video/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_input_video LANGUAGES CXX)

--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_kernel LANGUAGES CXX)

--- a/mola_launcher/CMakeLists.txt
+++ b/mola_launcher/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 if("$ENV{ROS_VERSION}" STREQUAL "2")
   set(DETECTED_ROS2 TRUE)

--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 if("$ENV{ROS_VERSION}" STREQUAL "2")
   set(DETECTED_ROS2 TRUE)

--- a/mola_msgs/CMakeLists.txt
+++ b/mola_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 project(mola_msgs)
 

--- a/mola_pose_list/CMakeLists.txt
+++ b/mola_pose_list/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_pose_list LANGUAGES CXX)

--- a/mola_relocalization/CMakeLists.txt
+++ b/mola_relocalization/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_relocalization LANGUAGES CXX)

--- a/mola_traj_tools/CMakeLists.txt
+++ b/mola_traj_tools/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_traj_tools LANGUAGES CXX)

--- a/mola_viz/CMakeLists.txt
+++ b/mola_viz/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_viz LANGUAGES CXX)

--- a/mola_yaml/CMakeLists.txt
+++ b/mola_yaml/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 # Tell CMake we'll use C++ for use in its tests/flags
 project(mola_yaml LANGUAGES CXX)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMake minimum version requirements across the project from 3.5 to 3.22...3.31 to align with modern toolchains and Ubuntu 22.04+.
  * Updated robin-map submodule pointer to a newer commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->