### PR TITLE
fix(mola_bridge_ros2): share rosNode_ with TF listener for consistent clock/use_sim_time

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -264,10 +264,12 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
       ros_clock_ = rosNode_->get_clock();
     }
 
-    // TF buffer:
-    tf_buffer_ = std::make_shared<tf2::BufferCore>();  // ros_clock_
-    // tf_buffer_->setUsingDedicatedThread(true);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+    // TF buffer + listener -- pass rosNode_ so the listener's /tf and
+    // /tf_static subscriptions share the same DDS participant, clock, and
+    // use_sim_time setting as the bridge.  spin_thread=false: rosNode_ is
+    // already spun by the loop below; a second spinner would be redundant.
+    tf_buffer_   = std::make_shared<tf2::BufferCore>();
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, rosNode_, false);
 
     // TF broadcaster:
     auto lckTfBc = mrpt::lockHelper(ros_tf_bc_mtx_);


### PR DESCRIPTION
## Summary

- Pass `rosNode_` to `tf2_ros::TransformListener` so its `/tf` and `/tf_static` subscriptions share the bridge's DDS participant, clock, and `use_sim_time` setting.
- Set `spin_thread=false` since `rosNode_` is already spun by the bridge's main 10 ms loop — a second spinner would be redundant.

## Motivation

The previous default constructor creates an **anonymous internal node** with its own DDS participant that does **not** inherit `use_sim_time`. This causes a latent inconsistency when playing bags with `ros2 bag play --clock`: the TF listener runs on wall clock while the rest of the bridge runs on sim clock, which can produce wrong or missed transform lookups.

The change is safe in all three usage scenarios:
| Scenario | Before | After |
|---|---|---|
| Live sensors | Works (extra DDS participant + thread) | Works, cleaner |
| `ros2 bag play` (no `--clock`) | Works | Works identically |
| `ros2 bag play --clock` | Latent `use_sim_time` mismatch | Correct, consistent clock |

## Test plan

- [ ] Build with `colcon build` on ROS 2 Humble/Jazzy
- [ ] Run with live LiDAR sensor and verify TF lookups succeed as before
- [ ] Run with `ros2 bag play --clock` and verify no transform errors in log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transform component initialization for better synchronization with the bridge's ROS 2 node configuration and more efficient resource utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MOLAorg/mola/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->