### PR TITLE
Fix view-direction vector frame mismatch in KeyframePointCloudMap

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -387,6 +387,16 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      *
      *  Setting this to `false`, or to a threshold ≥ 180°, effectively disables
      *  the filter even when view fields are present.
+     *
+     *  Contract: the "view_x/y/z" fields stored in a keyframe's point cloud
+     *  (`KeyFrame::pointcloud_`) MUST be expressed in the *local KF frame*,
+     *  not in the global/map frame. `KeyFrame::updatePointsGlobal()` rotates
+     *  them to the global frame using `mp2p_icp::rotateViewDirectionFields()`
+     *  (see `mp2p_icp/pointcloud_field_utils.h`). Any code that inserts
+     *  points carrying these fields into a keyframe (e.g.
+     *  `mp2p_icp_filters::FilterMerge`) must call the same helper to rotate
+     *  the fields alongside the point coordinates, or this filter will
+     *  silently compare vectors expressed in inconsistent frames.
      */
     bool use_view_direction_filter = true;
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -18,7 +18,10 @@
  */
 
 #include <mola_metric_maps/KeyframePointCloudMap.h>
+#if __has_include(<mp2p_icp/pointcloud_field_utils.h>)
 #include <mp2p_icp/pointcloud_field_utils.h>
+#define MOLA_MM_HAS_ROTATE_VIEW_HEADER 1
+#endif
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/core/get_env.h>
 #include <mrpt/maps/CGenericPointsMap.h>
@@ -44,6 +47,29 @@
 #endif
 
 #include <type_traits>
+
+#if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
+namespace
+{
+// SFINAE detection of mp2p_icp::rotateViewDirectionFields(): the function
+// was added to an already-existing header (pointcloud_field_utils.h), so
+// __has_include() alone cannot tell an old mp2p_icp_map checkout (header
+// present, function absent) apart from a new one. This trait probes the
+// declaration itself, purely in C++, with no CMake-side version check needed.
+template <typename, typename = void>
+struct mp2p_icp_has_rotate_view_fields : std::false_type
+{
+};
+
+template <typename T>
+struct mp2p_icp_has_rotate_view_fields<
+    T, std::void_t<decltype(mp2p_icp::rotateViewDirectionFields(
+           std::declval<mrpt::maps::CPointsMap&>(), std::declval<const mrpt::poses::CPose3D&>()))>>
+    : std::true_type
+{
+};
+}  // namespace
+#endif
 
 const thread_local auto ENV_DO_PROFILE_COV =
     mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_PROFILE_COV", false);
@@ -1488,7 +1514,44 @@ void KeyframePointCloudMap::KeyFrame::updatePointsGlobal() const
   // so it copies local-frame values as-is.  Rotate them to the global frame now.
   if (has_view)
   {
-    mp2p_icp::rotateViewDirectionFields(*pointcloud_global_, pose_);
+#if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
+    if constexpr (mp2p_icp_has_rotate_view_fields<void>::value)
+    {
+      mp2p_icp::rotateViewDirectionFields(*pointcloud_global_, pose_);
+    }
+    else
+#endif
+    {
+      // MRPT_TODO: this is a legacy fallback for mp2p_icp_map checkouts
+      // older than the one introducing mp2p_icp::rotateViewDirectionFields()
+      // (see MOLAorg/mp2p_icp#70), detected purely in C++ via the
+      // mp2p_icp_has_rotate_view_fields SFINAE trait above. Once the minimum
+      // required mp2p_icp_map version provides the helper, delete this
+      // branch, the #if/else above, and the trait itself.
+      auto* vx = pointcloud_global_->getPointsBufferRef_float_field("view_x");
+      auto* vy = pointcloud_global_->getPointsBufferRef_float_field("view_y");
+      auto* vz = pointcloud_global_->getPointsBufferRef_float_field("view_z");
+
+      if (vx == nullptr || vy == nullptr || vz == nullptr)
+      {
+        // One or more view fields are missing in the destination map even
+        // though the source had all three.
+        // TODO: log a warning here once a logger is available.
+      }
+      else
+      {
+        const size_t n = pointcloud_global_->size();
+
+        // TODO: Write an AVX2 version of this rotation loop.
+        for (size_t i = 0; i < n; ++i)
+        {
+          const auto vg = pose_.rotateVector({(*vx)[i], (*vy)[i], (*vz)[i]}).cast<float>();
+          (*vx)[i]      = vg.x;
+          (*vy)[i]      = vg.y;
+          (*vz)[i]      = vg.z;
+        }
+      }
+    }
   }
 }
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <mola_metric_maps/KeyframePointCloudMap.h>
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/core/get_env.h>
 #include <mrpt/maps/CGenericPointsMap.h>
