### PR TITLE
feat: add auto-exposed Console log window to MolaVizImGui

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -84,7 +84,7 @@ All plugin modules derive from these virtual base classes:
 - `VizInterface` — visualization (backend-agnostic, updated in v2.6). The
   `mola_viz_imgui` backend auto-exposes a dockable "Console" subwindow that
   aggregates mrpt-logger output from all running modules (gated by the
-  `console_enabled` param).
+  `console_enabled` param, added subsequently).
 - `Relocalization` — global localization / loop closure
 - `OfflineDatasetSource` — offline dataset handling
 - `KeyframeMapCapable` — mixin for keyframe-based metric maps needing per-KF

--- a/agents.md
+++ b/agents.md
@@ -81,7 +81,10 @@ All plugin modules derive from these virtual base classes:
 - `NavStateFilter` — navigation state estimators
 - `LocalizationSourceBase` — localization systems
 - `MapSourceBase` / `MapServer` — map sources/servers
-- `VizInterface` — visualization (backend-agnostic, updated in v2.6)
+- `VizInterface` — visualization (backend-agnostic, updated in v2.6). The
+  `mola_viz_imgui` backend auto-exposes a dockable "Console" subwindow that
+  aggregates mrpt-logger output from all running modules (gated by the
+  `console_enabled` param).
 - `Relocalization` — global localization / loop closure
 - `OfflineDatasetSource` — offline dataset handling
 - `KeyframeMapCapable` — mixin for keyframe-based metric maps needing per-KF

--- a/mola_viz_imgui/CMakeLists.txt
+++ b/mola_viz_imgui/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(3rdparty/imgui_static imgui_static_build)
 
 # -- Module sources -----------------------------------------------------------
 set(LIB_SRCS
+  src/ConsoleLogSink.cpp
   src/MolaVizImGuiCore.cpp
   src/MolaVizImGui_handlers.cpp
   src/MolaVizImGui.cpp

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -336,6 +337,14 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
 
   void dataset_ui_check_new_modules();
   void dataset_ui_update();
+
+  // ---------------------------------------------------------------------------
+  // Console window: log capture from all discovered ExecutableBase modules
+  // ---------------------------------------------------------------------------
+  double                lastTimeCheckForConsoleModules_ = 0;
+  std::set<std::string> consoleHookedModules_;  // instance names already hooked
+
+  void console_check_new_modules();
 };
 
 }  // namespace mola

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -480,13 +480,12 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   // Console window UI state (per instance).
   std::string console_filter_text_;
   bool        console_level_enabled_[4] = {false, true, true, true};  // D,I,W,E
-  int         console_source_combo_     = 0;  // 0 == "all"
   bool        console_autoscroll_       = true;
 
