### PR TITLE
feat: viz with movable frames

### DIFF
--- a/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
+++ b/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
@@ -30,6 +30,7 @@
 #include <mrpt/containers/yaml_frwd.h>
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/math/TPoint3D.h>
+#include <mrpt/math/TPose3D.h>
 #include <mrpt/opengl/opengl_frwds.h>
 #include <mrpt/rtti/CObject.h>
 
@@ -44,6 +45,13 @@
 namespace nanogui { class Window; }
 // clang-format on
 // ---------------------------------------------------------------------------
+
+/** Feature macro: when defined, VizInterface offers update_3d_object_frame()
+ *  and the `parentFrame` argument of update_3d_object(), i.e. named movable
+ *  reference-frame nodes that child objects can be attached to.  Lets
+ *  out-of-repo modules (e.g. an older mola_lidar_odometry checkout) detect the
+ *  feature at compile time. */
+#define MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES 1
 
 namespace mola
 {
@@ -208,10 +216,43 @@ class VizInterface
    * \param obj            Object to display.
    * \param viewportName   Viewport inside the parent window.
    * \param parentWindow   Host window name.
+   * \param parentFrame    Optional name of a movable reference-frame node
+   *                       previously created via update_3d_object_frame().
+   *                       When non-empty, the object is attached as a child of
+   *                       that frame (so moving the frame moves the object
+   *                       without re-rendering it); the frame node is
+   *                       auto-created at the identity pose if it does not
+   *                       exist yet.  Empty (default) attaches to the viewport
+   *                       root, as before.
    * \return               future<bool>; resolves to true when executed.
    */
   virtual std::future<bool> update_3d_object(
       const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+      const std::string& viewportName = "main", const std::string& parentWindow = "main",
+      const std::string& parentFrame = "") = 0;
+
+  /**
+   * \brief Creates or repositions a named movable "reference frame" node.
+   *
+   * A frame node is an (initially empty) container placed at the viewport
+   * root.  Objects can be attached to it via the `parentFrame` argument of
+   * update_3d_object(); moving the frame then relocates all attached objects
+   * at once, without re-uploading their geometry.  This is how a back end such
+   * as mola_mapper_3d keeps a front end's dense clouds / local map (drawn once
+   * in its own `{odom_i}` frame) correctly placed in `{map}` as it estimates
+   * the `T_map_to_odom_i` transform online.
+   *
+   * Idempotent: the first call creates the node; later calls only update its
+   * pose, preserving any already-attached children.
+   *
+   * \param frameName    Name of the frame node (upsert key). Must be non-empty.
+   * \param pose         Pose of the frame in the viewport (i.e. in `{map}`).
+   * \param viewportName Viewport inside the parent window.
+   * \param parentWindow Host window name.
+   * \return             future<bool>; resolves to true when executed.
+   */
+  virtual std::future<bool> update_3d_object_frame(
+      const std::string& frameName, const mrpt::math::TPose3D& pose,
       const std::string& viewportName = "main", const std::string& parentWindow = "main") = 0;
 
   /**

--- a/mola_viz/include/mola_viz/MolaViz.h
+++ b/mola_viz/include/mola_viz/MolaViz.h
@@ -112,6 +112,12 @@ class MolaViz : public ExecutableBase, public VizInterface
   std::future<bool> update_3d_object(
       const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
+
+  std::future<bool> update_3d_object_frame(
+      const std::string& frameName, const mrpt::math::TPose3D& pose,
+      const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> insert_point_cloud_with_decay(
@@ -269,6 +275,11 @@ class MolaViz : public ExecutableBase, public VizInterface
   std::map<window_name_t, std::map<subwindow_name_t, nanogui::Window*>> subWindows_;
 
   mrpt::gui::CDisplayWindowGUI::Ptr create_and_add_window(const window_name_t& name);
+
+  /** Get-or-create a movable reference-frame node (a named CSetOfObjects at
+   *  the viewport root). GUI-thread only. \sa update_3d_object_frame() */
+  static std::shared_ptr<mrpt::opengl::CSetOfObjects> get_or_create_frame_node_(
+      mrpt::opengl::Scene& scene, const std::string& frameName, const std::string& viewportName);
 
   mutable std::shared_mutex subWindowsMtx_;
 

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -1698,12 +1698,13 @@ std::future<bool> MolaViz::subwindow_update_visualization(
 
 std::future<bool> MolaViz::update_3d_object(
     const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
-    const std::string& viewportName, const std::string& parentWindow)
+    const std::string& viewportName, const std::string& parentWindow,
+    const std::string& parentFrame)
 {
   using return_type = bool;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
-      [this, objName, obj, viewportName, parentWindow]()
+      [this, objName, obj, viewportName, parentWindow, parentFrame]()
       {
         MRPT_LOG_DEBUG_STREAM("update_3d_object() objName='" << objName << "'");
 
@@ -1713,19 +1714,104 @@ std::future<bool> MolaViz::update_3d_object(
         ASSERT_(topWin->background_scene);
 
         mrpt::opengl::CSetOfObjects::Ptr glContainer;
-        if (auto o = topWin->background_scene->getByName(objName, viewportName); o)
+        auto&                            scene = *topWin->background_scene;
+        if (parentFrame.empty())
         {
-          glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
-          ASSERT_(glContainer);
+          // Non-recursive search: only direct children of the viewport root,
+          // so objects nested inside frame nodes are not falsely matched.
+          if (auto vp = scene.getViewport(viewportName); vp)
+          {
+            for (const auto& o : *vp)
+            {
+              if (o->getName() == objName)
+              {
+                glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+                break;
+              }
+            }
+          }
+          if (!glContainer)
+          {
+            // Not at root. Evict from any frame node it may live in, then
+            // create a fresh container at the viewport root.
+            if (auto o = scene.getByName(objName, viewportName); o)
+            {
+              scene.removeObject(o, viewportName);
+            }
+            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            scene.insert(glContainer, viewportName);
+          }
         }
         else
         {
-          glContainer = mrpt::opengl::CSetOfObjects::Create();
-          topWin->background_scene->insert(glContainer, viewportName);
+          // Attach as a child of the named movable frame node, auto-creating
+          // the frame at the identity pose if it does not exist yet:
+          auto frameNode = get_or_create_frame_node_(scene, parentFrame, viewportName);
+          if (auto o = frameNode->getByName(objName); o)
+          {
+            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+          }
+          if (!glContainer)
+          {
+            // Not in this frame. Evict from root or another frame before
+            // inserting here (removeObject searches recursively).
+            if (auto o = scene.getByName(objName, viewportName); o)
+            {
+              scene.removeObject(o, viewportName);
+            }
+            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            frameNode->insert(glContainer);
+          }
         }
 
         *glContainer = *obj;
         glContainer->setName(objName);
+        return true;
+      });
+
+  auto lck = mrpt::lockHelper(guiThreadPendingTasksMtx_);
+  guiThreadPendingTasks_.emplace_back([=]() { (*task)(); });
+  guiThreadMustReLayoutTheseWindows_.insert(parentWindow);
+  return task->get_future();
+}
+
+mrpt::opengl::CSetOfObjects::Ptr MolaViz::get_or_create_frame_node_(
+    mrpt::opengl::Scene& scene, const std::string& frameName, const std::string& viewportName)
+{
+  // Called from the GUI thread only.
+  mrpt::opengl::CSetOfObjects::Ptr frameNode;
+  if (auto o = scene.getByName(frameName, viewportName); o)
+  {
+    frameNode = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+    ASSERT_(frameNode);
+  }
+  else
+  {
+    frameNode = mrpt::opengl::CSetOfObjects::Create();
+    frameNode->setName(frameName);
+    scene.insert(frameNode, viewportName);
+  }
+  return frameNode;
+}
+
+std::future<bool> MolaViz::update_3d_object_frame(
+    const std::string& frameName, const mrpt::math::TPose3D& pose, const std::string& viewportName,
+    const std::string& parentWindow)
+{
+  using return_type = bool;
+
+  auto task = std::make_shared<std::packaged_task<return_type()>>(
+      [this, frameName, pose, viewportName, parentWindow]()
+      {
+        ASSERT_(!frameName.empty());
+        ASSERT_(windows_.count(parentWindow));
+        auto topWin = windows_.at(parentWindow).win;
+        ASSERT_(topWin);
+        ASSERT_(topWin->background_scene);
+
+        auto frameNode =
+            get_or_create_frame_node_(*topWin->background_scene, frameName, viewportName);
+        frameNode->setPose(pose);
         return true;
       });
 

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -146,9 +146,18 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   std::future<bool> update_3d_object(
       const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override
+  {
+    return core_ptr_->update_3d_object(objName, obj, viewportName, parentWindow, parentFrame);
+  }
+
+  std::future<bool> update_3d_object_frame(
+      const std::string& frameName, const mrpt::math::TPose3D& pose,
+      const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override
   {
-    return core_ptr_->update_3d_object(objName, obj, viewportName, parentWindow);
+    return core_ptr_->update_3d_object_frame(frameName, pose, viewportName, parentWindow);
   }
 
   std::future<bool> insert_point_cloud_with_decay(

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -199,6 +199,12 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   std::future<bool> update_3d_object(
       const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
+
+  std::future<bool> update_3d_object_frame(
+      const std::string& frameName, const mrpt::math::TPose3D& pose,
+      const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> insert_point_cloud_with_decay(

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -626,12 +626,34 @@ std::future<std::optional<std::string>> MolaVizImGuiCore::open_file_dialog(
 // VizInterface: 3-D scene API
 // ---------------------------------------------------------------------------
 
+namespace
+{
+/** Get-or-create a movable reference-frame node (a named CSetOfObjects at the
+ *  viewport root). Caller must already hold the scene mutex. */
+mrpt::opengl::CSetOfObjects::Ptr getOrCreateFrameNode(
+    mrpt::opengl::COpenGLScene& scene, const std::string& frameName,
+    const std::string& viewportName)
+{
+  mrpt::opengl::CSetOfObjects::Ptr frameNode;
+  if (auto o = scene.getByName(frameName, viewportName); o)
+    frameNode = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+  if (!frameNode)
+  {
+    frameNode = mrpt::opengl::CSetOfObjects::Create();
+    frameNode->setName(frameName);
+    scene.insert(frameNode, viewportName);
+  }
+  return frameNode;
+}
+}  // namespace
+
 std::future<bool> MolaVizImGuiCore::update_3d_object(
     const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
-    const std::string& viewportName, const std::string& parentWindow)
+    const std::string& viewportName, const std::string& parentWindow,
+    const std::string& parentFrame)
 {
   auto task = std::make_shared<std::packaged_task<bool()>>(
-      [this, objName, obj, viewportName, parentWindow]()
+      [this, objName, obj, viewportName, parentWindow, parentFrame]()
       {
         auto it = windows_.find(parentWindow);
         if (it == windows_.end()) return false;
@@ -640,18 +662,79 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
         std::lock_guard lk(it->second.background_scene_mtx);
 
         mrpt::opengl::CSetOfObjects::Ptr container;
-        if (auto o = scene->getByName(objName, viewportName); o)
-          container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
-        if (!container)
+        if (parentFrame.empty())
         {
-          // Either the name was unused, or an object of a different type is
-          // stored under it; (re)create a CSetOfObjects (insert overwrites by
-          // name) so we never dereference a null container below.
-          container = mrpt::opengl::CSetOfObjects::Create();
-          scene->insert(container, viewportName);
+          // Non-recursive search: only direct children of the viewport root,
+          // so objects nested inside frame nodes are not falsely matched.
+          if (auto vp = scene->getViewport(viewportName); vp)
+          {
+            for (const auto& o : *vp)
+            {
+              if (o->getName() == objName)
+              {
+                container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+                break;
+              }
+            }
+          }
+          if (!container)
+          {
+            // Not at root. Evict from any frame node it may live in, then
+            // create a fresh container at the viewport root.
+            if (auto o = scene->getByName(objName, viewportName); o)
+            {
+              scene->removeObject(o, viewportName);
+            }
+            container = mrpt::opengl::CSetOfObjects::Create();
+            scene->insert(container, viewportName);
+          }
+        }
+        else
+        {
+          // Attach as a child of the named movable frame node:
+          auto frameNode = getOrCreateFrameNode(*scene, parentFrame, viewportName);
+          if (auto o = frameNode->getByName(objName); o)
+          {
+            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+          }
+          if (!container)
+          {
+            // Not in this frame. Evict from root or another frame before
+            // inserting here (removeObject searches recursively).
+            if (auto o = scene->getByName(objName, viewportName); o)
+            {
+              scene->removeObject(o, viewportName);
+            }
+            container = mrpt::opengl::CSetOfObjects::Create();
+            frameNode->insert(container);
+          }
         }
         *container = *obj;
         container->setName(objName);
+        return true;
+      });
+
+  std::lock_guard lk(guiThreadPendingTasksMtx_);
+  guiThreadPendingTasks_.emplace_back([=]() { (*task)(); });
+  return task->get_future();
+}
+
+std::future<bool> MolaVizImGuiCore::update_3d_object_frame(
+    const std::string& frameName, const mrpt::math::TPose3D& pose, const std::string& viewportName,
+    const std::string& parentWindow)
+{
+  auto task = std::make_shared<std::packaged_task<bool()>>(
+      [this, frameName, pose, viewportName, parentWindow]()
+      {
+        ASSERT_(!frameName.empty());
+        auto it = windows_.find(parentWindow);
+        if (it == windows_.end()) return false;
+
+        auto&           scene = it->second.background_scene;
+        std::lock_guard lk(it->second.background_scene_mtx);
+
+        auto frameNode = getOrCreateFrameNode(*scene, frameName, viewportName);
+        frameNode->setPose(pose);
         return true;
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 3D objects can now be attached to named, movable reference frames.
  * Added an API to create/update a frame’s pose, so grouped objects can be repositioned together.
  * Frame nodes are auto-created when needed.

* **Bug Fixes**
  * Improved scene update behavior to keep object placement consistent when frames move.

* **API Changes**
  * 3D object update calls now accept an optional parent frame parameter (default: empty) across visualization interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->