### PR TITLE
fix(mola_kernel): guard RawDataSourceBase consumer list against concu…

### DIFF
--- a/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
+++ b/mola_kernel/include/mola_kernel/interfaces/RawDataSourceBase.h
@@ -33,6 +33,8 @@
 #include <mrpt/io/CFileGZOutputStream.h>
 #endif
 
+#include <mutex>
+
 namespace mola
 {
 /** 0-based indices of observations in a dataset */
@@ -93,6 +95,12 @@ class RawDataSourceBase : public mola::ExecutableBase
  private:
   /** Target of captured data */
   std::vector<RawDataConsumer*> rdc_;
+
+  /** Protects rdc_: modules are initialized in PARALLEL threads by
+   * mola_launcher, so two consumers attaching to the same data source race on
+   * this vector.
+   */
+  mutable std::mutex rdc_mtx_;
 
   /** used to optionally export captured observations to an MRPT rawlog */
 #if MRPT_VERSION >= 0x020f07

--- a/mola_kernel/src/interfaces/RawDataSourceBase.cpp
+++ b/mola_kernel/src/interfaces/RawDataSourceBase.cpp
@@ -126,14 +126,22 @@ void RawDataSourceBase::sendObservationsToFrontEnds(const mrpt::obs::CObservatio
   MRPT_TRY_START
 
   ASSERT_(obs);
+  // Snapshot the consumer list under the lock (it may still be growing if
+  // another module is initializing concurrently), then dispatch without holding
+  // the lock so onNewObservation() is not serialized.
+  std::vector<RawDataConsumer*> consumers;
+  {
+    std::lock_guard<std::mutex> lck(rdc_mtx_);
+    consumers = rdc_;
+  }
   // Forward the data to my associated consumer:
-  if (!rdc_.empty())
+  if (!consumers.empty())
   {
     // prepare observation before processing it:
     prepareObservationBeforeFrontEnds(obs);
 
     // Forward data:
-    for (auto& subscriber : rdc_)
+    for (auto& subscriber : consumers)
     {
       subscriber->onNewObservation(obs);
     }
@@ -262,6 +270,9 @@ void RawDataSourceBase::sendObservationsToFrontEnds(const mrpt::obs::CObservatio
 void RawDataSourceBase::attachToDataConsumer(RawDataConsumer& rdc)
 {
   // TODO(jlbc) fix shared_from_this()??
+  // Locked: mola_launcher initializes modules in parallel threads, so two
+  // consumers attaching to the same data source would otherwise race on rdc_.
+  std::lock_guard<std::mutex> lck(rdc_mtx_);
   rdc_.push_back(&rdc);  // rdc.getAsPtr();
 }
 


### PR DESCRIPTION
…rrent attach

mola_launcher initializes modules in parallel threads (executor_thread), so when two consumers subscribe to the SAME raw_data_source (e.g. both LidarOdometry and a mapper module use `raw_data_source: dataset_input`), both call attachToDataConsumer() concurrently and race on the unsynchronized std::vector<RawDataConsumer*> push_back. This corrupted the heap and caused an intermittent SIGSEGV at startup (caught via coredump: _M_realloc_insert into a garbage pointer under RawDataSourceBase::attachToDataConsumer <- FrontEndBase:: initialize <- MolaLauncherApp::executor_thread).

Add a mutex guarding rdc_: lock the push_back, and snapshot the list under the lock in sendObservationsToFrontEnds() before dispatching (dispatch itself runs without the lock so onNewObservation() is not serialized). Validated: 16/16 SharedMapOnly startups on MulRan DCC01 with two consumers, 0 crashes / 0 cores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when multiple components connect to the same data source at the same time.
  * Reduced the risk of race conditions during observation delivery and consumer registration.
  * Made observation dispatch safer by taking a consistent snapshot before notifying consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->