@@ -1487,29 +1488,7 @@ void KeyframePointCloudMap::KeyFrame::updatePointsGlobal() const
   // so it copies local-frame values as-is.  Rotate them to the global frame now.
   if (has_view)
   {
-    auto* vx = pointcloud_global_->getPointsBufferRef_float_field("view_x");
-    auto* vy = pointcloud_global_->getPointsBufferRef_float_field("view_y");
-    auto* vz = pointcloud_global_->getPointsBufferRef_float_field("view_z");
-
-    if (vx == nullptr || vy == nullptr || vz == nullptr)
-    {
-      // One or more view fields are missing in the destination map even
-      // though the source had all three.
-      // TODO: log a warning here once a logger is available.
-    }
-    else
-    {
-      const size_t n = pointcloud_global_->size();
-
-      // TODO: Write an AVX2 version of this rotation loop.
-      for (size_t i = 0; i < n; ++i)
-      {
-        const auto vg = pose_.rotateVector({(*vx)[i], (*vy)[i], (*vz)[i]}).cast<float>();
-        (*vx)[i]      = vg.x;
-        (*vy)[i]      = vg.y;
-        (*vz)[i]      = vg.z;
-      }
-    }
+    mp2p_icp::rotateViewDirectionFields(*pointcloud_global_, pose_);
   }
 }
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -49,27 +49,104 @@
 #include <type_traits>
 
 #if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
-namespace
-{
-// SFINAE detection of mp2p_icp::rotateViewDirectionFields(): the function
+// Feature detection for mp2p_icp::rotateViewDirectionFields(): the function
 // was added to an already-existing header (pointcloud_field_utils.h), so
 // __has_include() alone cannot tell an old mp2p_icp_map checkout (header
-// present, function absent) apart from a new one. This trait probes the
-// declaration itself, purely in C++, with no CMake-side version check needed.
-template <typename, typename = void>
-struct mp2p_icp_has_rotate_view_fields : std::false_type
+// present, function absent) apart from a new one.
+//
+// A plain decltype/void_t probe on the *qualified* name doesn't work: looking
+// up a name that simply does not exist in a fixed, non-dependent namespace is
+// a hard compile error, not a SFINAE-friendly substitution failure (confirmed
+// against mp2p_icp 2.9.0, which lacks the function). A using-directive-based
+// "ADL barrier" doesn't work either: a using-directive only injects the used
+// namespace's members at the *nearest common ancestor* of the directive's
+// own namespace and the used one (here, the global namespace, since
+// mp2p_icp and any namespace we declare are unrelated siblings) -- so a
+// fallback declared in our own namespace is found first and always wins,
+// regardless of whether the real overload exists.
+//
+// What does work: reopening mp2p_icp itself to add a low-priority ellipsis
+// fallback as a genuine member of that same namespace. Now both candidates
+// (real declaration, if any, and our fallback) live in the exact same
+// namespace, so ordinary overload resolution picks the real one whenever
+// it exists (exact match beats the ellipsis conversion), and falls back
+// to ours otherwise -- with no lookup error in either case.
+namespace mp2p_icp
+{
+struct rotate_view_fields_unavailable_tag
 {
 };
+[[maybe_unused]] rotate_view_fields_unavailable_tag rotateViewDirectionFields(...);
+}  // namespace mp2p_icp
 
-template <typename T>
-struct mp2p_icp_has_rotate_view_fields<
-    T, std::void_t<decltype(mp2p_icp::rotateViewDirectionFields(
-           std::declval<mrpt::maps::CPointsMap&>(), std::declval<const mrpt::poses::CPose3D&>()))>>
-    : std::true_type
+namespace
 {
-};
+template <typename Pts, typename Pose>
+constexpr bool mp2p_icp_has_rotate_view_fields()
+{
+  return !std::is_same_v<
+      decltype(mp2p_icp::rotateViewDirectionFields(
+          std::declval<Pts&>(), std::declval<const Pose&>())),
+      mp2p_icp::rotate_view_fields_unavailable_tag>;
+}
 }  // namespace
 #endif
