### PR TITLE
feat: frame-aware parentFrame for decay clouds and camera look-at

### DIFF
--- a/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
+++ b/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
@@ -47,10 +47,11 @@ namespace nanogui { class Window; }
 // ---------------------------------------------------------------------------
 
 /** Feature macro: when defined, VizInterface offers update_3d_object_frame()
- *  and the `parentFrame` argument of update_3d_object() and
- *  insert_point_cloud_with_decay(), i.e. named movable reference-frame nodes
- *  that child objects can be attached to.  Lets out-of-repo modules (e.g. an
- *  older mola_lidar_odometry checkout) detect the feature at compile time. */
+ *  and the `parentFrame` argument of update_3d_object(),
+ *  insert_point_cloud_with_decay(), and update_viewport_look_at(), i.e. named
+ *  movable reference-frame nodes that child objects / camera targets can be
+ *  resolved against.  Lets out-of-repo modules (e.g. an older
+ *  mola_lidar_odometry checkout) detect the feature at compile time. */
 #define MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES 1
 
 namespace mola

--- a/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
+++ b/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
@@ -47,10 +47,10 @@ namespace nanogui { class Window; }
 // ---------------------------------------------------------------------------
 
 /** Feature macro: when defined, VizInterface offers update_3d_object_frame()
- *  and the `parentFrame` argument of update_3d_object(), i.e. named movable
- *  reference-frame nodes that child objects can be attached to.  Lets
- *  out-of-repo modules (e.g. an older mola_lidar_odometry checkout) detect the
- *  feature at compile time. */
+ *  and the `parentFrame` argument of update_3d_object() and
+ *  insert_point_cloud_with_decay(), i.e. named movable reference-frame nodes
+ *  that child objects can be attached to.  Lets out-of-repo modules (e.g. an
+ *  older mola_lidar_odometry checkout) detect the feature at compile time. */
 #define MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES 1
 
 namespace mola
@@ -262,11 +262,15 @@ class VizInterface
    * \param decay_time_seconds Lifetime in seconds before the cloud fades out.
    * \param viewportName       Target viewport.
    * \param parentWindow       Host window name.