-  // Name resolved from `console_source_combo_` once per frame (empty == "all"),
-  // so every entry filtered that frame -- including the Save path -- is
-  // compared by name rather than by an index into a set that can reorder as
-  // new modules register mid-session.
+  // Selected source filter, keyed by name (empty == "all"), not by an index
+  // into `ConsoleLogSink::sources()` -- that set is sorted and its order
+  // shifts as new modules register mid-session, so an index alone would
+  // silently start pointing at a different source.
   std::string console_selected_source_name_;
 };
 

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -43,6 +44,36 @@ struct GLFWwindow;
 
 namespace mola
 {
+
+/** One captured log line, tagged with its originating module and severity. */
+struct ConsoleLogEntry
+{
+  mrpt::Clock::time_point      timestamp;
+  mrpt::system::VerbosityLevel level = mrpt::system::LVL_INFO;
+  std::string                  source;  // module instance name
+  std::string                  text;  // single line (already split on \n)
+};
+
+/** Thread-safe rolling store of captured log lines, bounded by entry count.
+ *  Shared (shared_ptr) between MolaVizImGuiCore and the per-module logger
+ *  callbacks, so it outlives any module still holding a callback. */
+class ConsoleLogSink
+{
+ public:
+  void                        push(const ConsoleLogEntry& e);
+  std::deque<ConsoleLogEntry> snapshot() const;
+  void                        clear();
+  void                        note_source(const std::string& s);
+  std::vector<std::string>    sources() const;
+
+  std::atomic<size_t> max_entries{5000};
+  std::atomic<double> window_seconds{120.0};
+
+ private:
+  mutable std::mutex          mtx_;
+  std::deque<ConsoleLogEntry> entries_;
+  std::set<std::string>       sources_;
+};
 
 /** Core rendering and state-management logic for the Dear ImGui MOLA viz backend.
  *
@@ -314,6 +345,24 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
    */
   std::string imgui_app_name_ = "default";
 
+  /** Console subwindow: master enable. When false, no log interception and
+   *  the Console window is not shown. */
+  bool console_enabled_ = true;
+
+  /** Max number of captured log entries kept in the rolling buffer. */
+  unsigned int console_max_entries_ = 5000;
+
+  /** Rolling time window (seconds): entries older than this are dropped. */
+  double console_window_seconds_ = 120.0;
+
+  /** Verbosity threshold used when registering module log callbacks.
+   *  Default DEBUG so the UI can reveal all levels. */
+  mrpt::system::VerbosityLevel console_capture_level_ = mrpt::system::LVL_DEBUG;
+
+  /** Sink shared with the per-module logger callbacks; always allocated,
+   *  populated only while `console_enabled_` is true. */
+  std::shared_ptr<ConsoleLogSink> console_sink_ = std::make_shared<ConsoleLogSink>();
+
   /** @} */
 
   // =========================================================================
@@ -402,6 +451,7 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   void render_subwindow(SubWindowState& sw);
   void render_sensor_windows(const window_name_t& parentName, PerWindowData& win);
   void render_console_overlay(PerWindowData& win);
+  void render_console_window(PerWindowData& win);
   void render_widget_description(const mola::gui::WindowDescription& desc, SubWindowState& sw);
   void render_tab(const mola::gui::Tab& tab, const std::string& ctx);
   void render_any_widget(const mola::gui::AnyWidget& w, const std::string& ctx);
@@ -409,6 +459,10 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
 
   void internal_drain_task_queue();
   void internal_handle_decaying_clouds(PerWindowData& win);
+
+  // Console window: filter test shared between on-screen rendering and Save.
+  bool console_entry_passes_filters(const ConsoleLogEntry& e) const;
+  void console_save_to_file();
 
   // Cleanup callbacks registered via register_gui_cleanup().
   std::vector<std::function<void()>> instance_cleanups_;
@@ -422,6 +476,18 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   std::map<std::string, int>         widget_slider_int_vals_;
   std::map<std::string, int>         widget_combo_indices_;
   std::map<uint64_t, std::string>    widget_textpanel_bufs_;
+
+  // Console window UI state (per instance).
+  std::string console_filter_text_;
+  bool        console_level_enabled_[4] = {false, true, true, true};  // D,I,W,E
+  int         console_source_combo_     = 0;  // 0 == "all"
+  bool        console_autoscroll_       = true;
+
+  // Name resolved from `console_source_combo_` once per frame (empty == "all"),
+  // so every entry filtered that frame -- including the Save path -- is
+  // compared by name rather than by an index into a set that can reorder as
+  // new modules register mid-session.
+  std::string console_selected_source_name_;
 };
 
 }  // namespace mola