+
+namespace
+{
+// MRPT_TODO: this is the pre-fix, open-coded rotation loop, kept only as a
+// fallback for mp2p_icp_map checkouts older than the one introducing
+// mp2p_icp::rotateViewDirectionFields() (see MOLAorg/mp2p_icp#70). Delete
+// this function (and its call sites below) once the minimum required
+// mp2p_icp_map version provides the helper.
+[[maybe_unused]] void rotateViewDirectionFieldsLegacy(
+    mrpt::maps::CPointsMap& pts, const mrpt::poses::CPose3D& tf)
+{
+  auto* vx = pts.getPointsBufferRef_float_field("view_x");
+  auto* vy = pts.getPointsBufferRef_float_field("view_y");
+  auto* vz = pts.getPointsBufferRef_float_field("view_z");
+
+  if (vx == nullptr || vy == nullptr || vz == nullptr)
+  {
+    // One or more view fields are missing in the destination map even
+    // though the source had all three.
+    // TODO: log a warning here once a logger is available.
+    return;
+  }
+
+  const size_t n = pts.size();
+
+  // TODO: Write an AVX2 version of this rotation loop.
+  for (size_t i = 0; i < n; ++i)
+  {
+    const auto vg = tf.rotateVector({(*vx)[i], (*vy)[i], (*vz)[i]}).cast<float>();
+    (*vx)[i]      = vg.x;
+    (*vy)[i]      = vg.y;
+    (*vz)[i]      = vg.z;
+  }
+}
+
+#if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
+template <typename Pts, typename Pose>
+void rotateViewDirectionFieldsOrFallback(Pts& pts, const Pose& tf)
+{
+  // This dispatch must live in a template so that if constexpr genuinely
+  // discards (without type-checking) the untaken branch: outside of a
+  // template, both branches of "if constexpr" are still fully compiled,
+  // which would try to actually call the ellipsis fallback declared above
+  // when the real helper is absent -- an ill-formed call, since it'd
+  // require copying a non-copyable mrpt::maps::CPointsMap.
+  if constexpr (mp2p_icp_has_rotate_view_fields<Pts, Pose>())
+  {
+    mp2p_icp::rotateViewDirectionFields(pts, tf);
+  }
+  else
+  {
+    rotateViewDirectionFieldsLegacy(pts, tf);
+  }
+}
+#endif
+}  // namespace
 
 const thread_local auto ENV_DO_PROFILE_COV =
     mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_PROFILE_COV", false);