+   * \param parentFrame        If non-empty, the cloud is attached as a child of
+   *                           the named movable frame node (same semantics as
+   *                           the parentFrame argument of update_3d_object()).
    * \return                   future<bool> resolving to true when executed.
    */
   virtual std::future<bool> insert_point_cloud_with_decay(
       const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
-      const std::string& viewportName = "main", const std::string& parentWindow = "main") = 0;
+      const std::string& viewportName = "main", const std::string& parentWindow = "main",
+      const std::string& parentFrame = "") = 0;
 
   /**
    * \brief Removes all clouds previously inserted with
@@ -275,10 +279,20 @@ class VizInterface
   virtual std::future<bool> clear_all_point_clouds_with_decay(
       const std::string& viewportName = "main", const std::string& parentWindow = "main") = 0;
 
-  /** Moves the viewport camera look-at point. */
+  /**
+   * \brief Moves the viewport camera look-at point.
+   *
+   * \param lookAt       Target point in the local coordinate frame of
+   *                     `parentFrame` (if given) or in world/scene space.
+   * \param parentFrame  If non-empty, the backend looks up the named movable
+   *                     frame node, applies its current scene pose to `lookAt`,
+   *                     and uses the resulting world-space point as the target.
+   *                     This makes the camera follow a vehicle rendered under
+   *                     a frame node rather than chasing its odom-frame coords.
+   */
   virtual std::future<bool> update_viewport_look_at(
       const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName = "main",
-      const std::string& parentWindow = "main") = 0;
+      const std::string& parentWindow = "main", const std::string& parentFrame = "") = 0;
 
   /**
    * \brief Rotates the viewport camera around the vertical axis.

--- a/mola_viz/include/mola_viz/MolaViz.h
+++ b/mola_viz/include/mola_viz/MolaViz.h
@@ -262,7 +262,8 @@ class MolaViz : public ExecutableBase, public VizInterface
 
     std::string                                        opengl_viewport_name;
     std::shared_ptr<mrpt::opengl::CPointCloudColoured> cloud;
-    float                                              initial_alpha = 1.0f;
+    mrpt::opengl::CSetOfObjects::Ptr container;  // owning container at insert time
+    float                            initial_alpha = 1.0f;
   };
 
   struct PerWindowData

--- a/mola_viz/include/mola_viz/MolaViz.h
+++ b/mola_viz/include/mola_viz/MolaViz.h
@@ -123,7 +123,8 @@ class MolaViz : public ExecutableBase, public VizInterface
   std::future<bool> insert_point_cloud_with_decay(
       const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
 
   std::future<bool> clear_all_point_clouds_with_decay(
       const std::string& viewportName = "main",
@@ -131,7 +132,8 @@ class MolaViz : public ExecutableBase, public VizInterface
 
   std::future<bool> update_viewport_look_at(
       const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
 
   std::future<bool> update_viewport_camera_azimuth(
       double azimuth, bool absolute_falseForRelative = true,

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -1882,11 +1882,15 @@ std::future<bool> MolaViz::insert_point_cloud_with_decay(
 
         const float initial_alpha = mrpt::u8tof(cloud->shaderPointsVertexColorBuffer().at(0).A);
         winData.decaying_clouds.emplace_back(viewportName, cloud, initial_alpha);
+        winData.decaying_clouds.back().container = glContainer;
 
         while (winData.decaying_clouds.size() > maxScans)
         {
           auto& oldest = winData.decaying_clouds.front();
-          glContainer->removeObject(oldest.cloud);
+          if (oldest.container)
+          {
+            oldest.container->removeObject(oldest.cloud);
+          }
           winData.decaying_clouds.pop_front();
         }
         return true;
@@ -1958,12 +1962,16 @@ std::future<bool> MolaViz::update_viewport_look_at(
         {
           if (auto o = topWin->background_scene->getByName(parentFrame, viewportName); o)
           {
-            const auto worldPt = mrpt::poses::CPose3D(o->getPose()).composePoint(
-                mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
+            const auto worldPt =
+                mrpt::poses::CPose3D(o->getPose())
+                    .composePoint(mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
             worldLookAt = {
-                static_cast<float>(worldPt.x),
-                static_cast<float>(worldPt.y),
+                static_cast<float>(worldPt.x), static_cast<float>(worldPt.y),
                 static_cast<float>(worldPt.z)};
+          }
+          else
+          {
+            return false;  // frame node not in scene yet; skip camera update
           }
         }
         MRPT_LOG_DEBUG_STREAM("update_viewport_look_at() lookAt=" << worldLookAt.asString());

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -1824,12 +1824,12 @@ std::future<bool> MolaViz::update_3d_object_frame(
 std::future<bool> MolaViz::insert_point_cloud_with_decay(
     const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud,
     const double decay_time_seconds, const std::string& viewportName,
-    const std::string& parentWindow)
+    const std::string& parentWindow, const std::string& parentFrame)
 {
   using return_type = bool;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
-      [this, cloud, decay_time_seconds, viewportName, parentWindow]()
+      [this, cloud, decay_time_seconds, viewportName, parentWindow, parentFrame]()
       {
         if (!cloud || cloud->empty())
         {
@@ -1843,16 +1843,35 @@ std::future<bool> MolaViz::insert_point_cloud_with_decay(
         ASSERT_(topWin->background_scene);
 
         mrpt::opengl::CSetOfObjects::Ptr glContainer;
-        if (auto o = topWin->background_scene->getByName(DECAY_CLOUDS_NAME, viewportName); o)
+        if (parentFrame.empty())
         {
-          glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
-          ASSERT_(glContainer);
+          if (auto o = topWin->background_scene->getByName(DECAY_CLOUDS_NAME, viewportName); o)
+          {
+            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            ASSERT_(glContainer);
+          }
+          else
+          {
+            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            topWin->background_scene->insert(glContainer, viewportName);
+            glContainer->setName(DECAY_CLOUDS_NAME);
+          }
         }
         else
         {
-          glContainer = mrpt::opengl::CSetOfObjects::Create();
-          topWin->background_scene->insert(glContainer, viewportName);
-          glContainer->setName(DECAY_CLOUDS_NAME);
+          auto frameNode =
+              get_or_create_frame_node_(*topWin->background_scene, parentFrame, viewportName);
+          if (auto o = frameNode->getByName(DECAY_CLOUDS_NAME); o)
+          {
+            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            ASSERT_(glContainer);
+          }
+          else
+          {
+            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            glContainer->setName(DECAY_CLOUDS_NAME);
+            frameNode->insert(glContainer);
+          }
         }
 
         glContainer->insert(cloud);
@@ -1921,20 +1940,34 @@ std::future<bool> MolaViz::clear_all_point_clouds_with_decay(
 // ---------------------------------------------------------------------------
 
 std::future<bool> MolaViz::update_viewport_look_at(
-    const mrpt::math::TPoint3Df& lookAt, [[maybe_unused]] const std::string& viewportName,
-    const std::string& parentWindow)
+    const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName,
+    const std::string& parentWindow, const std::string& parentFrame)
 {
   using return_type = bool;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
-      [this, lookAt, parentWindow]()
+      [this, lookAt, viewportName, parentWindow, parentFrame]()
       {
-        MRPT_LOG_DEBUG_STREAM("update_viewport_look_at() lookAt=" << lookAt.asString());
         ASSERT_(windows_.count(parentWindow));
         auto topWin = windows_.at(parentWindow).win;
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
-        topWin->camera().setCameraPointing(lookAt.x, lookAt.y, lookAt.z);
+
+        mrpt::math::TPoint3Df worldLookAt = lookAt;
+        if (!parentFrame.empty())
+        {
+          if (auto o = topWin->background_scene->getByName(parentFrame, viewportName); o)
+          {
+            const auto worldPt = mrpt::poses::CPose3D(o->getPose()).composePoint(
+                mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
+            worldLookAt = {
+                static_cast<float>(worldPt.x),
+                static_cast<float>(worldPt.y),
+                static_cast<float>(worldPt.z)};
+          }
+        }
+        MRPT_LOG_DEBUG_STREAM("update_viewport_look_at() lookAt=" << worldLookAt.asString());
+        topWin->camera().setCameraPointing(worldLookAt.x, worldLookAt.y, worldLookAt.z);
         return true;
       });
 

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -163,10 +163,11 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   std::future<bool> insert_point_cloud_with_decay(
       const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override
   {
     return core_ptr_->insert_point_cloud_with_decay(
-        cloud, decay_time_seconds, viewportName, parentWindow);
+        cloud, decay_time_seconds, viewportName, parentWindow, parentFrame);
   }
 
   std::future<bool> clear_all_point_clouds_with_decay(
@@ -178,9 +179,10 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
 
   std::future<bool> update_viewport_look_at(
       const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override
   {
-    return core_ptr_->update_viewport_look_at(lookAt, viewportName, parentWindow);
+    return core_ptr_->update_viewport_look_at(lookAt, viewportName, parentWindow, parentFrame);
   }
 
   std::future<bool> update_viewport_camera_azimuth(

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -210,7 +210,8 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   std::future<bool> insert_point_cloud_with_decay(
       const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
 
   std::future<bool> clear_all_point_clouds_with_decay(
       const std::string& viewportName = "main",
@@ -218,7 +219,8 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
 
   std::future<bool> update_viewport_look_at(
       const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName = "main",
-      const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::string& parentWindow = DEFAULT_WINDOW_NAME,
+      const std::string& parentFrame  = "") override;
 
   std::future<bool> update_viewport_camera_azimuth(
       double azimuth, bool absolute_falseForRelative = true,

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -343,7 +343,8 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
     }
     std::string                                        viewport_name;
     std::shared_ptr<mrpt::opengl::CPointCloudColoured> cloud;
-    float                                              initial_alpha = 1.0f;
+    mrpt::opengl::CSetOfObjects::Ptr container;  // owning container at insert time
+    float                            initial_alpha = 1.0f;
   };
 
   struct PerWindowData

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -832,10 +832,15 @@ std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
 
         const float alpha = mrpt::u8tof(cloud->shaderPointsVertexColorBuffer().at(0).A);
         wd.decaying_clouds.emplace_back(viewportName, cloud, alpha);
+        wd.decaying_clouds.back().container = container;
 
         while (wd.decaying_clouds.size() > maxScans)
         {
-          container->removeObject(wd.decaying_clouds.front().cloud);
+          auto& oldest = wd.decaying_clouds.front();
+          if (oldest.container)
+          {
+            oldest.container->removeObject(oldest.cloud);
+          }
           wd.decaying_clouds.pop_front();
         }
         return true;
@@ -871,7 +876,7 @@ std::future<bool> MolaVizImGuiCore::clear_all_point_clouds_with_decay(
 
 std::future<bool> MolaVizImGuiCore::update_viewport_look_at(
     const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName,
-    const std::string&           parentWindow, const std::string& parentFrame)
+    const std::string& parentWindow, const std::string& parentFrame)
 {
   auto task = std::make_shared<std::packaged_task<bool()>>(
       [this, lookAt, viewportName, parentWindow, parentFrame]()
@@ -886,12 +891,16 @@ std::future<bool> MolaVizImGuiCore::update_viewport_look_at(
           std::lock_guard lk(wd.background_scene_mtx);
           if (auto o = wd.background_scene->getByName(parentFrame, viewportName); o)
           {
-            const auto worldPt = mrpt::poses::CPose3D(o->getPose()).composePoint(
-                mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
+            const auto worldPt =
+                mrpt::poses::CPose3D(o->getPose())
+                    .composePoint(mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
             worldLookAt = {
-                static_cast<float>(worldPt.x),
-                static_cast<float>(worldPt.y),
+                static_cast<float>(worldPt.x), static_cast<float>(worldPt.y),
                 static_cast<float>(worldPt.z)};
+          }
+          else
+          {
+            return false;  // frame node not in scene yet; skip camera update
           }
         }
         wd.cam_look_at[0] = worldLookAt.x;

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -780,10 +780,11 @@ std::future<bool> MolaVizImGuiCore::clear_background_scene(
 
 std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
     const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
-    const std::string& viewportName, const std::string& parentWindow)
+    const std::string& viewportName, const std::string& parentWindow,
+    const std::string& parentFrame)
 {
   auto task = std::make_shared<std::packaged_task<bool()>>(
-      [this, cloud, decay_time_seconds, viewportName, parentWindow]()
+      [this, cloud, decay_time_seconds, viewportName, parentWindow, parentFrame]()
       {
         if (!cloud || cloud->empty()) return true;
 
@@ -796,15 +797,28 @@ std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
         std::lock_guard       lk(wd.background_scene_mtx);
 
         mrpt::opengl::CSetOfObjects::Ptr container;
-        if (auto o = wd.background_scene->getByName(DECAY_NAME, viewportName); o)
-          container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
-        if (!container)
+        if (parentFrame.empty())
         {
-          // Either the reserved name was never used, or someone inserted a
-          // non-CSetOfObjects under it.  Recreate fresh (overwrites by name).
-          container = mrpt::opengl::CSetOfObjects::Create();
-          wd.background_scene->insert(container, viewportName);
-          container->setName(DECAY_NAME);
+          if (auto o = wd.background_scene->getByName(DECAY_NAME, viewportName); o)
+            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+          if (!container)
+          {
+            container = mrpt::opengl::CSetOfObjects::Create();
+            wd.background_scene->insert(container, viewportName);
+            container->setName(DECAY_NAME);
+          }
+        }
+        else
+        {
+          auto frameNode = getOrCreateFrameNode(*wd.background_scene, parentFrame, viewportName);
+          if (auto o = frameNode->getByName(DECAY_NAME); o)
+            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+          if (!container)
+          {
+            container = mrpt::opengl::CSetOfObjects::Create();
+            container->setName(DECAY_NAME);
+            frameNode->insert(container);
+          }
         }
         container->insert(cloud);
 
@@ -856,18 +870,33 @@ std::future<bool> MolaVizImGuiCore::clear_all_point_clouds_with_decay(
 }
 
 std::future<bool> MolaVizImGuiCore::update_viewport_look_at(
-    const mrpt::math::TPoint3Df& lookAt, const std::string& /*viewportName*/,
-    const std::string&           parentWindow)
+    const mrpt::math::TPoint3Df& lookAt, const std::string& viewportName,
+    const std::string&           parentWindow, const std::string& parentFrame)
 {
   auto task = std::make_shared<std::packaged_task<bool()>>(
-      [this, lookAt, parentWindow]()
+      [this, lookAt, viewportName, parentWindow, parentFrame]()
       {
         auto it = windows_.find(parentWindow);
         if (it == windows_.end()) return false;
-        auto& wd          = it->second;
-        wd.cam_look_at[0] = lookAt.x;
-        wd.cam_look_at[1] = lookAt.y;
-        wd.cam_look_at[2] = lookAt.z;
+        auto& wd = it->second;
+
+        mrpt::math::TPoint3Df worldLookAt = lookAt;
+        if (!parentFrame.empty())
+        {
+          std::lock_guard lk(wd.background_scene_mtx);
+          if (auto o = wd.background_scene->getByName(parentFrame, viewportName); o)
+          {
+            const auto worldPt = mrpt::poses::CPose3D(o->getPose()).composePoint(
+                mrpt::math::TPoint3D(lookAt.x, lookAt.y, lookAt.z));
+            worldLookAt = {
+                static_cast<float>(worldPt.x),
+                static_cast<float>(worldPt.y),
+                static_cast<float>(worldPt.z)};
+          }
+        }
+        wd.cam_look_at[0] = worldLookAt.x;
+        wd.cam_look_at[1] = worldLookAt.y;
+        wd.cam_look_at[2] = worldLookAt.z;
         wd.cam_dirty      = true;
         return true;
       });


### PR DESCRIPTION
## Summary

- `insert_point_cloud_with_decay()` gains an optional `parentFrame` parameter: when non-empty the cloud is inserted as a child of the named movable frame node (same semantics as `update_3d_object()`'s `parentFrame`), so it moves automatically when the frame is repositioned by a central mapper.
- `update_viewport_look_at()` gains the same `parentFrame` parameter: the backend looks up the frame node's current world pose and composes it with the supplied local-frame point before moving the camera, so `camera_follows_vehicle` tracks the vehicle in map space rather than in raw odometry space.
- Both backends (`MolaViz`, `MolaVizImGuiCore`) and the `MolaVizImGui` forwarder are updated.
- The existing `MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES` feature macro already covers both new parameters; no additional macro is introduced.

## Motivation

`mola_lidar_odometry` draws all its persistent 3D objects under a movable frame node (added in #160). The two remaining calls that ignored the frame hierarchy — transient deskewed-scan clouds and the camera look-at target — caused visual misalignment when `mola_mapper_3d` repositioned the `{odom_lidar}` frame after geo-ref convergence or loop closure.

## Test plan

- [ ] Build `mola`, `mola_viz`, `mola_viz_imgui`, `mola_lidar_odometry` — all green locally on Jazzy.
- [ ] Run `mola-cli` with `mola_lidar_odometry` + `mola_mapper_3d` on MulRan DCC01; confirm deskewed clouds and camera follow position stay aligned with the local map after geo-ref convergence.
- [ ] Confirm standalone LIO (no `mola_mapper_3d`, `parentFrame = ""`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for attaching decaying point clouds to a movable frame instead of only the viewport root.
  * Added frame-aware camera targeting so “look at” points can be resolved relative to a movable frame.
* **Bug Fixes**
  * Improved removal of expired point clouds so they are cleaned up from the correct on-screen container.
  * Camera updates now safely skip invalid frame targets instead of applying an incorrect position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->