### PR TITLE
feat(mola_yaml): $import map directive for base-file + overrides

### DIFF
--- a/docs/source/concept-slam-configuration-file.rst
+++ b/docs/source/concept-slam-configuration-file.rst
@@ -142,6 +142,60 @@ is replaced by the full contents of the referenced file.
          $include{my_params.yaml}   # ← my_params.yaml contributes all keys here
 
 
+.. _yaml_import:
+
+Import a base file and override entries: ``$import``
+------------------------------------------------------
+
+While ``$include{}`` replaces a *whole* node with the contents of a file, the
+``$import`` **map key** lets you load a file as a **base** and then **override**
+only a few of its entries inline.  A map containing an ``$import`` key is
+replaced by the **deep-merge** of the imported file(s) with the map's
+*remaining* keys overlaid on top:
+
+- The ``$import`` value is either a single file path (scalar) or a **sequence**
+  of paths.  When several files are given, they are merged in order, so a later
+  file overrides an earlier one.
+- The **sibling** keys of ``$import`` are then overlaid and therefore **override**
+  the imported base.  Nested maps are merged **deeply**, so you can override a
+  single deep key without restating its whole subtree; scalars and sequences are
+  replaced wholesale.
+- Paths follow the same rules as ``$include{}`` (absolute or relative to the
+  current file's directory; the path expression itself is pre-processed by the
+  ``$()`` / ``${}`` passes), and the same **circular-reference detection** applies.
+
+This is the recommended way to share a common parameter block across several
+near-identical launch files while tweaking just a few values, instead of
+duplicating the whole block:
+
+.. code-block:: yaml
+
+    modules:
+      - type: CLASS_NAME1
+        name: instance1
+        params:
+          $import: shared-params.yaml   # base (a path, or a sequence of paths)
+          max_rate_hz: 10.0             # override a single entry of the base
+          nested:
+            gain: 2.0                   # deep-override one nested key (siblings kept)
+
+Equivalent multi-file base, where ``overrides.yaml`` wins over ``base.yaml``:
+
+.. code-block:: yaml
+
+    params:
+      $import:
+        - base.yaml
+        - overrides.yaml
+      extra_key: 123                    # still overrides both imported files
+
+.. note::
+
+   ``$import`` is resolved in the same (first) pass as ``$include{}``.  Use
+   ``$include{}`` when a node *is* the file; use ``$import`` when you want the
+   file as a base **plus** local overrides.
+
+
 .. _yaml_cmd:
 
 Run an external command: ``$(command)``
@@ -267,6 +321,10 @@ when a token falls inside a comment:
      - Contents of ``path``
      - 1st
      - Left verbatim
+   * - ``$import`` (map key)
+     - Imported file(s), with sibling keys overriding
+     - 1st
+     - n/a (a map key, not a scalar token)
    * - ``$(command)``
      - stdout of ``command``
      - 2nd
@@ -289,13 +347,13 @@ Debugging pre-processing
 --------------------------
 
 Set the environment variable ``VERBOSE=1`` before launching any MOLA
-executable to print each ``$include{}`` directive as it is resolved:
+executable to print each external file (``$include{}`` or ``$import``) as it is
+resolved:
 
 .. code-block:: bash
 
     VERBOSE=1 ros2 launch my_slam_system slam.launch.py
 
-Each include prints a line of the form::
+Each resolved file prints a line of the form::
 
-    [mola::parse_yaml] $include{ "/absolute/path/to/file.yaml" }
-    [mola::parse_yaml] $include done: "/absolute/path/to/file.yaml"
+    [mola::parse_yaml] loading external YAML: "/absolute/path/to/file.yaml"