@@ -1515,43 +1592,10 @@ void KeyframePointCloudMap::KeyFrame::updatePointsGlobal() const
   if (has_view)
   {
 #if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
-    if constexpr (mp2p_icp_has_rotate_view_fields<void>::value)
-    {
-      mp2p_icp::rotateViewDirectionFields(*pointcloud_global_, pose_);
-    }
-    else
+    rotateViewDirectionFieldsOrFallback(*pointcloud_global_, pose_);
+#else
+    rotateViewDirectionFieldsLegacy(*pointcloud_global_, pose_);
 #endif
-    {
-      // MRPT_TODO: this is a legacy fallback for mp2p_icp_map checkouts
-      // older than the one introducing mp2p_icp::rotateViewDirectionFields()
-      // (see MOLAorg/mp2p_icp#70), detected purely in C++ via the
-      // mp2p_icp_has_rotate_view_fields SFINAE trait above. Once the minimum
-      // required mp2p_icp_map version provides the helper, delete this
-      // branch, the #if/else above, and the trait itself.
-      auto* vx = pointcloud_global_->getPointsBufferRef_float_field("view_x");
-      auto* vy = pointcloud_global_->getPointsBufferRef_float_field("view_y");
-      auto* vz = pointcloud_global_->getPointsBufferRef_float_field("view_z");
-
-      if (vx == nullptr || vy == nullptr || vz == nullptr)
-      {
-        // One or more view fields are missing in the destination map even
-        // though the source had all three.
-        // TODO: log a warning here once a logger is available.
-      }
-      else
-      {
-        const size_t n = pointcloud_global_->size();
-
-        // TODO: Write an AVX2 version of this rotation loop.
-        for (size_t i = 0; i < n; ++i)
-        {
-          const auto vg = pose_.rotateVector({(*vx)[i], (*vy)[i], (*vz)[i]}).cast<float>();
-          (*vx)[i]      = vg.x;
-          (*vy)[i]      = vg.y;
-          (*vz)[i]      = vg.z;
-        }
-      }
-    }
   }
 }
 

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -628,7 +628,64 @@ void test_view_filter_with_rotated_local_frame()
   }
 }
 
-// ── 17. Per-KF pose plumbing for online gravity rebake ────────────────────
+// ── 17. View filter pairing must be accepted regardless of KF heading ─────
+//
+// Regression test for the FilterMerge double-rotation bug: a keyframe's
+// view_{x,y,z} fields must be expressed in the *local KF frame* regardless
+// of the keyframe's absolute heading (see the contract documented at
+// `TCreationOptions::use_view_direction_filter`). If view vectors were
+// rotated twice (once by the inserter, once by `updatePointsGlobal()`), the
+// effective residual rotation error would grow with the keyframe heading,
+// eventually flipping an aligned-view pair into a "rejected" one. Sweeping
+// heading in {0, 90, 180, 270} deg must accept the very same Q->P pair at
+// every heading, since the underlying geometry (Q and P seen from the same
+// direction) does not change with heading.
+void test_view_filter_heading_sweep_pairing_accepted()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+
+  // Global reference: background grid at z=0 + P with view=(0,+1,0).
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f);  // bg: view=(0,0,+1)
+  appendPt(global_pts, 50.f, 0.f, 0.f, 0.f, +1.f, 0.f);  // P: view=(0,+1,0)
+
+  auto global_m = makeMapFromCloud(makeCloudWithViews(global_pts));
+  global_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+  global_m.creationOptions.use_view_direction_filter = true;
+  global_m.creationOptions.max_view_angle_deg        = 60.0;  // tight
+
+  for (const double heading_deg : {0.0, 90.0, 180.0, 270.0})
+  {
+    const auto kfPose = mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+        0.0, 0.0, 0.0, mrpt::DEG2RAD(heading_deg), 0.0, 0.0);
+
+    // Q sits near P=(50,0,0) in the global frame, regardless of heading.
+    // Express both its position and its view vector (which globally must
+    // match P's view (0,+1,0)) in the LOCAL KF frame.
+    const mrpt::math::TPoint3D  Q_global_pt{50.0, 0.0, kDz};
+    const mrpt::math::TPoint3D  Q_local_pt = kfPose.inverseComposePoint(Q_global_pt);
+    const mrpt::math::TVector3D localView  = kfPose.inverseRotateVector({0.0, 1.0, 0.0});
+
+    auto local_pts = makeGridPts(kDz, 0.f, 0.f, 1.f);  // bg, local view=(0,0,+1)
+    appendPt(
+        local_pts, static_cast<float>(Q_local_pt.x), static_cast<float>(Q_local_pt.y),
+        static_cast<float>(Q_local_pt.z), static_cast<float>(localView.x),
+        static_cast<float>(localView.y), static_cast<float>(localView.z));
+
+    auto local_m = makeMapFromCloud(makeCloudWithViews(local_pts), kfPose);
+
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, kfPose, kMaxDist, pairings);
+
+    const mrpt::math::TPoint3Df Q_local{
+        static_cast<float>(Q_local_pt.x), static_cast<float>(Q_local_pt.y),
+        static_cast<float>(Q_local_pt.z)};
+    const mrpt::math::TPoint3Df P_global{50.f, 0.f, 0.f};
+    ASSERT_(hasPairing(pairings, Q_local, P_global));
+  }
+}
+
+// ── 19. Per-KF pose plumbing for online gravity rebake ────────────────────
 //
 // Covers the additions used by mola_lidar_odometry's TrajectoryRebaker:
 //   - cloneKFPoses