--- a/mola_viz_imgui/src/ConsoleLogSink.cpp
+++ b/mola_viz_imgui/src/ConsoleLogSink.cpp
@@ -1,0 +1,57 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+/**
+ * @file   ConsoleLogSink.cpp
+ * @brief  Thread-safe rolling store of captured mrpt-logger output.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+
+#include <mola_viz_imgui/MolaVizImGuiCore.h>
+
+using namespace mola;
+
+void ConsoleLogSink::push(const ConsoleLogEntry& e)
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  entries_.push_back(e);
+  sources_.insert(e.source);
+  const size_t cap = max_entries.load();
+  while (entries_.size() > cap)
+  {
+    entries_.pop_front();
+  }
+}
+
+std::deque<ConsoleLogEntry> ConsoleLogSink::snapshot() const
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  return entries_;
+}
+
+void ConsoleLogSink::clear()
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  entries_.clear();
+}
+
+void ConsoleLogSink::note_source(const std::string& s)
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  sources_.insert(s);
+}
+
+std::vector<std::string> ConsoleLogSink::sources() const
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  return {sources_.begin(), sources_.end()};
+}

--- a/mola_viz_imgui/src/ConsoleLogSink.cpp
+++ b/mola_viz_imgui/src/ConsoleLogSink.cpp
@@ -25,6 +25,17 @@ void ConsoleLogSink::push(const ConsoleLogEntry& e)
   std::lock_guard<std::mutex> lk(mtx_);
   entries_.push_back(e);
   sources_.insert(e.source);
+
+  const double maxAge = window_seconds.load();
+  if (maxAge > 0)
+  {
+    const double cutoff = mrpt::Clock::nowDouble() - maxAge;
+    while (!entries_.empty() && mrpt::Clock::toDouble(entries_.front().timestamp) < cutoff)
+    {
+      entries_.pop_front();
+    }
+  }
+
   const size_t cap = max_entries.load();
   while (entries_.size() > cap)
   {

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -29,6 +29,7 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/initializer.h>
+#include <mrpt/system/string_utils.h>
 #include <mrpt/system/thread_name.h>
 
 #include <stdexcept>
@@ -139,6 +140,15 @@ void MolaVizImGui::initialize(const Yaml& c)
   core_ptr_->target_fps_     = cfg.getOrDefault("target_fps", core_ptr_->target_fps_);
   core_ptr_->imgui_app_name_ = cfg.getOrDefault("imgui_app_name", core_ptr_->imgui_app_name_);
 
+  core_ptr_->console_enabled_ = cfg.getOrDefault("console_enabled", core_ptr_->console_enabled_);
+  core_ptr_->console_max_entries_ =
+      cfg.getOrDefault("console_max_entries", core_ptr_->console_max_entries_);
+  core_ptr_->console_window_seconds_ =
+      cfg.getOrDefault("console_window_seconds", core_ptr_->console_window_seconds_);
+
+  core_ptr_->console_sink_->max_entries    = core_ptr_->console_max_entries_;
+  core_ptr_->console_sink_->window_seconds = core_ptr_->console_window_seconds_;
+
   {
     std::lock_guard lk(instanceMtx_);
     instance_ = this;
@@ -168,6 +178,12 @@ void MolaVizImGui::spinOnce()
   {
     dataset_ui_update();
     lastTimeUpdateDatasetUIs_ = tNow;
+  }
+
+  if (core_ptr_->console_enabled_ && tNow - lastTimeCheckForConsoleModules_ > PERIOD_CHECK_NEW_MODS)
+  {
+    console_check_new_modules();
+    lastTimeCheckForConsoleModules_ = tNow;
   }
 }
 
@@ -399,5 +415,50 @@ void MolaVizImGui::dataset_ui_update()
     const size_t N   = mod->datasetUI_size();
     e.lbPlaybackPosition->set(mrpt::format("%zu / %zu", pos, N));
     if (e.liveSliderPos) e.liveSliderPos->set(static_cast<float>(pos));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Console window: log capture from all discovered ExecutableBase modules
+// ---------------------------------------------------------------------------
+
+void MolaVizImGui::console_check_new_modules()
+{
+  auto sink = core_ptr_->console_sink_;
+  if (!sink) return;
+
+  for (auto& module : findService<ExecutableBase>())
+  {
+    if (module.get() == this) continue;  // never hook ourselves (recursion)
+
+    const std::string name = module->getModuleInstanceName();
+    if (consoleHookedModules_.count(name)) continue;
+    consoleHookedModules_.insert(name);
+    sink->note_source(name);
+
+    // Capture all levels for the UI filter; does not change console verbosity.
+    module->setVerbosityLevelForCallbacks(core_ptr_->console_capture_level_);
+
+    // shared_ptr capture keeps the sink alive as long as the module's logger
+    // holds this callback; 'name' (not loggerName) is captured for a stable id.
+    module->logRegisterCallback(
+        [sink, name](
+            std::string_view msg, mrpt::system::VerbosityLevel       level,
+            std::string_view /*loggerName*/, mrpt::Clock::time_point timestamp)
+        {
+          std::vector<std::string> lines;
+          mrpt::system::tokenize(std::string(msg), "\r\n", lines);
+          if (lines.empty()) lines.push_back(std::string(msg));
+
+          for (const auto& line : lines)
+          {
+            ConsoleLogEntry e;
+            e.timestamp = timestamp;
+            e.level     = level;
+            e.source    = name;
+            e.text      = line;
+            sink->push(e);
+          }
+        });
   }
 }

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -20,15 +20,21 @@
 #include <GLFW/glfw3.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
+#include <imgui_stdlib.h>
 #include <mola_viz_imgui/MolaVizImGuiCore.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/lock_helper.h>
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/opengl/CSetOfObjects.h>
+#include <mrpt/system/datetime.h>
+#include <mrpt/system/filesystem.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <stdexcept>
 
 using namespace mola;
@@ -245,6 +251,10 @@ void MolaVizImGuiCore::spin_one_frame(const window_name_t& name)
   }
 
   render_sensor_windows(name, wd);
+  if (console_enabled_)
+  {
+    render_console_window(wd);
+  }
   render_console_overlay(wd);
   internal_handle_decaying_clouds(wd);
 }
@@ -298,6 +308,10 @@ void MolaVizImGuiCore::render_frame(const window_name_t& name, PerWindowData& wd
   }
 
   render_sensor_windows(name, wd);
