### PR TITLE
mola-cli: support multiple YAML files, switch to CLI11

### DIFF
--- a/docs/source/concept-slam-configuration-file.rst
+++ b/docs/source/concept-slam-configuration-file.rst
@@ -36,6 +36,29 @@ Notes:
 - ``INSTANCE_NAME1``: Arbitrary name of this instance of the module. All names
   must be unique in a SLAM system.
 
+.. _yaml_multiple_files:
+
+Launching from multiple files
+================================
+
+:ref:`mola_cli` accepts more than one YAML file on the command line:
+
+.. code-block:: none
+
+  mola-cli sensors.yaml pipeline.yaml visualization.yaml
+
+Each file keeps the exact same self-contained structure described above (a
+top-level ``modules`` entry). ``mola-cli`` loads and pre-processes each file
+independently -- so ``$include{}``, ``$()`` and ``${}`` paths inside each file
+are still resolved relative to *that* file's own directory -- and then merges
+all of their ``modules`` lists into a single running system, in the order the
+files were given on the command line.
+
+This is useful to split a SLAM system definition into reusable building
+blocks (e.g. one file per sensor, plus a shared pipeline and visualization
+file). As with a single file, all module ``name``\ s must be unique across
+**all** the given files.
+
 
 .. _yaml_extensions:
 

--- a/docs/source/module-mola-launcher.rst
+++ b/docs/source/module-mola-launcher.rst
@@ -28,64 +28,73 @@ SYNOPSIS
 
     USAGE:
 
-       mola-cli  [--list-module-shared-dirs] [--list-modules]
-                 [--rtti-children-of <mp2p_icp::ICP_Base>] [--rtti-list-all]
-                 [--profiler-whole] [-p] [-v <INFO>] [-c <demo.yml>] [--]
-                 [--version] [-h]
+       mola-cli [OPTIONS] [config...]
 
 
-    Where:
+    POSITIONALS:
 
-       --list-module-shared-dirs
-         Finds all MOLA module source/shared directories, then list them. Paths
-         can be added with the environment variable MOLA_MODULES_SHARED_PATH.
+       config TEXT ...
+         Input YAML config file(s) (*.yaml). If more than one file is given,
+         all of them are loaded and their `modules` sections are merged
+         together into a single running system.
 
-       --list-modules
-         Loads all MOLA modules, then list them. It also shows the list of
-         paths in which the program looks for module dynamic libraries, then
-         exits.
+    OPTIONS:
 
-       --rtti-children-of <mp2p_icp::ICP_Base>
-         Loads all MOLA modules, then list all known classes that inherit from
-         the given one, and exits.
+       -h,  --help
+         Print this help message and exit.
 
-       --rtti-list-all
-         Loads all MOLA modules, then list all classes registered via
-         mrpt::rtti, and exits.
+       -v,  --verbosity TEXT
+         Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)
+
+       -p,  --profiler
+         Enable time profiler by default in all modules (Default: NO)
 
        --profiler-whole
          Enable whole-history time profiler in all modules (Default: NO). **DO
          NOT** use in production, only to benchmark short runs (unbounded
          memory usage)
 
-       -p,  --profiler
-         Enable time profiler by default in all modules (Default: NO)
+       --rtti-list-all
+         Loads all MOLA modules, then list all classes registered via
+         mrpt::rtti, and exits.
 
-       -v <INFO>,  --verbosity <INFO>
-         Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)
+       --rtti-children-of TEXT
+         Loads all MOLA modules, then list all known classes that inherit from
+         the given one, and exits.
 
-       -c <demo.yml>,  --config <demo.yml>
-         Input YAML config file (required) (*.yml)
+       --list-modules
+         Loads all MOLA modules, then list them. It also shows the list of
+         paths in which the program looks for module dynamic libraries, then
+         exits.
 
-       --,  --ignore_rest
-         Ignores the rest of the labeled arguments following this flag.
-
-       --version
-         Displays version information and exits.
-
-       -h,  --help
-         Displays usage information and exits.
+       --list-module-shared-dirs
+         Finds all MOLA module source/shared directories, then list them. Paths
+         can be added with the environment variable MOLA_MODULES_SHARED_PATH.
 
 
 Notes:
 
   - Finer-control of the verbosity for individual modules is possible by using the `verbosity` variable in the YAML launch file, see: :ref:`yaml_slam_cfg_file`.
