### PR TITLE
fix(bridge_ros2): transform relocalization pose into reference frame

### DIFF
--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -309,6 +309,13 @@ class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
 
   void callbackOnRelocalizeTopic(const geometry_msgs::msg::PoseWithCovarianceStamped& o);
 
+  /// Converts an incoming relocalization pose into the localization
+  /// reference_frame, composing reference_frame <- header.frame_id via /tf when
+  /// they differ. Returns false (and leaves \a out unspecified) if the required
+  /// transform is not available.
+  bool relocalizationPoseInReferenceFrame(
+      const geometry_msgs::msg::PoseWithCovarianceStamped& o, mrpt::poses::CPose3DPDFGaussian& out);
+
   bool waitForTransform(
       mrpt::poses::CPose3D& des, const std::string& frame, const std::string& referenceFrame);
 

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1450,9 +1450,15 @@ void BridgeROS2::service_relocalize_near_pose(
     return;
   }
 
+  mrpt::poses::CPose3DPDFGaussian p;
+  if (!relocalizationPoseInReferenceFrame(request->pose, p))
+  {
+    response->accepted = false;
+    return;
+  }
+
   for (const auto& m : molaSubs_.relocalization)
   {
-    const mrpt::poses::CPose3DPDFGaussian p = mrpt::ros2bridge::fromROS(request->pose.pose);
     m->relocalize_near_pose_pdf(p);
   }
 
@@ -1463,11 +1469,43 @@ void BridgeROS2::callbackOnRelocalizeTopic(const geometry_msgs::msg::PoseWithCov
 {
   auto lck = mrpt::lockHelper(rosPubsMtx_);
 
+  mrpt::poses::CPose3DPDFGaussian p;
+  if (!relocalizationPoseInReferenceFrame(o, p))
+  {
+    MRPT_LOG_THROTTLE_ERROR_FMT(
+        5.0, "Ignoring relocalization request: no /tf transform '%s' -> '%s'.",
+        o.header.frame_id.c_str(), params_.reference_frame.c_str());
+    return;
+  }
+
   for (const auto& m : molaSubs_.relocalization)
   {
-    const mrpt::poses::CPose3DPDFGaussian p = mrpt::ros2bridge::fromROS(o.pose);
     m->relocalize_near_pose_pdf(p);
   }
+}
+
+bool BridgeROS2::relocalizationPoseInReferenceFrame(
+    const geometry_msgs::msg::PoseWithCovarianceStamped& o, mrpt::poses::CPose3DPDFGaussian& out)
+{
+  out = mrpt::ros2bridge::fromROS(o.pose);
+
+  // The pose may arrive in any tf frame (e.g. RViz publishes the "2D Pose
+  // Estimate" in its fixed frame), but MOLA relocalization interprets it in the
+  // localization reference_frame. Compose reference_frame <- header.frame_id so
+  // the request is not silently misread when the two frames differ.
+  if (o.header.frame_id.empty() || o.header.frame_id == params_.reference_frame)
+  {
+    return true;
+  }
+
+  mrpt::poses::CPose3D reference_T_msg;
+  if (!waitForTransform(reference_T_msg, o.header.frame_id, params_.reference_frame))
+  {
+    return false;
+  }
+
+  out.changeCoordinatesReference(reference_T_msg);
+  return true;
 }
 
 void BridgeROS2::service_map_load(


### PR DESCRIPTION
## Summary

- The relocalization topic callback and the `relocalize_near_pose` service passed the incoming `PoseWithCovarianceStamped` straight to `relocalize_near_pose_pdf()`, ignoring its `header.frame_id`. The pose was always interpreted in the localization `reference_frame`, so publishing it in a different frame (e.g. RViz's "2D Pose Estimate" in its fixed frame) relocalized to the wrong place.
- Now the pose is transformed into `reference_frame` via the tf buffer before relocalizing, with the covariance rotated accordingly. When the frame already matches (or is empty), the pose is used as-is, so existing callers are unaffected.
- If the required transform isn't available, the request is rejected (service) or ignored (topic) instead of silently relocalizing to a wrong pose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced relocalization pose validation and coordinate frame transformation. The bridge now automatically converts incoming relocalization poses to the configured reference frame using available transforms, and properly rejects requests when required frame transformations cannot be resolved.
  * Improved error handling in relocalization message processing with throttled logging when pose frame conversions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->