+  if (console_enabled_)
+  {
+    render_console_window(wd);
+  }
   render_console_overlay(wd);
   internal_handle_decaying_clouds(wd);
 
@@ -447,6 +461,155 @@ void MolaVizImGuiCore::render_console_overlay(PerWindowData& wd)
   }
 
   ImGui::End();
+}
+
+namespace
+{
+ImVec4 color_for_level(mrpt::system::VerbosityLevel level)
+{
+  switch (level)
+  {
+    case mrpt::system::LVL_DEBUG:
+      return ImVec4(0.6f, 0.6f, 0.6f, 1.0f);
+    case mrpt::system::LVL_WARN:
+      return ImVec4(1.0f, 0.85f, 0.3f, 1.0f);
+    case mrpt::system::LVL_ERROR:
+      return ImVec4(1.0f, 0.4f, 0.4f, 1.0f);
+    case mrpt::system::LVL_INFO:
+    default:
+      return ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
+  }
+}
+
+bool contains_ci(std::string_view hay, std::string_view needle)
+{
+  auto to_lower = [](std::string_view s)
+  {
+    std::string r(s);
+    std::transform(r.begin(), r.end(), r.begin(), [](unsigned char c) { return std::tolower(c); });
+    return r;
+  };
+  return to_lower(hay).find(to_lower(needle)) != std::string::npos;
+}
+
+std::string format_console_line(const ConsoleLogEntry& e)
+{
+  mrpt::system::TTimeParts parts;
+  mrpt::system::timestampToParts(e.timestamp, parts, /*localTime=*/true);
+  const unsigned int millisec =
+      static_cast<unsigned int>((parts.second - static_cast<unsigned int>(parts.second)) * 1000);
+  return mrpt::format(
+      "[%02u:%02u:%02u.%03u] [%s] %s", parts.hour, parts.minute,
+      static_cast<unsigned int>(parts.second), millisec, e.source.c_str(), e.text.c_str());
+}
+}  // namespace
+
+bool MolaVizImGuiCore::console_entry_passes_filters(const ConsoleLogEntry& e) const
+{
+  const double now    = mrpt::Clock::nowDouble();
+  const double maxAge = console_window_seconds_;
+  if (maxAge > 0 && now - mrpt::Clock::toDouble(e.timestamp) > maxAge) return false;
+
+  if (!console_level_enabled_[static_cast<int>(e.level)]) return false;
+
+  if (!console_selected_source_name_.empty() && e.source != console_selected_source_name_)
+    return false;
+
+  if (!console_filter_text_.empty() && !contains_ci(e.text, console_filter_text_) &&
+      !contains_ci(e.source, console_filter_text_))
+    return false;
+
+  return true;
+}
+
+void MolaVizImGuiCore::console_save_to_file()
+{
+  const std::string fname = "mola_console_" +
+                            mrpt::system::fileNameStripInvalidChars(
+                                mrpt::system::dateTimeLocalToString(mrpt::Clock::now())) +
+                            ".txt";
+
+  std::ofstream f(fname);
+  if (!f)
+  {
+    MRPT_LOG_ERROR_STREAM("Console: could not open '" << fname << "' for writing.");
+    return;
+  }
+
+  for (const auto& e : console_sink_->snapshot())
+  {
+    if (!console_entry_passes_filters(e)) continue;
+    f << format_console_line(e) << "\n";
+  }
+  MRPT_LOG_INFO_STREAM("Console: saved log to '" << fname << "'.");
+}
+
+void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
+{
+  if (!console_sink_) return;
+
+  ImGui::SetNextWindowSize(ImVec2(700, 300), ImGuiCond_FirstUseEver);
+  if (!ImGui::Begin("Console"))
+  {
+    ImGui::End();
+    return;
+  }
+
+  // ---- Toolbar row --------------------------------------------------------
+  if (ImGui::SmallButton("Clear")) console_sink_->clear();
+  ImGui::SameLine();
+  const bool wantSave = ImGui::SmallButton("Save");
+  ImGui::SameLine();
+
+  ImGui::SetNextItemWidth(180);
+  ImGui::InputTextWithHint("##filter", "Filter (substring)", &console_filter_text_);
+  ImGui::SameLine();
+
+  const std::vector<std::string> srcs = console_sink_->sources();
+  std::vector<const char*>       items;
+  items.push_back("all");
+  for (const auto& s : srcs) items.push_back(s.c_str());
+  if (console_source_combo_ >= static_cast<int>(items.size())) console_source_combo_ = 0;
+  ImGui::SetNextItemWidth(160);
+  ImGui::Combo("Source", &console_source_combo_, items.data(), static_cast<int>(items.size()));
+  console_selected_source_name_ =
+      console_source_combo_ > 0 ? srcs[static_cast<size_t>(console_source_combo_ - 1)] : "";
+  ImGui::SameLine();
+
+  ImGui::TextUnformatted("Levels:");
+  ImGui::SameLine();
+  ImGui::Checkbox("D", &console_level_enabled_[0]);
+  ImGui::SameLine();
+  ImGui::Checkbox("I", &console_level_enabled_[1]);
+  ImGui::SameLine();
+  ImGui::Checkbox("W", &console_level_enabled_[2]);
+  ImGui::SameLine();
+  ImGui::Checkbox("E", &console_level_enabled_[3]);
+  ImGui::SameLine();
+  ImGui::Checkbox("Autoscroll", &console_autoscroll_);
+
+  ImGui::Separator();
+
+  // ---- Log area -------------------------------------------------------------
+  ImGui::BeginChild("##log", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+
+  for (const auto& e : console_sink_->snapshot())
+  {
+    if (!console_entry_passes_filters(e)) continue;
+
+    const ImVec4 col = color_for_level(e.level);
+    ImGui::PushStyleColor(ImGuiCol_Text, col);
+    ImGui::TextUnformatted(format_console_line(e).c_str());
+    ImGui::PopStyleColor();
+  }
+
+  if (console_autoscroll_ && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
+    ImGui::SetScrollHereY(1.0f);
+
+  ImGui::EndChild();
+  ImGui::End();
+
+  if (wantSave) console_save_to_file();
 }
 
 void MolaVizImGuiCore::render_subwindow(SubWindowState& sw)

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -569,11 +569,23 @@ void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
   std::vector<const char*>       items;
   items.push_back("all");
   for (const auto& s : srcs) items.push_back(s.c_str());
-  if (console_source_combo_ >= static_cast<int>(items.size())) console_source_combo_ = 0;
+
+  // Re-derive the combo index from the selected *name* every frame, since
+  // `srcs` is a sorted set whose order shifts as new modules register --
+  // an index alone would silently start pointing at a different source.
+  int selCombo = 0;
+  if (!console_selected_source_name_.empty())
+  {
+    const auto it = std::find(srcs.begin(), srcs.end(), console_selected_source_name_);
+    if (it != srcs.end())
+      selCombo = static_cast<int>(it - srcs.begin()) + 1;
+    else
+      console_selected_source_name_.clear();
+  }
+
   ImGui::SetNextItemWidth(160);
-  ImGui::Combo("Source", &console_source_combo_, items.data(), static_cast<int>(items.size()));
-  console_selected_source_name_ =
-      console_source_combo_ > 0 ? srcs[static_cast<size_t>(console_source_combo_ - 1)] : "";
+  if (ImGui::Combo("Source", &selCombo, items.data(), static_cast<int>(items.size())))
+    console_selected_source_name_ = selCombo > 0 ? srcs[static_cast<size_t>(selCombo - 1)] : "";
   ImGui::SameLine();
 
   ImGui::TextUnformatted("Levels:");


### PR DESCRIPTION
## Summary
- Adds a dockable "Console" subwindow to the `mola_viz_imgui` backend that aggregates `mrpt`-logger output from all running `ExecutableBase` modules (auto-discovered), Chrome-DevTools-style: toolbar (filter box, source selector, per-level checkboxes, Clear/Save) + scrolling colored log area.
- Log capture is done by injecting an `output_logger_callback_t` into each module's `COutputLogger` and widening its callback verbosity to DEBUG (console output verbosity is untouched); entries land in a thread-safe rolling buffer (`ConsoleLogSink`) bounded by both max entry count and max age.
- Gated by new params: `console_enabled` (default true), `console_max_entries` (default 5000), `console_window_seconds` (default 120).
- Save button writes the currently-filtered entries to an auto-named file in CWD.

## Test plan
- [x] `colcon build --packages-select mola_viz_imgui` — clean build
- [x] Ran `mola-lo-gui-kitti 04` (with GUI, under `timeout`) end-to-end through the full 271-scan sequence — no crashes, GUI came up normally, log shows no errors/exceptions
- [x] Independent review pass caught a source-filter index-stability bug (fixed: filter by resolved source name instead of a re-sorted index)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dockable in-app **Console** view that aggregates live log output from running modules.
  * Logs are captured automatically, stored in a rolling history (bounded by time and count), and can be filtered by source, verbosity level, and case-insensitive text.
  * Console UI includes **Clear**, **Save to file**, and **auto-scroll** controls.
* **Documentation**
  * Expanded visualization interface documentation to describe the Console window behavior and configuration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->