+  - Each YAML file keeps the same self-contained structure described in
+    :ref:`yaml_slam_cfg_file` (a top-level ``modules`` entry). When several
+    files are given, ``mola-cli`` processes them in the order given on the
+    command line, instantiating the ``modules`` of each one into the same
+    running system. Module ``name``\ s must be unique across **all** the given
+    files.
 
 Example: Launching a SLAM system with performance details at end:
 
 .. code-block:: none
 
   mola-cli kitti_lidar_slam.yml -p
+
+
+Example: Launching a SLAM system whose sensors, pipeline, and visualization
+are defined in separate, reusable files:
+
+.. code-block:: none
+
+  mola-cli sensors.yaml pipeline.yaml visualization.yaml
 
 
 Example: To list all known ICP algorithms:
@@ -152,31 +161,27 @@ SYNOPSIS
 
     USAGE:
 
-       mola-yaml-parser  [--no-env-vars] [--no-cmd-runs] [--no-includes] [--]
-                         [--version] [-h] <YAML files>
+       mola-yaml-parser [OPTIONS] YAML_file
 
-    Where:
 
-       --no-env-vars
-         Disables solving YAML `${xxx}`s (Default: NO)
+    POSITIONALS:
 
-       --no-cmd-runs
-         Disables solving YAML `$(cmd)`s (Default: NO)
+       YAML_file TEXT REQUIRED
+         Input YAML file (required) (*.yml)
+
+    OPTIONS:
+
+       -h,  --help
+         Print this help message and exit.
 
        --no-includes
          Disables solving YAML `$include{}`s (Default: NO)
 
-       --,  --ignore_rest
-         Ignores the rest of the labeled arguments following this flag.
+       --no-cmd-runs
+         Disables solving YAML `$(cmd)`s (Default: NO)
 
-       --version
-         Displays version information and exits.
-
-       -h,  --help
-         Displays usage information and exits.
-
-       <YAML files>
-         (required)  Input YAML file (required) (*.yml)
+       --no-env-vars
+         Disables solving YAML `${xxx}`s (Default: NO)
 
 
 Example:

--- a/mola_launcher/apps/CMakeLists.txt
+++ b/mola_launcher/apps/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------------
 
 find_package(mrpt-core)