--- a/mola_yaml/include/mola_yaml/yaml_helpers.h
+++ b/mola_yaml/include/mola_yaml/yaml_helpers.h
@@ -47,7 +47,17 @@ namespace mola
  * Pre-processing is performed in the following fixed order:
  *  1. **`$include{path}`** - replaced with the contents of the referenced
  *     YAML file (recursive; relative paths resolved against
- *     `includesBasePath`).
+ *     `includesBasePath`). In the SAME pass, the **`$import`** map directive is
+ *     also resolved: a map whose `$import` key names one (scalar) or several
+ *     (sequence) external YAML files is replaced by the deep-merge of those
+ *     file(s) with the map's REMAINING keys overlaid on top, so the sibling
+ *     entries OVERRIDE particular entries of the imported base (nested maps
+ *     merge deeply; scalars/sequences replace). Example:
+ *     ```
+ *     params:
+ *       $import: shared-params.yaml   # base (a path, or a sequence of paths)
+ *       max_rate_hz: 10.0             # override one entry of the imported base
+ *     ```
  *  2. **`$(cmd)`** - replaced with the trimmed stdout of the shell command
  *     `cmd` (exit code ≠ 0 throws).
  *  3. **`${VAR}`** or **`${VAR|default}`** - replaced with the value of

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -352,6 +352,104 @@ struct IncludeGuard
 };
 
 /**
+ * Recursively deep-merge `overlay` on top of `base` (in place).
+ *
+ *  - When both nodes are maps, keys are merged recursively: a key present only
+ *    in `overlay` is added; a key present in both is merged by recursing.
+ *  - For any other combination (scalar, sequence, or type mismatch), `overlay`
+ *    REPLACES `base` wholesale.
+ *
+ * This is the override semantics of the `$import` directive: sibling entries
+ * override the imported base, and nested maps are merged deeply so a single
+ * deep key can be overridden without restating its whole subtree.
+ */
+void deepMergeNode(yaml::node_t& base, const yaml::node_t& overlay)
+{
+  if (base.isMap() && overlay.isMap())
+  {
+    auto& baseMap = base.asMap();
+    for (const auto& [key, value] : overlay.asMap())
+    {
+      if (auto it = baseMap.find(key); it != baseMap.end())
+      {
+        deepMergeNode(it->second, value);
+      }
+      else
+      {
+        baseMap[key] = value;
+      }
+    }
+  }
+  else
+  {
+    base = overlay;
+  }
+}
+
+/**
+ * Resolve `pathExpr` (which may itself contain `${}` / `$()` expressions and be
+ * a relative path) and load + fully pre-process the referenced YAML file,
+ * returning the resulting node.
+ *
+ * Shared by the `$include{path}` scalar directive (whole-node replacement) and
+ * the `$import` map directive (structural merge). Relative paths resolve against
+ * `opts.includesBasePath`; nested includes/imports inside the loaded file
+ * resolve against that file's own directory. Circular references are detected
+ * via the thread-local `g_activeIncludes` stack.
+ */
+[[nodiscard]] yaml::node_t loadExternalYaml(
+    const std::string& pathExpr, const mola::YAMLParseOptions& opts)
+{
+  // Resolve any variable/command expressions inside the path itself.
+  std::string expr = trimWSNL(mola::parse_yaml(pathExpr, opts));
+
+  // Resolve relative paths against the current include base.
+  if (!opts.includesBasePath.empty())
+  {
+    fs::path p = expr;
+    if (p.is_relative())
+    {
+      p    = fs::path(opts.includesBasePath) / p;
+      expr = p.string();
+    }
+  }
+
+  // Derive the nested base dir from the resolved path so that relative
+  // includes/imports inside the loaded file resolve relative to its own dir.
+  const std::string newIncludeBaseDir = fs::path(expr).remove_filename().string();
+
+  if (!mrpt::system::fileExists(expr))
+  {
+    THROW_EXCEPTION_FMT("Cannot find referenced YAML file: `%s`", expr.c_str());
+  }
+
+  // Detect circular references via the active include/import chain.
+  const std::string canonicalExpr = fs::weakly_canonical(fs::path(expr)).string();
+  for (const auto& active : g_activeIncludes)
+  {
+    if (active == canonicalExpr)
+    {
+      THROW_EXCEPTION_FMT(
+          "Circular include/import detected: `%s` is already being processed",
+          canonicalExpr.c_str());
+    }
+  }
+  IncludeGuard includeGuard(canonicalExpr);
+
+  if (::getenv("VERBOSE") != nullptr)
+  {
+    std::cout << "[mola::parse_yaml] loading external YAML: \"" << expr << "\"\n";
+  }
+
+  const auto filData = yaml::FromFile(expr);
+
+  auto nestedOpts             = opts;
+  nestedOpts.includesBasePath = newIncludeBaseDir;
+
+  return yaml::FromText(mola::parse_yaml(mola::yaml_to_string(filData), nestedOpts)).node();
+}
+
+/**
  * Recursively walk a `yaml::node_t` tree and expand any scalar nodes whose
  * text matches `$include{path}`.
  *
@@ -386,68 +484,10 @@ void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opt
           static_cast<unsigned int>(tokenStart), text.c_str());
     }
 
-    // Resolve any variable/command expressions inside the path itself
-    std::string expr = text.substr(exprStart, exprEnd - exprStart);
-    expr             = trimWSNL(mola::parse_yaml(expr, opts));  // pass opts!
-
-    // Resolve relative paths against the current include base.
-    if (!opts.includesBasePath.empty())
-    {
-      fs::path p = expr;
-      if (p.is_relative())
-      {
-        p    = fs::path(opts.includesBasePath) / p;
-        expr = p.string();
-      }
-    }
-
-    // Always derive the nested base dir from the resolved (possibly absolute)
-    // expr, not from the parent's base path.  This ensures that nested
-    // relative $include{} directives inside the included file resolve relative
-    // to *that* file's own directory, regardless of whether expr was absolute
-    // or relative from the caller's perspective.
-    const std::string newIncludeBaseDir = fs::path(expr).remove_filename().string();
-
-    if (!mrpt::system::fileExists(expr))
-    {
-      THROW_EXCEPTION_FMT("Cannot find $include{}'d YAML file: `%s`", expr.c_str());
-    }
-
-    // Detect circular includes: resolve to a canonical path and check whether
-    // it is already in the active include chain for this thread.
-    const std::string canonicalExpr = fs::weakly_canonical(fs::path(expr)).string();
-
-    for (const auto& active : g_activeIncludes)
-    {
-      if (active == canonicalExpr)
-      {
-        THROW_EXCEPTION_FMT(
-            "Circular $include{} detected: `%s` is already being included", canonicalExpr.c_str());
-      }
-    }
-
-    // Push this file onto the active-include stack; popped automatically on
-    // scope exit (including exception unwind) via IncludeGuard.
-    IncludeGuard includeGuard(canonicalExpr);
-
-    if (::getenv("VERBOSE"))
-    {
-      std::cout << "[mola::parse_yaml] $include{ \"" << expr << "\" }\n";
-    }
-
-    // Load the file, update the base path for nested includes, pre-process
-    // the included content, then replace the current node.
-    const auto filData = yaml::FromFile(expr);
-
-    auto nestedOpts             = opts;
-    nestedOpts.includesBasePath = newIncludeBaseDir;
-
-    n = yaml::FromText(mola::parse_yaml(mola::yaml_to_string(filData), nestedOpts));
-
-    if (::getenv("VERBOSE"))
-    {
-      std::cout << "[mola::parse_yaml] $include done: \"" << expr << "\"\n";
-    }
+    // Load + fully pre-process the referenced file, then REPLACE this node with
+    // the loaded content (whole-node substitution).
+    const std::string expr = text.substr(exprStart, exprEnd - exprStart);
+    n                      = loadExternalYaml(expr, opts);
   }
   else if (n.isSequence())
   {
@@ -458,7 +498,66 @@ void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opt
   }
   else if (n.isMap())
   {
-    for (auto& [key, value] : n.asMap())
+    auto& m = n.asMap();
+
+    // `$import` directive: a map whose `$import` key names one (scalar) or
+    // several (sequence) external YAML files is REPLACED by the deep-merge of
+    // those files (in listed order) with the map's REMAINING keys overlaid on
+    // top. So the imported file(s) act as a base, and the sibling entries
+    // OVERRIDE particular entries (nested maps merge deeply; scalars/sequences
+    // replace). This is what lets `params:` reference a shared file and then
+    // tweak just a few keys, instead of duplicating the whole block.
+    // NOTE: parens-init (NOT braces): `node_t{std::string}` would bind to the
+    // initializer_list<node_t> constructor and build a 1-element SEQUENCE node
+    // instead of a scalar, which then throws in operator<'s internalAsStr().
+    const yaml::node_t importKey(std::string("$import"));
+    if (const auto itImport = m.find(importKey); itImport != m.end())
+    {
+      std::vector<std::string> importPaths;
+      const auto&              importVal = itImport->second;
+      if (importVal.isScalar())
+      {
+        importPaths.push_back(importVal.as<std::string>());
+      }
+      else if (importVal.isSequence())
+      {
+        for (const auto& element : importVal.asSequence())
+        {
+          importPaths.push_back(element.as<std::string>());
+        }
+      }
+      else
+      {
+        THROW_EXCEPTION("`$import` value must be a file path string or a sequence of paths.");
+      }
+
+      // Base: deep-merge of the imported file(s), in the order listed.
+      yaml::node_t merged = yaml::Map();
+      for (const auto& path : importPaths)
+      {
+        const yaml::node_t loaded = loadExternalYaml(path, opts);
+        deepMergeNode(merged, loaded);
+      }
+
+      // Overlay: the remaining sibling keys (recursively pre-processed first),
+      // which override the imported base.
+      for (auto& [key, value] : m)
+      {
+        if (key.isScalar() && key.as<std::string>() == "$import")
+        {
+          continue;
+        }
+        recursiveProcessIncludes(value, opts);
+        yaml::node_t single = yaml::Map();
+        single.asMap()[key] = value;
+        deepMergeNode(merged, single);
+      }
+
+      n = merged;
+      return;
+    }
+
+    for (auto& [key, value] : m)
     {
       recursiveProcessIncludes(value, opts);
     }

--- a/mola_yaml/tests/test-yaml-parser.cpp
+++ b/mola_yaml/tests/test-yaml-parser.cpp
@@ -550,6 +550,86 @@ void test_yaml2stringAdditional()
   }
 }
 
+// ---------------------------------------------------------------------------
+// 11. `$import` directive: import a base file and OVERRIDE particular entries
+//
+// A map with a `$import` key (scalar path or sequence of paths) is replaced by
+// the deep-merge of the imported file(s) with the map's remaining keys overlaid
+// on top (siblings override the base; nested maps merge deeply).
+// ---------------------------------------------------------------------------
+void test_parseImportOverride()
+{
+  using mrpt::containers::yaml;
+
+  mola::YAMLParseOptions opts;
+  opts.includesBasePath = MOLA_MODULE_SOURCE_DIR;
+
+  // --- single import + scalar override + new key + deep-nested override ---
+  {
+    const std::string input =
+        "params:\n"
+        "  $import: test_import_base.yaml\n"
+        "  b: 99\n"  // override an existing scalar
+        "  c: 3\n"  // add a brand-new key
+        "  nested:\n"
+        "    y: 200\n";  // deep-override one nested key (x must survive)
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_(y.isMap());
+    ASSERT_EQUAL_(y["params"]["a"].as<int>(), 1);  // from base
+    ASSERT_EQUAL_(y["params"]["b"].as<int>(), 99);  // overridden
+    ASSERT_EQUAL_(y["params"]["c"].as<int>(), 3);  // added
+    ASSERT_EQUAL_(y["params"]["nested"]["x"].as<int>(), 10);  // kept (deep merge)
+    ASSERT_EQUAL_(y["params"]["nested"]["y"].as<int>(), 200);  // overridden
+    ASSERT_EQUAL_(y["params"]["list"](0).as<std::string>(), "p");  // from base
+  }
+
+  // --- sequence import: later file overrides earlier; sibling overrides both ---
+  {
+    const std::string input =
+        "config:\n"
+        "  $import:\n"
+        "    - test1.yaml\n"  // a:10 b:20
+        "    - test_import_o2.yaml\n"  // b:777 e:5
+        "  a: 1000\n";  // sibling override
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["config"]["a"].as<int>(), 1000);  // sibling wins over imports
+    ASSERT_EQUAL_(y["config"]["b"].as<int>(), 777);  // 2nd import wins over 1st
+    ASSERT_EQUAL_(y["config"]["e"].as<int>(), 5);
+  }
+
+  // --- via load_yaml_file(): relative import resolved against the file's dir ---
+  {
+    const auto file = MOLA_MODULE_SOURCE_DIR + "/test_import_top.yaml"s;
+    const auto y    = mola::load_yaml_file(file);
+    ASSERT_EQUAL_(y["params"]["a"].as<int>(), 1);  // from base
+    ASSERT_EQUAL_(y["params"]["b"].as<int>(), 42);  // overridden
+    ASSERT_EQUAL_(y["params"]["nested"]["x"].as<int>(), 10);  // kept
+    ASSERT_EQUAL_(y["params"]["nested"]["y"].as<int>(), 222);  // overridden
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12. `$import` of a missing file must throw
+// ---------------------------------------------------------------------------
+void test_parseImportMissingFile()
+{
+  mola::YAMLParseOptions opts;
+  opts.includesBasePath = MOLA_MODULE_SOURCE_DIR;
+
+  bool did_throw = false;
+  try
+  {
+    const std::string input = "p:\n  $import: this_file_does_not_exist_xyz.yaml\n";
+    const auto        y     = mola::parse_yaml(mrpt::containers::yaml::FromText(input), opts);
+    (void)y;
+  }
+  catch (const std::exception&)
+  {
+    did_throw = true;
+  }
+  ASSERT_(did_throw);
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -570,6 +650,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_parseMissingIncludeFile();
     test_parseVarsInLoadedFile();
     test_yaml2stringAdditional();
+    test_parseImportOverride();
+    test_parseImportMissingFile();
 
     std::cout << "Test successful.\n";
   }

--- a/mola_yaml/tests/test_import_base.yaml
+++ b/mola_yaml/tests/test_import_base.yaml
@@ -1,0 +1,10 @@
+# base params for $import override tests
+---
+a: 1
+b: 2
+nested:
+  x: 10
+  y: 20
+list:
+  - p
+  - q

--- a/mola_yaml/tests/test_import_o2.yaml
+++ b/mola_yaml/tests/test_import_o2.yaml
@@ -1,0 +1,4 @@
+# second overlay file for $import sequence tests (overlaps test1.yaml's `b`)
+---
+b: 777
+e: 5

--- a/mola_yaml/tests/test_import_top.yaml
+++ b/mola_yaml/tests/test_import_top.yaml
@@ -1,0 +1,7 @@
+# top-level file exercising $import + overrides via load_yaml_file()
+---
+params:
+  $import: test_import_base.yaml
+  b: 42
+  nested:
+    y: 222


### PR DESCRIPTION
## Summary

Adds a new `$import` map directive to the MOLA YAML pre-processor (`mola_yaml`).

While `$include{path}` replaces a **whole node** with a file's contents, `$import`
loads one or more files as a **base** and lets you **override** particular entries
inline. A map containing an `$import` key is replaced by the deep-merge of the
imported file(s) with the map's remaining keys overlaid on top:

```yaml
params:
  $import: shared-params.yaml   # base (a path, or a sequence of paths)
  max_rate_hz: 10.0             # override a single entry
  nested:
    gain: 2.0                   # deep-override one nested key (siblings kept)
```

- `$import` accepts a single path (scalar) or a **sequence** of paths (later files
  win over earlier ones); the **sibling** keys then override the imported base.
- Nested maps merge **deeply** (override one deep key without restating its
  subtree); scalars/sequences are replaced wholesale.
- Resolved in the **same first pass** as `$include{}`, reusing its path
  pre-processing (`$()`/`${}`), relative-path resolution, and circular-reference
  detection.

### Motivation

`mola-cli` launch files for related datasets share large, near-identical `params`
blocks that currently must be duplicated (or fully replaced via a scalar
`$include{}`, which forbids per-file tweaks). `$import` lets each launch file
reference one shared params file and override just the few keys that differ.

## Changes

- `mola_yaml/src/yaml_helpers.cpp`: `deepMergeNode()` + `loadExternalYaml()`
  helpers; `$import` handling in the node walk (and refactor of `$include{}` to
  reuse the shared loader).
- `mola_yaml/include/mola_yaml/yaml_helpers.h`: documented the directive.
- Unit tests (`mola_yaml/tests/`): single import, multi-file sequence precedence,
  sibling + deep-nested override, `load_yaml_file()` path, missing-file throw,
  plus data files.
- Docs: new `$import` section + processing-order table row in
  `concept-slam-configuration-file.rst`.

## Testing

`colcon test --packages-select mola_yaml` — all pass (existing + new cases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `$import` YAML configuration directive, allowing a base file to be merged with additional overrides.
  * Improved verbose loading output to show resolved external YAML files during preprocessing.

* **Documentation**
  * Updated configuration docs to describe `$import`, its merge behavior, processing order, and path resolution rules.

* **Tests**
  * Added coverage for deep merges, nested overrides, multiple imported files, relative paths, and missing-file errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->