### PR TITLE
feat: bridge ros2 now autodetects rclpp shutdown ownership

### DIFF
--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -264,6 +264,7 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
 
   std::atomic<bool> shouldExit_{false};
   std::atomic<bool> isSpinning_{false};
+  bool              owned_rclcpp_{false};  ///< true iff this instance called rclcpp::init()
 
   /// Returns a copy of the shared_ptr to the ROS 2 node, or empty if not
   /// initialized yet.

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -200,12 +200,11 @@ BridgeROS2::~BridgeROS2()
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    if (rclcpp::ok())
+    if (owned_rclcpp_ && rclcpp::ok())
     {
       rclcpp::shutdown();
     }
 
-    rclcpp::shutdown();
     if (rosNodeThread_.joinable())
     {
       rosNodeThread_.join();
@@ -248,10 +247,13 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
     const int    argc = static_cast<int>(rosArgs.size());
     const char** argv = rosArgsC.data();
 
-    // Initialize ROS (only once):
+    // Initialize ROS only if not already initialized by the host application.
+    // Track ownership so the destructor and spin thread only call shutdown()
+    // when this instance was the one that called init().
     if (!rclcpp::ok())
     {
       rclcpp::init(argc, argv);
+      owned_rclcpp_ = true;
     }
 
     auto lckNode = mrpt::lockHelper(rosNodeMtx_);
@@ -374,7 +376,10 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
       rclcpp::spin_some(rosNode_);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    rclcpp::shutdown();
+    if (owned_rclcpp_)
+    {
+      rclcpp::shutdown();
+    }
   }
   catch (const std::exception& e)
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ROS 2 lifecycle management so the bridge no longer shuts down ROS 2 when the host application initialized it. The bridge now tracks initialization ownership and conditionally performs ROS 2 shutdown only when it performed the original initialization, preventing unintended termination of a shared ROS 2 runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->