-find_package(mrpt-tclap) # tclap wrapper, useful for Windows, etc.
+find_package(CLI11 REQUIRED)
 find_package(mrpt-containers)
 
 mola_add_executable(
@@ -18,7 +18,7 @@ mola_add_executable(
     mola::mola_launcher
     mola::mola_kernel
     mrpt::core
-    mrpt::tclap
+    CLI11::CLI11
 )
 
 mola_add_executable(
@@ -34,6 +34,6 @@ mola_add_executable(
   SOURCES mola-yaml-parser.cpp
   LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::tclap
+    CLI11::CLI11
     mrpt::containers
 )

--- a/mola_launcher/apps/mola-cli.cpp
+++ b/mola_launcher/apps/mola-cli.cpp
@@ -20,74 +20,21 @@
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_launcher/MolaLauncherApp.h>
 #include <mola_yaml/yaml_helpers.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/rtti/CObject.h>
 #include <mrpt/system/filesystem.h>
 
+#include <CLI/CLI.hpp>
 #include <csignal>  // sigaction
 #include <iostream>
+#include <optional>
 #include <string>
+#include <vector>
 
 #if defined(WIN32)
 #include <windows.h>  // SetConsoleCtrlHandler
 #endif
 // TODO(jlbc): win32: add SetConsoleCtrlHandler
-
-// Declare supported cli switches ===========
-struct Cli
-{
-  TCLAP::CmdLine                        cmd{"mola-cli"};
-  TCLAP::UnlabeledValueArg<std::string> arg_yaml_cfg{
-      "config", "Input YAML config file (required) (*.yaml)", false, "", "mola-system.yaml", cmd};
-
-  TCLAP::ValueArg<std::string> arg_verbosity_level{
-      "v",    "verbosity", "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)", false, "",
-      "INFO", cmd};
-
-  TCLAP::SwitchArg arg_enable_profiler{
-      "p", "profiler", "Enable time profiler by default in all modules (Default: NO)", cmd};
-
-  TCLAP::SwitchArg arg_enable_profiler_whole{
-      "", "profiler-whole",
-      "Enable whole-history time profiler in all modules (Default: NO). **DO "
-      "NOT** use in production, only to benchmark short runs (unbounded "
-      "memory "
-      "usage)",
-      cmd};
-
-  TCLAP::SwitchArg arg_rtti_list_all{
-      "", "rtti-list-all",
-      "Loads all MOLA modules, then list all classes registered via "
-      "mrpt::rtti, "
-      "and exits.",
-      cmd};
-
-  TCLAP::ValueArg<std::string> arg_rtti_list_children{
-      "",
-      "rtti-children-of",
-      "Loads all MOLA modules, then list all known classes that inherit from "
-      "the "
-      "given one, and exits.",
-      false,
-      "",
-      "mp2p_icp::ICP_Base",
-      cmd};
-
-  TCLAP::SwitchArg arg_list_modules{
-      "", "list-modules",
-      "Loads all MOLA modules, then list them. It also shows the list of "
-      "paths "
-      "in which the program looks for module dynamic libraries, then exits.",
-      cmd};
-
-  TCLAP::SwitchArg arg_list_module_shared_dirs{
-      "", "list-module-shared-dirs",
-      "Finds all MOLA module source/shared directories, then list them. "
-      "Paths "
-      "can be added with the environment variable MOLA_MODULES_SHARED_PATH.",
-      cmd};
-};
 
 namespace
 {
@@ -114,18 +61,18 @@ void mola_install_signal_handler()
 
 // Default task for mola-cli: launching a SLAM system
 // -----------------------------------------------------
-int mola_cli_launch_slam(Cli& cli, const std::optional<std::vector<std::string>>& rosArgs)
+int mola_cli_launch_slam(
+    const std::vector<std::string>& yamlFiles, const std::string& verbosity, bool enableProfiler,
+    bool enableProfilerWhole, const std::optional<std::vector<std::string>>& rosArgs)
 {
   using namespace std::string_literals;
 
-  // Load YAML config file:
-  if (!cli.arg_yaml_cfg.isSet())
+  if (yamlFiles.empty())
   {
-    TCLAP::ArgException e("mola-system.yaml is required to launch a SLAM system.");
-    cli.cmd.getOutput()->failure(cli.cmd, e);
+    std::cerr << "Error: at least one YAML config file (*.yaml) is required "
+                 "to launch a SLAM system.\n";
     return 1;
   }
-  const auto file_yml = cli.arg_yaml_cfg.getValue();
 
   // replace a special variable for ROS args:
   mola::YAMLParseOptions po;
@@ -138,24 +85,26 @@ int mola_cli_launch_slam(Cli& cli, const std::optional<std::vector<std::string>>
     po.variables["ROS_ARGS"] = strRosArgs;
   }
 
-  // Load YAML from file:
-  auto cfg = mola::load_yaml_file(file_yml, po);
-
   mola::MolaLauncherApp app;
   theApp = &app;  // for the signal handler
 
-  if (cli.arg_verbosity_level.isSet())
+  if (!verbosity.empty())
   {
     using vl     = mrpt::typemeta::TEnumType<mrpt::system::VerbosityLevel>;
-    const auto v = vl::name2value(cli.arg_verbosity_level.getValue());
+    const auto v = vl::name2value(verbosity);
     app.setVerbosityLevel(v);
   }
 
-  app.profiler_.enable(cli.arg_enable_profiler.isSet() || cli.arg_enable_profiler_whole.isSet());
-  app.profiler_.enableKeepWholeHistory(cli.arg_enable_profiler_whole.isSet());
+  app.profiler_.enable(enableProfiler || enableProfilerWhole);
+  app.profiler_.enableKeepWholeHistory(enableProfilerWhole);
 
-  // Create SLAM system:
-  app.setup(cfg, mrpt::system::extractFileDirectory(file_yml));
+  // Load and set up each YAML config file. All `modules` sections are merged
+  // together into the same running system.
+  for (const auto& file_yml : yamlFiles)
+  {
+    auto cfg = mola::load_yaml_file(file_yml, po);
+    app.setup(cfg, mrpt::system::extractFileDirectory(file_yml));
+  }
 
   // Run it:
   app.spin();
@@ -181,14 +130,12 @@ int mola_cli_rtti_list_all()
 
 // list children of a given class:
 // -----------------------------------------------------
-int mola_cli_rtti_list_child(Cli& cli)
+int mola_cli_rtti_list_child(const std::string& parentName)
 {
   mola::MolaLauncherApp app;
   theApp = &app;  // for the signal handler
 
   app.scanAndLoadLibraries();
-
-  const auto parentName = cli.arg_rtti_list_children.getValue();
 
   std::cout << "Listing children of class: " << parentName << "\n";
 
@@ -249,10 +196,60 @@ int main(int argc, char** argv)
 {
   try
   {
-    Cli cli;
+    CLI::App cli{"mola-cli"};
+
+    std::vector<std::string> argYamlCfg;
+    cli.add_option(
+        "config", argYamlCfg,
+        "Input YAML config file(s) (*.yaml). If more than one file is "
+        "given, all of them are loaded and their `modules` sections are "
+        "merged together into a single running system.");
+
+    std::string argVerbosityLevel;
+    cli.add_option(
+        "-v,--verbosity", argVerbosityLevel,
+        "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)");
+
+    bool argEnableProfiler = false;
+    cli.add_flag(
+        "-p,--profiler", argEnableProfiler,
+        "Enable time profiler by default in all modules (Default: NO)");
+
+    bool argEnableProfilerWhole = false;
+    cli.add_flag(
+        "--profiler-whole", argEnableProfilerWhole,
+        "Enable whole-history time profiler in all modules (Default: NO). "
+        "**DO NOT** use in production, only to benchmark short runs "
+        "(unbounded memory usage)");
+
+    bool argRttiListAll = false;
+    cli.add_flag(
+        "--rtti-list-all", argRttiListAll,
+        "Loads all MOLA modules, then list all classes registered via "
+        "mrpt::rtti, and exits.");
+
+    std::string argRttiListChildren;
+    cli.add_option(
+        "--rtti-children-of", argRttiListChildren,
+        "Loads all MOLA modules, then list all known classes that inherit "
+        "from the given one, and exits.");
+
+    bool argListModules = false;
+    cli.add_flag(
+        "--list-modules", argListModules,
+        "Loads all MOLA modules, then list them. It also shows the list of "
+        "paths in which the program looks for module dynamic libraries, "
+        "then exits.");
+
+    bool argListModuleSharedDirs = false;
+    cli.add_flag(
+        "--list-module-shared-dirs", argListModuleSharedDirs,
+        "Finds all MOLA module source/shared directories, then list them. "
+        "Paths can be added with the environment variable "
+        "MOLA_MODULES_SHARED_PATH.");
 
     // Handle special ROS arguments (if mola-cli is launched as a ROS node)
-    // before handling (argc,argv) to tclap:
+    // before handling (argc,argv) to CLI11:
     std::optional<std::vector<std::string>> rosArgs;
     std::vector<std::string>                otherArgs;
     for (int i = 0; i < argc; i++)
@@ -273,25 +270,31 @@ int main(int argc, char** argv)
     const int argcBis = static_cast<int>(argvBis.size());
 
     // Parse arguments:
-    if (!cli.cmd.parse(argcBis, argvBis.data())) return 1;  // should exit.
+    try
+    {
+      cli.parse(argcBis, argvBis.data());
+    }
+    catch (const CLI::ParseError& e)
+    {
+      return cli.exit(e);
+    }
 
     mola_install_signal_handler();
 
-    // Different tasks that can be dine with mola-cli:
-    if (cli.arg_rtti_list_all.isSet())  //
+    // Different tasks that can be done with mola-cli:
+    if (argRttiListAll)  //
       return mola_cli_rtti_list_all();
 
-    if (cli.arg_rtti_list_children.isSet()) return mola_cli_rtti_list_child(cli);
+    if (!argRttiListChildren.empty()) return mola_cli_rtti_list_child(argRttiListChildren);
 
-    if (cli.arg_list_modules.isSet())  //
+    if (argListModules)  //
       return mola_cli_list_modules();
 
-    if (cli.arg_list_module_shared_dirs.isSet()) return mola_cli_list_module_shared_dirs();
+    if (argListModuleSharedDirs) return mola_cli_list_module_shared_dirs();
 
     // Default task:
-    return mola_cli_launch_slam(cli, rosArgs);
-
-    return 0;
+    return mola_cli_launch_slam(
+        argYamlCfg, argVerbosityLevel, argEnableProfiler, argEnableProfilerWhole, rosArgs);
   }
   catch (std::exception& e)
   {

--- a/mola_launcher/apps/mola-yaml-parser.cpp
+++ b/mola_launcher/apps/mola-yaml-parser.cpp
@@ -19,40 +19,49 @@
 
 #include <mola_kernel/pretty_print_exception.h>
 #include <mola_yaml/yaml_helpers.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/system/filesystem.h>
 
+#include <CLI/CLI.hpp>
 #include <iostream>
-
-// Declare supported cli switches ===========
-static TCLAP::CmdLine   cmd("mola-yaml-parser");
-static TCLAP::SwitchArg arg_no_includes(
-    "", "no-includes", "Disables solving YAML `$include{}`s (Default: NO)", cmd);
-static TCLAP::SwitchArg arg_no_cmd_runs(
-    "", "no-cmd-runs", "Disables solving YAML `$(cmd)`s (Default: NO)", cmd);
-static TCLAP::SwitchArg arg_no_env_vars(
-    "", "no-env-vars", "Disables solving YAML `${xxx}`s (Default: NO)", cmd);
-static TCLAP::UnlabeledValueArg<std::string> arg_input_files(
-    "YAML_file", "Input YAML file (required) (*.yml)", true, "params.yml", "YAML files", cmd);
+#include <string>
 
 int main(int argc, char** argv)
 {
   try
   {
-    // Parse arguments:
-    if (!cmd.parse(argc, argv)) return 1;  // should exit.
+    CLI::App cli{"mola-yaml-parser"};
 
-    const auto filName = arg_input_files.getValue();
+    bool argNoIncludes = false;
+    cli.add_flag(
+        "--no-includes", argNoIncludes, "Disables solving YAML `$include{}`s (Default: NO)");
+
+    bool argNoCmdRuns = false;
+    cli.add_flag("--no-cmd-runs", argNoCmdRuns, "Disables solving YAML `$(cmd)`s (Default: NO)");
+
+    bool argNoEnvVars = false;
+    cli.add_flag("--no-env-vars", argNoEnvVars, "Disables solving YAML `${xxx}`s (Default: NO)");
+
+    std::string argInputFile;
+    cli.add_option("YAML_file", argInputFile, "Input YAML file (required) (*.yml)")->required();
+
+    try
+    {
+      cli.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+      return cli.exit(e);
+    }
 
     // MOLA-specific parsing:
     mola::YAMLParseOptions options;
-    if (arg_no_includes.isSet()) options.doIncludes = false;
-    if (arg_no_cmd_runs.isSet()) options.doCmdRuns = false;
-    if (arg_no_env_vars.isSet()) options.doEnvVars = false;
+    if (argNoIncludes) options.doIncludes = false;
+    if (argNoCmdRuns) options.doCmdRuns = false;
+    if (argNoEnvVars) options.doEnvVars = false;
 
-    auto d = mola::load_yaml_file(filName);
+    auto d = mola::load_yaml_file(argInputFile, options);
 
     // Dump output:
     d.printAsYAML(std::cout);

--- a/mola_launcher/package.xml
+++ b/mola_launcher/package.xml
@@ -17,7 +17,7 @@
   <depend>mola_kernel</depend>
 
   <depend>mrpt_libbase</depend>
-  <depend>mrpt_libtclap</depend>
+  <depend>cli11</depend>
 
   <doc_depend>doxygen</doc_depend>
 


### PR DESCRIPTION
## Summary
- `mola-cli` now accepts one or more YAML config files as positional arguments. Each file keeps its existing self-contained `modules:` structure; all of their `modules` sections are loaded and merged into a single running system, in the order given on the command line. Relative paths (e.g. external `params:` files, `$include{}`) inside each file are still resolved relative to that file's own directory.
- Replaced the TCLAP-based CLI argument parsing in `mola-cli` and `mola-yaml-parser` with CLI11 (`libcli11-dev` / rosdep key `cli11`), removing the `mrpt_libtclap` dependency from `mola_launcher`.
- Fixed a latent bug in `mola-yaml-parser` where `--no-includes`/`--no-cmd-runs`/`--no-env-vars` options were parsed but never actually passed to `load_yaml_file`.
- Updated `docs/source/module-mola-launcher.rst` (CLI synopsis for both tools) and `docs/source/concept-slam-configuration-file.rst` (new section on launching from multiple files).

## Test plan
- [ ] `colcon build --symlink-install` (mola_launcher)
- [ ] `mola-cli --help` / `mola-yaml-parser --help` show expected CLI11 usage
- [ ] `mola-cli sensors.yaml pipeline.yaml` launches a system combining modules from both files
- [ ] `mola-cli single.yaml` still works as before
- [ ] `mola-cli --rtti-children-of mp2p_icp::ICP_Base`, `--list-modules`, `--list-module-shared-dirs` still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `mola-cli` now supports launching SLAM systems from multiple YAML configuration files supplied on the command line, with automatic merging of module definitions while enforcing unique module names.

* **Documentation**
  * Updated command-line interface documentation with revised option descriptions and examples demonstrating multi-file configuration usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->