@@ -731,7 +788,7 @@ void test_kf_pose_plumbing()
   ASSERT_EQUAL_(m.nextFreeKeyFrameID_public(), KFID{0});
 }
 
-// ── 18. Default filter parameters are sane ────────────────────────────────
+// ── 20. Default filter parameters are sane ────────────────────────────────
 void test_default_creation_options()
 {
   mola::KeyframePointCloudMap m;
@@ -793,6 +850,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_view_filter_with_rotated_local_frame ...\n";
     test_view_filter_with_rotated_local_frame();
+
+    std::cout << "test_view_filter_heading_sweep_pairing_accepted ...\n";
+    test_view_filter_heading_sweep_pairing_accepted();
 
     std::cout << "test_kf_pose_plumbing ...\n";
     test_kf_pose_plumbing();


### PR DESCRIPTION
## Summary
- `KeyFrame::updatePointsGlobal()` rotates `view_x/y/z` vectors assuming they are stored in the local KF frame, but `mp2p_icp_filters::FilterMerge` was leaving them in the global frame when inserting into a `KeyframePointCloudMap` (companion fix in MOLAorg/mp2p_icp#70). The resulting double rotation made the cov-to-cov view-angle pairing filter reject valid pairs as the keyframe heading diverged from the map's build-time reference (worst case near 180 deg), collapsing ICP localization quality near that heading.
- Replaces the open-coded rotation loop with the shared `mp2p_icp::rotateViewDirectionFields()` helper, and documents the local-KF-frame contract directly above `TCreationOptions::use_view_direction_filter`.

Depends on MOLAorg/mp2p_icp#70 (adds the shared helper).

## Test plan
- [x] New `test_view_filter_heading_sweep_pairing_accepted()` in `mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp`: sweeps keyframe heading {0,90,180,270} deg and asserts an aligned-view pairing is accepted at every heading (this is the exact regression signal from the bug report).
- [x] Full `mola_metric_maps` ctest suite passes (12/12).

https://claude.ai/code/session_019eSQrx7sEpMHn3F6DfyVmj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that point-cloud `view_x/view_y/view_z` direction values must be stored in each keyframe’s local frame; consistent local-to-global rotation is required for correct view-direction filtering.

* **Refactor**
  * Improved rotation of point-cloud view-direction fields during global updates by using a shared rotation utility when available, with automatic fallback to the existing per-point rotation behavior.

* **Tests**
  * Added a regression test ensuring the view-direction pairing filter consistently accepts matching local-to-global pairings across keyframe headings (0°, 90°, 180°, 270°).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->