### PR TITLE
Keyframe map regrouping + optional KD-tree persistence (localization-only speedups)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -132,6 +132,26 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   `.ini` file, using `OptionsCapable` generically for classes in this library, plus a
   `dynamic_cast`-based fallback in `include/mola_metric_maps/OptionsIniIO.h` for basic
   `mrpt::maps` classes (`CPointsMap`-derived, `COccupancyGridMap2D`).
+- CLI tool `mm-kf-regroup` (in `apps/`): offline optimization of a `KeyframePointCloudMap`
+  layer for fast **localization-only** operation. It groups many small keyframes into a few
+  larger, deliberately-overlapping "super-keyframes" so the ICP active set stays size 1 (no
+  per-scan keyframe switching). Backed by `KeyframePointCloudMap::regroupKeyframes()`
+  (see `RegroupParams`): builds a keyframe adjacency graph with voxel Jaccard-min overlap
+  edge weights, then greedy overlapping set-cover clustering auto-sized from each keyframe's
+  bounding box (large outdoors, small indoors). Merged clouds are voxel-decimated
+  (`--decimate-voxel`, view-direction fields carried) to bound the overlap-induced point
+  blow-up. On a 1000-KF outdoor map this yields ~5 super-KFs. This is "idea 1" of the
+  keyframe-map persistence plan.
+- CLI tool `mm-kf-bake-kdtrees` (in `apps/`): "idea 2" of the same plan. Caches each
+  keyframe's per-cloud 3D KD-tree index inside the `.mm` so it is not rebuilt on every load
+  (faster localization-only startup). Backed by the `serialize_kdtrees` creationOption of
+  `KeyframePointCloudMap` (default false; bumps map serialization to v2, writing a
+  self-describing per-KF flag byte + KD-tree blob). Requires the MRPT KD-tree save/load
+  index API (`mrpt::math::KDTreeCapable::kdtree_save_index_3D()` / `kdtree_load_index_3D()`,
+  feature-detected via the `MRPT_HAS_KDTREE_SAVE_LOAD_INDEX` macro); when absent the option
+  is a no-op on write and the reader skips any stored blob, so `.mm` files stay
+  interoperable across MRPT builds. On the 5-super-KF outdoor map above (9.4M points),
+  baking adds ~58 MB of index data and the load path installs the indices with no rebuild.
 
 ---
 

--- a/mola_metric_maps/apps/CMakeLists.txt
+++ b/mola_metric_maps/apps/CMakeLists.txt
@@ -1,3 +1,5 @@
 # Apps:
 add_subdirectory(mm2ini)
 add_subdirectory(ini2mm)
+add_subdirectory(mm-kf-regroup)
+add_subdirectory(mm-kf-bake-kdtrees)

--- a/mola_metric_maps/apps/kf_cli_utils.h
+++ b/mola_metric_maps/apps/kf_cli_utils.h
@@ -79,6 +79,12 @@ inline size_t forEachKeyframeMapLayer(
         const std::string&, const mola::KeyframePointCloudMap::Ptr&, mrpt::maps::CMetricMap::Ptr&)>&
         fn)
 {
+  // Distinguish "requested layer absent" from "no keyframe layers at all".
+  if (!layerName.empty() && mm.layers.find(layerName) == mm.layers.end())
+  {
+    throw std::runtime_error("Layer '" + layerName + "' not found in the input map.");
+  }
+
   size_t numProcessed = 0;
   for (auto& [name, layer] : mm.layers)
   {

--- a/mola_metric_maps/apps/kf_cli_utils.h
+++ b/mola_metric_maps/apps/kf_cli_utils.h
@@ -1,0 +1,117 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   kf_cli_utils.h
+ * @brief  Shared helpers for the KeyframePointCloudMap CLI tools (mm-kf-regroup,
+ *         mm-kf-bake-kdtrees): plugin loading, map loading, and iteration over
+ *         KeyframePointCloudMap layers.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 2, 2026
+ */
+#pragma once
+
+#include <mola_metric_maps/KeyframePointCloudMap.h>
+#include <mp2p_icp/metricmap.h>
+#include <mrpt/maps/CMetricMap.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
+
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace mola::kf_cli
+{
+/// Loads one or more comma-separated *.so plugin modules (no-op if empty).
+inline void loadPlugins(const std::string& plugins)
+{
+  if (plugins.empty())
+  {
+    return;
+  }
+  std::string errMsg;
+  std::cout << "Loading plugin(s): " << plugins << std::endl;
+  if (!mrpt::system::loadPluginModules(plugins, errMsg))
+  {
+    throw std::runtime_error(errMsg);
+  }
+}
+
+/// Loads plugins (if any) and reads a `.mm` metric map from disk. `tag` is a
+/// short tool name used to prefix log lines.
+inline mp2p_icp::metric_map_t loadMap(
+    const std::string& input, const std::string& plugins, const std::string& tag)
+{
+  loadPlugins(plugins);
+
+  ASSERT_FILE_EXISTS_(input);
+
+  std::cout << "[" << tag << "] Reading input map from: '" << input << "'..." << std::endl;
+
+  mp2p_icp::metric_map_t mm;
+  mm.load_from_file(input);
+  return mm;
+}
+
+/// Invokes `fn(layerName, kfMap, layerSlot)` for every `KeyframePointCloudMap`
+/// layer of `mm`. `layerSlot` is a mutable reference to the layer pointer in
+/// `mm.layers`, so callers can replace the layer in place if needed.
+///
+/// If `layerName` is non-empty, only that layer is processed and it is an error
+/// (throws) if it exists but is not a `KeyframePointCloudMap`. If `layerName` is
+/// empty, non-matching layers are silently skipped.
+///
+/// Returns the number of layers processed.
+inline size_t forEachKeyframeMapLayer(
+    mp2p_icp::metric_map_t& mm, const std::string& layerName,
+    const std::function<void(
+        const std::string&, const mola::KeyframePointCloudMap::Ptr&, mrpt::maps::CMetricMap::Ptr&)>&
+        fn)
+{
+  size_t numProcessed = 0;
+  for (auto& [name, layer] : mm.layers)
+  {
+    if (!layer)
+    {
+      continue;
+    }
+    if (!layerName.empty() && name != layerName)
+    {
+      continue;
+    }
+
+    auto kfMap = std::dynamic_pointer_cast<mola::KeyframePointCloudMap>(layer);
+    if (!kfMap)
+    {
+      if (!layerName.empty())
+      {
+        throw std::runtime_error(
+            "Layer '" + name + "' is not a mola::KeyframePointCloudMap (it is a '" +
+            layer->GetRuntimeClass()->className + "').");
+      }
+      continue;  // silently skip non-matching layers when processing all
+    }
+
+    fn(name, kfMap, layer);
+    numProcessed++;
+  }
+
+  if (numProcessed == 0)
+  {
+    throw std::runtime_error(
+        "No mola::KeyframePointCloudMap layer was found/processed in the input map.");
+  }
+  return numProcessed;
+}
+}  // namespace mola::kf_cli

--- a/mola_metric_maps/apps/mm-kf-bake-kdtrees/CMakeLists.txt
+++ b/mola_metric_maps/apps/mm-kf-bake-kdtrees/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(mm-kf-bake-kdtrees)
+
+find_package(CLI11 REQUIRED)
+
+mola_add_executable(
+  TARGET ${PROJECT_NAME}
+  SOURCES
+    main.cpp
+  LINK_LIBRARIES
+    mola_metric_maps
+    CLI11::CLI11
+)

--- a/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
@@ -1,0 +1,156 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   mm-kf-bake-kdtrees/main.cpp
+ * @brief  CLI tool to bake the per-keyframe KD-tree indices into a .mm file so
+ *         they do not have to be rebuilt every time the map is loaded (fast
+ *         localization-only startup).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 2, 2026
+ */
+
+#include <mola_metric_maps/KeyframePointCloudMap.h>
+#include <mp2p_icp/metricmap.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
+
+#include <CLI/CLI.hpp>
+#include <iostream>
+#include <stdexcept>
+
+namespace
+{
+struct Args
+{
+  std::string input;
+  std::string output;
+  std::string layer;  // empty: process all KeyframePointCloudMap layers
+  std::string plugins;
+  bool        disable = false;  // if set, strip cached kd-trees instead of adding them
+};
+
+void run_bake(const Args& args)
+{
+  if (!args.plugins.empty())
+  {
+    std::string errMsg;
+    std::cout << "Loading plugin(s): " << args.plugins << std::endl;
+    if (!mrpt::system::loadPluginModules(args.plugins, errMsg))
+    {
+      throw std::runtime_error(errMsg);
+    }
+  }
+
+  ASSERT_FILE_EXISTS_(args.input);
+
+  std::cout << "[mm-kf-bake-kdtrees] Reading input map from: '" << args.input << "'..."
+            << std::endl;
+
+  mp2p_icp::metric_map_t mm;
+  mm.load_from_file(args.input);
+
+  size_t numProcessed = 0;
+  for (auto& [layerName, layer] : mm.layers)
+  {
+    if (!layer)
+    {
+      continue;
+    }
+    if (!args.layer.empty() && layerName != args.layer)
+    {
+      continue;
+    }
+
+    auto kfMap = std::dynamic_pointer_cast<mola::KeyframePointCloudMap>(layer);
+    if (!kfMap)
+    {
+      if (!args.layer.empty())
+      {
+        throw std::runtime_error(
+            "Layer '" + layerName + "' is not a mola::KeyframePointCloudMap (it is a '" +
+            layer->GetRuntimeClass()->className + "').");
+      }
+      continue;  // silently skip non-matching layers when processing all
+    }
+
+    kfMap->creationOptions.serialize_kdtrees = !args.disable;
+    std::cout << "[mm-kf-bake-kdtrees] Layer '" << layerName << "': serialize_kdtrees -> "
+              << (kfMap->creationOptions.serialize_kdtrees ? "true" : "false")
+              << " (KD-trees are (re)built on save only if not already current)." << std::endl;
+    numProcessed++;
+  }
+
+  if (numProcessed == 0)
+  {
+    throw std::runtime_error(
+        "No mola::KeyframePointCloudMap layer was found/processed in the input map.");
+  }
+
+  std::cout << "[mm-kf-bake-kdtrees] Writing output map to: '" << args.output << "'..."
+            << std::endl;
+  if (!mm.save_to_file(args.output))
+  {
+    throw std::runtime_error("Error writing output map file: '" + args.output + "'");
+  }
+
+  std::cout << "[mm-kf-bake-kdtrees] Done. Processed " << numProcessed << " layer(s)." << std::endl;
+}
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  try
+  {
+    CLI::App cli{
+        "mm-kf-bake-kdtrees: cache the per-keyframe KD-tree indices inside a .mm file so they "
+        "are not rebuilt on every load (fast localization-only startup)"};
+
+    Args args;
+
+    cli.add_option("-i,--input", args.input, "Input metric map file (*.mm)")
+        ->required()
+        ->check(CLI::ExistingFile);
+
+    cli.add_option("-o,--output", args.output, "Output metric map file (*.mm)")->required();
+
+    cli.add_option(
+        "--layer", args.layer,
+        "Name of the KeyframePointCloudMap layer to process. If omitted, all such layers are "
+        "processed.");
+
+    cli.add_flag(
+        "--disable", args.disable,
+        "Instead of baking, strip any cached KD-trees (sets serialize_kdtrees=false).");
+
+    cli.add_option(
+        "-l,--load-plugins", args.plugins,
+        "One or more (comma separated) *.so files to load as plugins");
+
+    try
+    {
+      cli.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+      return cli.exit(e);
+    }
+
+    run_bake(args);
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
@@ -21,12 +21,12 @@
 
 #include <mola_metric_maps/KeyframePointCloudMap.h>
 #include <mp2p_icp/metricmap.h>
-#include <mrpt/system/filesystem.h>
-#include <mrpt/system/os.h>
 
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <stdexcept>
+
+#include "../kf_cli_utils.h"
 
 namespace
 {
@@ -41,60 +41,27 @@ struct Args
 
 void run_bake(const Args& args)
 {
-  if (!args.plugins.empty())
+#if !defined(MRPT_HAS_KDTREE_SAVE_LOAD_INDEX)
+  if (!args.disable)
   {
-    std::string errMsg;
-    std::cout << "Loading plugin(s): " << args.plugins << std::endl;
-    if (!mrpt::system::loadPluginModules(args.plugins, errMsg))
-    {
-      throw std::runtime_error(errMsg);
-    }
+    std::cout << "[mm-kf-bake-kdtrees] WARNING: this MRPT build lacks the KD-tree save/load "
+                 "index API; baking is a no-op and no KD-tree data will be written."
+              << std::endl;
   }
+#endif
 
-  ASSERT_FILE_EXISTS_(args.input);
+  mp2p_icp::metric_map_t mm = mola::kf_cli::loadMap(args.input, args.plugins, "mm-kf-bake-kdtrees");
 
-  std::cout << "[mm-kf-bake-kdtrees] Reading input map from: '" << args.input << "'..."
-            << std::endl;
-
-  mp2p_icp::metric_map_t mm;
-  mm.load_from_file(args.input);
-
-  size_t numProcessed = 0;
-  for (auto& [layerName, layer] : mm.layers)
-  {
-    if (!layer)
-    {
-      continue;
-    }
-    if (!args.layer.empty() && layerName != args.layer)
-    {
-      continue;
-    }
-
-    auto kfMap = std::dynamic_pointer_cast<mola::KeyframePointCloudMap>(layer);
-    if (!kfMap)
-    {
-      if (!args.layer.empty())
+  const size_t numProcessed = mola::kf_cli::forEachKeyframeMapLayer(
+      mm, args.layer,
+      [&](const std::string& layerName, const mola::KeyframePointCloudMap::Ptr& kfMap,
+          mrpt::maps::CMetricMap::Ptr& /*layerSlot*/)
       {
-        throw std::runtime_error(
-            "Layer '" + layerName + "' is not a mola::KeyframePointCloudMap (it is a '" +
-            layer->GetRuntimeClass()->className + "').");
-      }
-      continue;  // silently skip non-matching layers when processing all
-    }
-
-    kfMap->creationOptions.serialize_kdtrees = !args.disable;
-    std::cout << "[mm-kf-bake-kdtrees] Layer '" << layerName << "': serialize_kdtrees -> "
-              << (kfMap->creationOptions.serialize_kdtrees ? "true" : "false")
-              << " (KD-trees are (re)built on save only if not already current)." << std::endl;
-    numProcessed++;
-  }
-
-  if (numProcessed == 0)
-  {
-    throw std::runtime_error(
-        "No mola::KeyframePointCloudMap layer was found/processed in the input map.");
-  }
+        kfMap->creationOptions.serialize_kdtrees = !args.disable;
+        std::cout << "[mm-kf-bake-kdtrees] Layer '" << layerName << "': serialize_kdtrees -> "
+                  << (kfMap->creationOptions.serialize_kdtrees ? "true" : "false")
+                  << " (KD-trees are (re)built on save only if not already current)." << std::endl;
+      });
 
   std::cout << "[mm-kf-bake-kdtrees] Writing output map to: '" << args.output << "'..."
             << std::endl;

--- a/mola_metric_maps/apps/mm-kf-regroup/CMakeLists.txt
+++ b/mola_metric_maps/apps/mm-kf-regroup/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(mm-kf-regroup)
+
+find_package(CLI11 REQUIRED)
+
+mola_add_executable(
+  TARGET ${PROJECT_NAME}
+  SOURCES
+    main.cpp
+  LINK_LIBRARIES
+    mola_metric_maps
+    CLI11::CLI11
+)

--- a/mola_metric_maps/apps/mm-kf-regroup/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-regroup/main.cpp
@@ -21,12 +21,12 @@
 
 #include <mola_metric_maps/KeyframePointCloudMap.h>
 #include <mp2p_icp/metricmap.h>
-#include <mrpt/system/filesystem.h>
-#include <mrpt/system/os.h>
 
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <stdexcept>
+
+#include "../kf_cli_utils.h"
 
 namespace
 {
@@ -49,60 +49,18 @@ struct Args
 
 void run_regroup(const Args& args)
 {
-  if (!args.plugins.empty())
-  {
-    std::string errMsg;
-    std::cout << "Loading plugin(s): " << args.plugins << std::endl;
-    if (!mrpt::system::loadPluginModules(args.plugins, errMsg))
-    {
-      throw std::runtime_error(errMsg);
-    }
-  }
-
-  ASSERT_FILE_EXISTS_(args.input);
-
-  std::cout << "[mm-kf-regroup] Reading input map from: '" << args.input << "'..." << std::endl;
-
-  mp2p_icp::metric_map_t mm;
-  mm.load_from_file(args.input);
+  mp2p_icp::metric_map_t mm = mola::kf_cli::loadMap(args.input, args.plugins, "mm-kf-regroup");
 
   const auto logCb = [](const std::string& s) { std::cout << s << std::endl; };
 
-  size_t numProcessed = 0;
-  for (auto& [layerName, layer] : mm.layers)
-  {
-    if (!layer)
-    {
-      continue;
-    }
-    if (!args.layer.empty() && layerName != args.layer)
-    {
-      continue;
-    }
-
-    auto kfMap = std::dynamic_pointer_cast<mola::KeyframePointCloudMap>(layer);
-    if (!kfMap)
-    {
-      if (!args.layer.empty())
+  const size_t numProcessed = mola::kf_cli::forEachKeyframeMapLayer(
+      mm, args.layer,
+      [&](const std::string& layerName, const mola::KeyframePointCloudMap::Ptr& kfMap,
+          mrpt::maps::CMetricMap::Ptr& layerSlot)
       {
-        throw std::runtime_error(
-            "Layer '" + layerName + "' is not a mola::KeyframePointCloudMap (it is a '" +
-            layer->GetRuntimeClass()->className + "').");
-      }
-      continue;  // silently skip non-matching layers when processing all
-    }
-
-    std::cout << "[mm-kf-regroup] Regrouping layer '" << layerName << "'..." << std::endl;
-    auto regrouped = kfMap->regroupKeyframes(args.params, logCb);
-    layer          = regrouped;  // replace the layer in-place
-    numProcessed++;
-  }
-
-  if (numProcessed == 0)
-  {
-    throw std::runtime_error(
-        "No mola::KeyframePointCloudMap layer was found/processed in the input map.");
-  }
+        std::cout << "[mm-kf-regroup] Regrouping layer '" << layerName << "'..." << std::endl;
+        layerSlot = kfMap->regroupKeyframes(args.params, logCb);  // replace the layer in-place
+      });
 
   std::cout << "[mm-kf-regroup] Writing output map to: '" << args.output << "'..." << std::endl;
   if (!mm.save_to_file(args.output))

--- a/mola_metric_maps/apps/mm-kf-regroup/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-regroup/main.cpp
@@ -1,0 +1,183 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   mm-kf-regroup/main.cpp
+ * @brief  CLI tool to regroup the keyframes of a KeyframePointCloudMap layer
+ *         into fewer, larger, overlapping "super-keyframes" for fast
+ *         localization-only operation.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 2, 2026
+ */
+
+#include <mola_metric_maps/KeyframePointCloudMap.h>
+#include <mp2p_icp/metricmap.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
+
+#include <CLI/CLI.hpp>
+#include <iostream>
+#include <stdexcept>
+
+namespace
+{
+struct Args
+{
+  std::string input;
+  std::string output;
+  std::string layer;  // empty: process all KeyframePointCloudMap layers
+  std::string plugins;
+
+  mola::KeyframePointCloudMap::RegroupParams params;
+
+  Args()
+  {
+    // Sensible default for the tool: decimate merged super-keyframes so the
+    // heavy inter-keyframe overlap does not blow up the output size. 0 disables.
+    params.merge_decimate_voxel = 0.2;
+  }
+};
+
+void run_regroup(const Args& args)
+{
+  if (!args.plugins.empty())
+  {
+    std::string errMsg;
+    std::cout << "Loading plugin(s): " << args.plugins << std::endl;
+    if (!mrpt::system::loadPluginModules(args.plugins, errMsg))
+    {
+      throw std::runtime_error(errMsg);
+    }
+  }
+
+  ASSERT_FILE_EXISTS_(args.input);
+
+  std::cout << "[mm-kf-regroup] Reading input map from: '" << args.input << "'..." << std::endl;
+
+  mp2p_icp::metric_map_t mm;
+  mm.load_from_file(args.input);
+
+  const auto logCb = [](const std::string& s) { std::cout << s << std::endl; };
+
+  size_t numProcessed = 0;
+  for (auto& [layerName, layer] : mm.layers)
+  {
+    if (!layer)
+    {
+      continue;
+    }
+    if (!args.layer.empty() && layerName != args.layer)
+    {
+      continue;
+    }
+
+    auto kfMap = std::dynamic_pointer_cast<mola::KeyframePointCloudMap>(layer);
+    if (!kfMap)
+    {
+      if (!args.layer.empty())
+      {
+        throw std::runtime_error(
+            "Layer '" + layerName + "' is not a mola::KeyframePointCloudMap (it is a '" +
+            layer->GetRuntimeClass()->className + "').");
+      }
+      continue;  // silently skip non-matching layers when processing all
+    }
+
+    std::cout << "[mm-kf-regroup] Regrouping layer '" << layerName << "'..." << std::endl;
+    auto regrouped = kfMap->regroupKeyframes(args.params, logCb);
+    layer          = regrouped;  // replace the layer in-place
+    numProcessed++;
+  }
+
+  if (numProcessed == 0)
+  {
+    throw std::runtime_error(
+        "No mola::KeyframePointCloudMap layer was found/processed in the input map.");
+  }
+
+  std::cout << "[mm-kf-regroup] Writing output map to: '" << args.output << "'..." << std::endl;
+  if (!mm.save_to_file(args.output))
+  {
+    throw std::runtime_error("Error writing output map file: '" + args.output + "'");
+  }
+
+  std::cout << "[mm-kf-regroup] Done. Processed " << numProcessed << " layer(s)." << std::endl;
+}
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  try
+  {
+    CLI::App cli{
+        "mm-kf-regroup: group the keyframes of a KeyframePointCloudMap into fewer, larger, "
+        "overlapping super-keyframes for fast localization-only operation"};
+
+    Args args;
+
+    cli.add_option("-i,--input", args.input, "Input metric map file (*.mm)")
+        ->required()
+        ->check(CLI::ExistingFile);
+
+    cli.add_option("-o,--output", args.output, "Output metric map file (*.mm)")->required();
+
+    cli.add_option(
+        "--layer", args.layer,
+        "Name of the KeyframePointCloudMap layer to process. If omitted, all such layers are "
+        "processed.");
+
+    cli.add_option(
+        "--voxel-size", args.params.voxel_size,
+        "Voxel resolution [m] used to compute keyframe overlaps. <=0: auto (default).");
+
+    cli.add_option(
+           "--edge-overlap", args.params.edge_overlap,
+           "Min pairwise voxel-overlap [0..1] to link two keyframes in the graph.")
+        ->check(CLI::Range(0.0, 1.0));
+
+    cli.add_option(
+           "--core-fraction", args.params.core_fraction,
+           "Inner-core fraction (0..1] of a super-keyframe extent within which members are marked "
+           "covered. Smaller => more inter-group overlap.")
+        ->check(CLI::Range(0.0, 1.0));
+
+    cli.add_option(
+           "--extent-factor", args.params.extent_factor,
+           "Super-keyframe spatial extent cap, as a multiple of the seed keyframe sensing radius.")
+        ->check(CLI::PositiveNumber);
+
+    cli.add_option(
+        "--decimate-voxel", args.params.merge_decimate_voxel,
+        "If >0, voxel-downsample [m] each merged super-keyframe cloud to bound its size.");
+
+    cli.add_option(
+        "-l,--load-plugins", args.plugins,
+        "One or more (comma separated) *.so files to load as plugins");
+
+    try
+    {
+      cli.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+      return cli.exit(e);
+    }
+
+    run_regroup(args);
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -32,6 +32,7 @@
 #include <mrpt/math/TBoundingBox.h>
 #include <mrpt/opengl/opengl_frwds.h>
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <vector>
@@ -258,6 +259,53 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
 
   /** @} */
 
+  /** @name Offline keyframe regrouping (localization-oriented map optimization)
+   *  @{ */
+
+  /** Parameters for regroupKeyframes(). */
+  struct RegroupParams
+  {
+    /** Voxel resolution [m] used to compute pairwise cloud overlaps. If <=0, it
+     *  is auto-derived from the median per-keyframe sensing radius. */
+    double voxel_size = 0;
+
+    /** Minimum pairwise voxel-overlap (Jaccard-min, in [0,1]) required to create
+     *  an edge in the keyframe adjacency graph, i.e. for two keyframes to be
+     *  candidates for merging into the same super-keyframe. */
+    double edge_overlap = 0.15;
+
+    /** Inner-core fraction, in (0,1], of a super-keyframe's spatial extent. A member
+     *  keyframe whose center lies within `core_fraction * extent` of the seed is
+     *  marked "covered" (deep inside, single-KF localization is reliable there).
+     *  Members in the outer band stay available to seed/join neighboring
+     *  super-keyframes, which is what produces the deliberate inter-group overlap. */
+    double core_fraction = 0.6;
+
+    /** Spatial extent cap of a super-keyframe, as a multiple of the seed keyframe's
+     *  own sensing radius (half its cloud bounding-box diagonal). This auto-sizes
+     *  groups non-uniformly: large outdoors (long range), small indoors. */
+    double extent_factor = 2.0;
+
+    /** If >0, voxel-downsample each merged super-keyframe cloud at this resolution
+     *  [m] to bound the point-count blow-up from the deliberate overlap. This is
+     *  strongly recommended for large maps. Per-point view-direction fields, when
+     *  present, are carried over (first point kept per voxel). */
+    double merge_decimate_voxel = 0;
+  };
+
+  /** Builds a NEW map whose keyframes are "super-keyframes": spatially coherent
+   *  groups of the original keyframes, merged into single larger clouds with
+   *  deliberate overlap, so that localization only needs ONE active keyframe at a
+   *  time (see \ref RegroupParams and the graph-theoretic grouping in the .cpp).
+   *  All options (creation/insertion/likelihood/render) are copied from `*this`.
+   *  Thread-safe (reads `*this` under its lock). `logCb`, if set, receives
+   *  human-readable progress lines.
+   */
+  [[nodiscard]] std::shared_ptr<KeyframePointCloudMap> regroupKeyframes(
+      const RegroupParams& params, const std::function<void(const std::string&)>& logCb = {}) const;
+
+  /** @} */
+
   /** Options for insertObservation()
    */
   struct TInsertionOptions : public mrpt::config::CLoadableOptions
@@ -408,6 +456,16 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      *  is `true` and the view fields are present.  Default: 120°.
      */
     double max_view_angle_deg = 120.0;
+
+    /** If `true`, each keyframe's per-cloud 3D KD-tree index is serialized
+     *  alongside its points (see `KeyframePointCloudMap` serialization), so it
+     *  does NOT have to be rebuilt when the map is loaded. This trades a larger
+     *  `.mm` file for faster startup in localization-only use. Requires an MRPT
+     *  build providing the KD-tree save/load API (feature-detected at compile
+     *  time); when unavailable this option is silently a no-op on write. Default
+     *  `false`. Typically enabled offline by the `mm-kf-bake-kdtrees` tool.
+     */
+    bool serialize_kdtrees = false;
   };
   TCreationOptions creationOptions;
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -39,7 +39,11 @@
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 #include <mrpt/version.h>  // For MRPT_VERSION
 
+#include <cmath>
+#include <cstdint>
 #include <numeric>  // std::accumulate
+#include <sstream>
+#include <unordered_set>
 
 #if defined(MOLA_METRIC_MAPS_USE_TBB)
 #include <tbb/enumerable_thread_specific.h>
@@ -231,7 +235,7 @@ IMPLEMENTS_SERIALIZABLE(KeyframePointCloudMap, CMetricMap, mola)
 // Serialization
 // =====================================
 
-uint8_t KeyframePointCloudMap::serializeGetVersion() const { return 1; }
+uint8_t KeyframePointCloudMap::serializeGetVersion() const { return 2; }
 void    KeyframePointCloudMap::serializeTo(mrpt::serialization::CArchive& out) const
 {
   auto lck = mrpt::lockHelper(*state_mtx_);
@@ -254,6 +258,28 @@ void    KeyframePointCloudMap::serializeTo(mrpt::serialization::CArchive& out) c
     {
       out.WriteAs<uint8_t>(1);  // has point cloud
       out << *kf.pointcloud();
+
+      // v2: optionally cache the per-cloud 3D KD-tree index so it does not have
+      // to be rebuilt on load. Self-describing (a flag byte precedes any blob),
+      // so readers can skip it regardless of the write-time option or MRPT build.
+      uint8_t     hasKdTree = 0;
+      std::string kdBlob;
+#if defined(MRPT_HAS_KDTREE_SAVE_LOAD_INDEX)
+      if (creationOptions.serialize_kdtrees)
+      {
+        std::ostringstream ss(std::ios::binary);
+        if (kf.pointcloud()->kdtree_save_index_3D(ss))
+        {
+          kdBlob    = ss.str();
+          hasKdTree = 1;
+        }
+      }
+#endif
+      out.WriteAs<uint8_t>(hasKdTree);
+      if (hasKdTree != 0)
+      {
+        out << kdBlob;
+      }
     }
     else
     {
@@ -276,6 +302,7 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
   {
     case 0:
     case 1:
+    case 2:
     {
       // params:
       creationOptions.readFromStream(in);
@@ -306,6 +333,26 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
           auto pc  = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
           ASSERT_(pc);
           kf.pointcloud(pc);
+
+          // v2: optional cached KD-tree index (see serializeTo). Always consume
+          // the flag byte + blob so the stream stays aligned even when this
+          // build cannot install the index.
+          if (version >= 2)
+          {
+            const auto hasKdTree = in.ReadAs<uint8_t>();
+            if (hasKdTree != 0)
+            {
+              std::string kdBlob;
+              in >> kdBlob;
+#if defined(MRPT_HAS_KDTREE_SAVE_LOAD_INDEX)
+              std::istringstream ss(kdBlob, std::ios::binary);
+              // Install the precomputed index so the first query does not rebuild
+              // it. Points were just deserialized above (which marks the tree
+              // outdated), so this must come after kf.pointcloud(pc).
+              pc->kdtree_load_index_3D(ss);
+#endif
+            }
+          }
         }
       }
 
@@ -1139,6 +1186,414 @@ const mrpt::maps::CSimplePointsMap* KeyframePointCloudMap::getAsSimplePointsMap(
 }
 
 // ==========================
+//   Keyframe regrouping
+// ==========================
+
+namespace
+{
+/// Packs a voxel coordinate triplet into a single 64-bit key. Uses 21 bits per
+/// axis with a large centering offset, covering ~ +/-1e6 voxels per axis.
+inline int64_t voxelKey(float x, float y, float z, double inv_voxel)
+{
+  constexpr int64_t kOffset = 1 << 20;  // center the range around 0
+  const auto        q       = [inv_voxel](float c)
+  { return static_cast<int64_t>(std::floor(static_cast<double>(c) * inv_voxel)) + kOffset; };
+  const int64_t ix = q(x);
+  const int64_t iy = q(y);
+  const int64_t iz = q(z);
+  return (ix << 42) | (iy << 21) | iz;
+}
+
+using VoxelSet = std::unordered_set<int64_t>;
+
+VoxelSet cloudToVoxelSet(const mrpt::maps::CPointsMap& pc, double inv_voxel)
+{
+  VoxelSet    s;
+  const auto& xs = pc.getPointsBufferRef_x();
+  const auto& ys = pc.getPointsBufferRef_y();
+  const auto& zs = pc.getPointsBufferRef_z();
+  s.reserve(xs.size());
+  for (size_t i = 0; i < xs.size(); i++)
+  {
+    s.insert(voxelKey(xs[i], ys[i], zs[i], inv_voxel));
+  }
+  return s;
+}
+
+/// Jaccard-min overlap: |A ∩ B| / min(|A|,|B|), in [0,1].
+double voxelOverlap(const VoxelSet& a, const VoxelSet& b)
+{
+  if (a.empty() || b.empty())
+  {
+    return 0;
+  }
+  const VoxelSet& small = a.size() <= b.size() ? a : b;
+  const VoxelSet& large = a.size() <= b.size() ? b : a;
+  size_t          inter = 0;
+  for (const auto k : small)
+  {
+    if (large.count(k) != 0)
+    {
+      inter++;
+    }
+  }
+  return static_cast<double>(inter) / static_cast<double>(small.size());
+}
+
+/// Builds one super-keyframe's cloud, expressed in the anchor (seed) LOCAL
+/// frame, by merging the GLOBAL clouds of all `members` (indices into
+/// `globals`), optionally voxel-decimating to bound the overlap-induced point
+/// blow-up, and finally rotating into the anchor frame. View-direction fields
+/// are carried and re-rotated when present in the seed cloud.
+mrpt::maps::CPointsMap::Ptr buildSuperKeyframeCloud(
+    const std::vector<size_t>& members, const std::vector<mrpt::maps::CPointsMap::Ptr>& globals,
+    const mrpt::poses::CPose3D& anchorPose, double decimateVoxel)
+{
+  const auto& seedGlobal = globals[members.front()];
+  const bool  hasView    = (seedGlobal->getPointsBufferRef_float_field("view_x") != nullptr) &&
+                       (seedGlobal->getPointsBufferRef_float_field("view_y") != nullptr) &&
+                       (seedGlobal->getPointsBufferRef_float_field("view_z") != nullptr);
+
+  const auto makeCloud = [hasView]() -> mrpt::maps::CPointsMap::Ptr
+  {
+    if (hasView)
+    {
+      auto gpc = mrpt::maps::CGenericPointsMap::Create();
+      gpc->registerField_float("view_x");
+      gpc->registerField_float("view_y");
+      gpc->registerField_float("view_z");
+      return gpc;
+    }
+    return mrpt::maps::CSimplePointsMap::Create();
+  };
+
+  // Merge all member clouds in the GLOBAL frame (view fields already global).
+  // When decimation is requested and the clouds carry no custom fields, fold the
+  // voxel-dedup INTO the merge, so we never materialize the (potentially
+  // enormous) fully-overlapped intermediate cloud. This is what keeps the tool
+  // tractable on large maps where each super-keyframe absorbs hundreds of
+  // heavily-overlapping keyframes.
+  mrpt::maps::CPointsMap::Ptr mergedGlobal = makeCloud();
+
+  const bool decimate = decimateVoxel > 0;
+  if (decimate)
+  {
+    // Voxel-dedup folded into the merge, carrying view_{x,y,z} (global frame)
+    // for the first point kept in each voxel when present.
+    const double                dinv = 1.0 / decimateVoxel;
+    std::unordered_set<int64_t> seen;
+    for (const size_t mIdx : members)
+    {
+      const auto& g  = globals[mIdx];
+      const auto& xs = g->getPointsBufferRef_x();
+      const auto& ys = g->getPointsBufferRef_y();
+      const auto& zs = g->getPointsBufferRef_z();
+
+      const mrpt::aligned_std_vector<float>* vx = nullptr;
+      const mrpt::aligned_std_vector<float>* vy = nullptr;
+      const mrpt::aligned_std_vector<float>* vz = nullptr;
+      if (hasView)
+      {
+        vx = g->getPointsBufferRef_float_field("view_x");
+        vy = g->getPointsBufferRef_float_field("view_y");
+        vz = g->getPointsBufferRef_float_field("view_z");
+      }
+
+      for (size_t i = 0; i < xs.size(); i++)
+      {
+        if (!seen.insert(voxelKey(xs[i], ys[i], zs[i], dinv)).second)
+        {
+          continue;
+        }
+        mergedGlobal->insertPointFast(xs[i], ys[i], zs[i]);
+        if (hasView && vx != nullptr && vy != nullptr && vz != nullptr)
+        {
+          mergedGlobal->insertPointField_float("view_x", (*vx)[i]);
+          mergedGlobal->insertPointField_float("view_y", (*vy)[i]);
+          mergedGlobal->insertPointField_float("view_z", (*vz)[i]);
+        }
+      }
+    }
+    mergedGlobal->mark_as_modified();
+  }
+  else
+  {
+    for (const size_t mIdx : members)
+    {
+      const auto& g = globals[mIdx];
+#if MRPT_VERSION >= 0x020f0b  // 2.15.11
+      mergedGlobal->insertAnotherMap(
+          g.get(), mrpt::poses::CPose3D::Identity(), false /*filterOutPointsAtZero*/,
+          false /*autoRegisterAllSourceFields*/);
+#else
+      mergedGlobal->insertAnotherMap(g.get(), mrpt::poses::CPose3D::Identity());
+#endif
+    }
+  }
+
+  // Express the merged cloud in the anchor (seed) local frame.
+  // (Identity - anchorPose) == anchorPose^{-1}.
+  const mrpt::poses::CPose3D anchorInv = mrpt::poses::CPose3D::Identity() - anchorPose;
+
+  mrpt::maps::CPointsMap::Ptr localCloud = makeCloud();
+#if MRPT_VERSION >= 0x020f0b  // 2.15.11
+  localCloud->insertAnotherMap(
+      mergedGlobal.get(), anchorInv, false /*filterOutPointsAtZero*/,
+      false /*autoRegisterAllSourceFields*/);
+#else
+  localCloud->insertAnotherMap(mergedGlobal.get(), anchorInv);
+#endif
+  // insertAnotherMap copies the (still global-frame) view vectors verbatim;
+  // rotate them into the anchor-local frame to satisfy the KF contract.
+  if (hasView)
+  {
+#if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
+    rotateViewDirectionFieldsOrFallback(*localCloud, anchorInv);
+#else
+    rotateViewDirectionFieldsLegacy(*localCloud, anchorInv);
+#endif
+  }
+
+  return localCloud;
+}
+}  // namespace
+
+std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
+    const RegroupParams& params, const std::function<void(const std::string&)>& logCb) const
+{
+  auto lck = mrpt::lockHelper(*state_mtx_);
+
+  const auto log = [&](const std::string& s)
+  {
+    if (logCb)
+    {
+      logCb(s);
+    }
+  };
+
+  // ---- 1) Collect keyframes that actually hold a (non-empty) cloud ----
+  struct KFInfo
+  {
+    KeyFrameID              id = 0;
+    mrpt::math::TPoint3D    center;  // global sensing-sphere center
+    double                  radius = 0;  // global sensing radius (half bbox diagonal)
+    mrpt::poses::CPose3D    pose;  // keyframe pose in the map frame
+    mrpt::Clock::time_point timestamp;
+  };
+  std::vector<KFInfo>                      kfs;
+  std::vector<mrpt::maps::CPointsMap::Ptr> globals;  // parallel to kfs: global-frame clouds
+
+  for (const auto& [id, kf] : keyframes_)
+  {
+    if (!kf.pointcloud() || kf.pointcloud()->empty())
+    {
+      continue;
+    }
+    const auto&                g    = kf.pointcloud_global();
+    const auto                 bbox = g->boundingBox();
+    const mrpt::math::TPoint3D center{
+        0.5 * (bbox.min.x + bbox.max.x), 0.5 * (bbox.min.y + bbox.max.y),
+        0.5 * (bbox.min.z + bbox.max.z)};
+    const double diag = std::sqrt(
+        mrpt::square(bbox.max.x - bbox.min.x) + mrpt::square(bbox.max.y - bbox.min.y) +
+        mrpt::square(bbox.max.z - bbox.min.z));
+    kfs.push_back({id, center, 0.5 * diag, kf.pose(), kf.timestamp});
+    globals.push_back(g);
+  }
+
+  const size_t n = kfs.size();
+
+  auto out               = KeyframePointCloudMap::Create();
+  out->creationOptions   = creationOptions;
+  out->insertionOptions  = insertionOptions;
+  out->likelihoodOptions = likelihoodOptions;
+  out->renderOptions     = renderOptions;
+
+  if (n == 0)
+  {
+    log("[regroup] Input map has no keyframes with clouds; returning empty map.");
+    return out;
+  }
+
+  // ---- 2) Determine the overlap voxel size ----
+  double voxelSize = params.voxel_size;
+  if (voxelSize <= 0)
+  {
+    std::vector<double> radii;
+    radii.reserve(n);
+    for (const auto& k : kfs)
+    {
+      radii.push_back(k.radius);
+    }
+    const auto mid = static_cast<std::ptrdiff_t>(radii.size() / 2);
+    std::nth_element(radii.begin(), radii.begin() + mid, radii.end());
+    const double medianR = radii[radii.size() / 2];
+    voxelSize            = std::clamp(medianR * 0.02, 0.1, 2.0);
+  }
+  const double invVoxel = 1.0 / voxelSize;
+  log(mrpt::format(
+      "[regroup] %zu keyframes with clouds, overlap voxel size = %.3f m", n, voxelSize));
+
+  // ---- 3) Voxelize all clouds (global frame) ----
+  std::vector<VoxelSet> voxels(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    voxels[i] = cloudToVoxelSet(*globals[i], invVoxel);
+  }
+
+  // ---- 4) Build the keyframe adjacency graph (overlap edges) ----
+  // Nodes = keyframes; edge weight = voxel Jaccard-min overlap. Only pairs whose
+  // sensing spheres intersect are considered (broad phase); edges are kept when
+  // their overlap is >= edge_overlap.
+  std::vector<std::vector<std::pair<size_t, double>>> adj(n);
+  size_t                                              numEdges = 0;
+  for (size_t i = 0; i < n; i++)
+  {
+    for (size_t j = i + 1; j < n; j++)
+    {
+      const double d = (kfs[i].center - kfs[j].center).norm();
+      if (d > kfs[i].radius + kfs[j].radius)
+      {
+        continue;  // spheres do not intersect: no possible overlap
+      }
+      const double ov = voxelOverlap(voxels[i], voxels[j]);
+      if (ov < params.edge_overlap)
+      {
+        continue;
+      }
+      adj[i].emplace_back(j, ov);
+      adj[j].emplace_back(i, ov);
+      numEdges++;
+    }
+  }
+  log(mrpt::format(
+      "[regroup] adjacency graph: %zu edges (avg degree %.1f)", numEdges,
+      2.0 * static_cast<double>(numEdges) / static_cast<double>(n)));
+
+  // ---- 5) Greedy overlapping set-cover clustering ----
+  // Seeds are chosen from the densest / most-connected keyframes first. Each
+  // super-keyframe grows by absorbing graph neighbors (highest overlap first)
+  // while staying within the seed's spatial extent cap. A member is marked
+  // "covered" only if it lies within the inner core; boundary members remain
+  // uncovered and thus seed/join neighboring groups -> deliberate overlap.
+  std::vector<bool> covered(n, false);
+
+  std::vector<size_t> order(n);
+  std::iota(order.begin(), order.end(), size_t(0));
+  std::sort(
+      order.begin(), order.end(),
+      [&](size_t a, size_t b)
+      {
+        const double sa =
+            static_cast<double>(voxels[a].size()) * (1.0 + static_cast<double>(adj[a].size()));
+        const double sb =
+            static_cast<double>(voxels[b].size()) * (1.0 + static_cast<double>(adj[b].size()));
+        if (sa != sb)
+        {
+          return sa > sb;
+        }
+        return kfs[a].id < kfs[b].id;
+      });
+
+  std::vector<std::vector<size_t>> clusters;  // each: member indices, seed first
+
+  for (const size_t seed : order)
+  {
+    if (covered[seed])
+    {
+      continue;
+    }
+
+    const double extentCap = std::max(params.extent_factor * kfs[seed].radius, voxelSize);
+
+    std::vector<size_t>        members   = {seed};
+    std::unordered_set<size_t> memberSet = {seed};
+    VoxelSet                   Vc        = voxels[seed];
+
+    // Grow: repeatedly add the best eligible neighbor of any current member.
+    for (;;)
+    {
+      double bestOv = -1.0;
+      size_t bestN  = 0;
+      bool   found  = false;
+      for (const size_t m : members)
+      {
+        for (const auto& [nb, w] : adj[m])
+        {
+          if (memberSet.count(nb) != 0)
+          {
+            continue;
+          }
+          if ((kfs[nb].center - kfs[seed].center).norm() > extentCap)
+          {
+            continue;
+          }
+          const double ov = voxelOverlap(voxels[nb], Vc);
+          if (ov < params.edge_overlap)
+          {
+            continue;
+          }
+          if (ov > bestOv)
+          {
+            bestOv = ov;
+            bestN  = nb;
+            found  = true;
+          }
+        }
+      }
+      if (!found)
+      {
+        break;
+      }
+      members.push_back(bestN);
+      memberSet.insert(bestN);
+      Vc.insert(voxels[bestN].begin(), voxels[bestN].end());
+    }
+
+    // Mark inner-core members as covered (boundary members stay available).
+    const double coreRadius = params.core_fraction * extentCap;
+    for (const size_t m : members)
+    {
+      if ((kfs[m].center - kfs[seed].center).norm() <= coreRadius)
+      {
+        covered[m] = true;
+      }
+    }
+    covered[seed] = true;  // always: guarantees the loop makes progress
+
+    clusters.push_back(std::move(members));
+  }
+
+  log(mrpt::format(
+      "[regroup] %zu keyframes -> %zu super-keyframes (%.2fx reduction)", n, clusters.size(),
+      clusters.empty() ? 0.0 : static_cast<double>(n) / static_cast<double>(clusters.size())));
+
+  // ---- 6) Build the output map: one super-keyframe per cluster ----
+  KeyFrameID nextId = 0;
+  for (const auto& members : clusters)
+  {
+    const auto& seed = kfs[members.front()];
+
+    auto localCloud =
+        buildSuperKeyframeCloud(members, globals, seed.pose, params.merge_decimate_voxel);
+
+    // Insert as a new super-keyframe (caches build lazily on first use / load).
+    auto [it, isNew] = out->keyframes_.try_emplace(
+        nextId, creationOptions.k_correspondences_for_cov,
+        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+    KeyFrame& nkf = it->second;
+    nkf.timestamp = seed.timestamp;
+    nkf.pose(seed.pose);
+    nkf.pointcloud(localCloud);
+    out->last_inserted_kf_id_ = nextId;
+    nextId++;
+  }
+  out->next_free_kf_id_ = nextId;
+
+  return out;
+}
+
+// ==========================
 //   Options
 // ==========================
 
@@ -1320,6 +1775,7 @@ void KeyframePointCloudMap::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR_CS(num_diverse_keyframes, uint64_t);
   MRPT_LOAD_CONFIG_VAR_CS(use_view_direction_filter, bool);
   MRPT_LOAD_CONFIG_VAR_CS(max_view_angle_deg, double);
+  MRPT_LOAD_CONFIG_VAR_CS(serialize_kdtrees, bool);
 }
 
 void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out) const
@@ -1333,16 +1789,18 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(num_diverse_keyframes, int);
   LOADABLEOPTS_DUMP_VAR(use_view_direction_filter, bool);
   LOADABLEOPTS_DUMP_VAR(max_view_angle_deg, double);
+  LOADABLEOPTS_DUMP_VAR(serialize_kdtrees, bool);
 }
 
 void KeyframePointCloudMap::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  out.WriteAs<uint8_t>(3);  // version
+  out.WriteAs<uint8_t>(4);  // version
   out << max_search_keyframes << k_correspondences_for_cov;
   out << rotation_distance_weight << num_diverse_keyframes;  // v1
   out << use_view_direction_filter << max_view_angle_deg;  // v2
   out << min_correspondences_for_cov << max_distance_for_cov;  // v3
+  out << serialize_kdtrees;  // v4
 }
 
 void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -1356,6 +1814,7 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
     case 1:
     case 2:
     case 3:
+    case 4:
     {
       in >> max_search_keyframes >> k_correspondences_for_cov;
       if (version >= 1)
@@ -1370,6 +1829,10 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
       {
         in >> min_correspondences_for_cov;
         in >> max_distance_for_cov;
+      }
+      if (version >= 4)
+      {
+        in >> serialize_kdtrees;
       }
     }
     break;

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -926,6 +926,69 @@ void test_regroup_serialization_roundtrip()
   ASSERT_EQUAL_(g2.point_count(), nPts);
 }
 
+// ── 26. Regroup: voxel decimation shrinks the cloud and keeps view fields ──
+// Two identical, fully-overlapping keyframes are merged into one super-keyframe
+// with merge_decimate_voxel>0. The duplicated points must collapse (fewer points
+// than the 2x input), and the per-point view-direction fields must survive the
+// decimation - verified functionally: with the view filter ON, an opposite-view
+// pair is rejected ONLY if the regrouped+decimated global cloud still carries
+// view fields, so ON must yield fewer pairings than OFF.
+void test_regroup_decimation_preserves_views()
+{
+  using mrpt::poses::CPose3D;
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+  constexpr float kBackX   = 20.0f;  // outside the grid, so it is an isolated NN
+
+  const auto makeKfPts = []
+  {
+    auto pts = makeGridPts(0.f, 0.f, 0.f, 1.f, 10, 10);  // 100 pts, view=(0,0,+1)
+    appendPt(pts, kBackX, 0.f, 0.f, 0.f, 0.f, -1.f);  // back-face pt, view=(0,0,-1)
+    return pts;
+  };
+
+  mola::KeyframePointCloudMap m;
+  m.creationOptions.k_correspondences_for_cov = 5;
+  m.creationOptions.max_search_keyframes      = 1;
+  for (int k = 0; k < 2; ++k)
+  {
+    auto obs        = mrpt::obs::CObservationPointCloud::Create();
+    obs->pointcloud = makeCloudWithViews(makeKfPts());
+    m.insertObservation(*obs, CPose3D::Identity());  // identical -> full overlap
+  }
+  const auto inPts = m.point_count();  // 2 * 101 = 202
+
+  mola::KeyframePointCloudMap::RegroupParams params;
+  params.merge_decimate_voxel = 0.5;  // dedup the co-located duplicate points
+  auto g                      = m.regroupKeyframes(params);
+  ASSERT_(!g->isEmpty());
+
+  // Decimation must collapse the two identical clouds.
+  ASSERT_LT_(g->point_count(), inPts);
+  ASSERT_LT_(g->point_count(), inPts * 3 / 4);
+
+  // Local query cloud: grid (for covariances) + a FRONT-face point whose nearest
+  // neighbor in the global cloud is the back-face point.
+  auto localPts = makeGridPts(kDz, 0.f, 0.f, 1.f, 10, 10);
+  appendPt(localPts, kBackX, 0.f, kDz, 0.f, 0.f, 1.f);  // front-face, view=(0,0,+1)
+  auto local_m = makeMapFromCloud(makeCloudWithViews(localPts));
+
+  g->creationOptions.max_search_keyframes = 1;
+  g->icp_get_prepared_as_global(CPose3D::Identity());
+
+  g->creationOptions.use_view_direction_filter = true;
+  g->creationOptions.max_view_angle_deg        = 120.0;
+  mp2p_icp::MatchedPointWithCovList pairingsOn;
+  g->nn_search_cov2cov(local_m, CPose3D::Identity(), kMaxDist, pairingsOn);
+
+  g->creationOptions.use_view_direction_filter = false;
+  mp2p_icp::MatchedPointWithCovList pairingsOff;
+  g->nn_search_cov2cov(local_m, CPose3D::Identity(), kMaxDist, pairingsOff);
+
+  // View fields survived decimation -> the opposite-view pair was rejected.
+  ASSERT_LT_(pairingsOn.size(), pairingsOff.size());
+}
+
 // ── 25. serialize_kdtrees round-trips the stream correctly ─────────────────
 // Whether or not the MRPT build provides the KD-tree save/load API, the map
 // serialization must stay stream-aligned with serialize_kdtrees enabled, and
@@ -1045,6 +1108,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_regroup_serialization_roundtrip ...\n";
     test_regroup_serialization_roundtrip();
+
+    std::cout << "test_regroup_decimation_preserves_views ...\n";
+    test_regroup_decimation_preserves_views();
 
     std::cout << "test_kdtree_serialization_roundtrip ...\n";
     test_kdtree_serialization_roundtrip();

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -788,6 +788,180 @@ void test_kf_pose_plumbing()
   ASSERT_EQUAL_(m.nextFreeKeyFrameID_public(), KFID{0});
 }
 
+// ── 21. Regroup: builds a multi-KF map along a line ───────────────────────
+/// Inserts `nkf` keyframes of large overlapping grid clouds, spaced `spacing`
+/// metres apart along +x. Returns the assembled map.
+mola::KeyframePointCloudMap makeLinearMap(size_t nkf, double spacing, bool withViews = false)
+{
+  using mrpt::literals::      operator""_deg;
+  mola::KeyframePointCloudMap m;
+  m.creationOptions.k_correspondences_for_cov = 5;
+  m.creationOptions.max_search_keyframes      = 3;
+
+  for (size_t i = 0; i < nkf; ++i)
+  {
+    // Large grid (21x21, ~20 m span) so consecutive KFs overlap heavily.
+    auto                        pts = makeGridPts(0.f, 0.f, 0.f, 1.f, 21, 21);
+    mrpt::maps::CPointsMap::Ptr pc;
+    if (withViews)
+    {
+      pc = makeCloudWithViews(pts);
+    }
+    else
+    {
+      auto simple = mrpt::maps::CSimplePointsMap::Create();
+      for (const auto& p : pts)
+      {
+        simple->insertPoint(p[0], p[1], p[2]);
+      }
+      pc = simple;
+    }
+    auto obs        = mrpt::obs::CObservationPointCloud::Create();
+    obs->pointcloud = pc;
+    m.insertObservation(
+        *obs, mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+                  static_cast<double>(i) * spacing, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg));
+  }
+  return m;
+}
+
+// ── 21. Regroup reduces KF count and stays deterministic ──────────────────
+void test_regroup_reduces_keyframes()
+{
+  auto m = makeLinearMap(/*nkf=*/15, /*spacing=*/3.0);
+  ASSERT_EQUAL_(m.keyframePoses().size(), 15UL);
+
+  mola::KeyframePointCloudMap::RegroupParams params;  // defaults
+  auto                                       g1 = m.regroupKeyframes(params);
+  ASSERT_(g1);
+  ASSERT_(!g1->isEmpty());
+
+  // Heavy overlap along the line must collapse 15 KFs into strictly fewer
+  // super-keyframes.
+  ASSERT_LT_(g1->keyframePoses().size(), 15UL);
+  ASSERT_GT_(g1->keyframePoses().size(), 0UL);
+
+  // Options are carried over from the source map.
+  ASSERT_EQUAL_(g1->creationOptions.max_search_keyframes, m.creationOptions.max_search_keyframes);
+
+  // Deterministic: same input + params -> same number of super-keyframes.
+  auto g2 = m.regroupKeyframes(params);
+  ASSERT_EQUAL_(g1->keyframePoses().size(), g2->keyframePoses().size());
+
+  // Global bounding box is approximately preserved (points are not lost).
+  const auto bbIn  = m.boundingBox();
+  const auto bbOut = g1->boundingBox();
+  ASSERT_NEAR_(bbIn.min.x, bbOut.min.x, 1.0f);
+  ASSERT_NEAR_(bbIn.max.x, bbOut.max.x, 1.0f);
+  ASSERT_NEAR_(bbIn.min.y, bbOut.min.y, 1.0f);
+  ASSERT_NEAR_(bbIn.max.y, bbOut.max.y, 1.0f);
+}
+
+// ── 22. Regroup: every original pose is covered by ONE super-keyframe ──────
+void test_regroup_single_kf_coverage()
+{
+  auto       m         = makeLinearMap(/*nkf=*/15, /*spacing=*/3.0);
+  const auto origPoses = m.keyframePoses();
+
+  mola::KeyframePointCloudMap::RegroupParams params;
+  auto                                       g = m.regroupKeyframes(params);
+
+  // Force single-active-KF localization behavior.
+  g->creationOptions.max_search_keyframes = 1;
+
+  for (const auto& [id, pose] : origPoses)
+  {
+    g->icp_get_prepared_as_global(pose);
+
+    // With only ONE active super-keyframe selected, a point at the robot
+    // location must still find a close neighbor: the group covers this pose.
+    mrpt::math::TPoint3Df query{static_cast<float>(pose.x()), static_cast<float>(pose.y()), 0.f};
+    mrpt::math::TPoint3Df result;
+    float                 dsqr = 0;
+    uint64_t              idx  = 0;
+    const bool            ok   = g->nn_single_search(query, result, dsqr, idx);
+    ASSERT_(ok);
+    // The grids are 1 m spaced and centered on each KF, so the nearest point
+    // to the robot location is well under 2 m if the pose is truly covered.
+    ASSERT_LT_(dsqr, 4.0f);
+  }
+}
+
+// ── 23. Regroup: empty input yields an empty (but valid) map ───────────────
+void test_regroup_empty()
+{
+  mola::KeyframePointCloudMap                m;
+  mola::KeyframePointCloudMap::RegroupParams params;
+  auto                                       g = m.regroupKeyframes(params);
+  ASSERT_(g);
+  ASSERT_(g->isEmpty());
+}
+
+// ── 24. Regroup: output survives serialization round-trip ──────────────────
+void test_regroup_serialization_roundtrip()
+{
+  auto m = makeLinearMap(/*nkf=*/12, /*spacing=*/3.0, /*withViews=*/true);
+
+  mola::KeyframePointCloudMap::RegroupParams params;
+  auto                                       g = m.regroupKeyframes(params);
+  ASSERT_(!g->isEmpty());
+
+  const auto nKF  = g->keyframePoses().size();
+  const auto nPts = g->point_count();
+
+  mrpt::io::CMemoryStream buf;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << *g;
+  }
+  buf.Seek(0);
+
+  mola::KeyframePointCloudMap g2;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar >> g2;
+  }
+
+  ASSERT_EQUAL_(g2.keyframePoses().size(), nKF);
+  ASSERT_EQUAL_(g2.point_count(), nPts);
+}
+
+// ── 25. serialize_kdtrees round-trips the stream correctly ─────────────────
+// Whether or not the MRPT build provides the KD-tree save/load API, the map
+// serialization must stay stream-aligned with serialize_kdtrees enabled, and
+// the loaded map must remain fully functional (points + NN queries).
+void test_kdtree_serialization_roundtrip()
+{
+  auto m = makeMapFromCloud(makeCloudWithViews(makeGridPts(0.f, 0.f, 0.f, 1.f, 10, 10)));
+  m.creationOptions.serialize_kdtrees = true;
+
+  mrpt::io::CMemoryStream buf;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << m;
+  }
+  buf.Seek(0);
+
+  mola::KeyframePointCloudMap m2;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar >> m2;
+  }
+
+  ASSERT_EQUAL_(m2.point_count(), m.point_count());
+  ASSERT_(m2.creationOptions.serialize_kdtrees == true);
+
+  // Functional: prepare a single-KF submap and run a NN query on the loaded map.
+  m2.creationOptions.max_search_keyframes = 1;
+  m2.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+  mrpt::math::TPoint3Df query{0.f, 0.f, 0.f};
+  mrpt::math::TPoint3Df result;
+  float                 dsqr = 0;
+  uint64_t              idx  = 0;
+  ASSERT_(m2.nn_single_search(query, result, dsqr, idx));
+  ASSERT_LT_(dsqr, 4.0f);
+}
+
 // ── 20. Default filter parameters are sane ────────────────────────────────
 void test_default_creation_options()
 {
@@ -859,6 +1033,21 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_default_creation_options ...\n";
     test_default_creation_options();
+
+    std::cout << "test_regroup_reduces_keyframes ...\n";
+    test_regroup_reduces_keyframes();
+
+    std::cout << "test_regroup_single_kf_coverage ...\n";
+    test_regroup_single_kf_coverage();
+
+    std::cout << "test_regroup_empty ...\n";
+    test_regroup_empty();
+
+    std::cout << "test_regroup_serialization_roundtrip ...\n";
+    test_regroup_serialization_roundtrip();
+
+    std::cout << "test_kdtree_serialization_roundtrip ...\n";
+    test_kdtree_serialization_roundtrip();
 
     std::cout << "\nAll tests passed.\n";
   }


### PR DESCRIPTION
Two offline optimizations of a `KeyframePointCloudMap` layer for fast **localization-only** operation, exposed as CLI tools under `mola_metric_maps/apps`.

## 1. `mm-kf-regroup` — keyframe regrouping
Groups many small keyframes into fewer, larger, deliberately-overlapping "super-keyframes" so the ICP active set stays size 1 (no per-scan keyframe switching).

Backed by new API `KeyframePointCloudMap::regroupKeyframes(RegroupParams)`:
- keyframe adjacency graph with **voxel Jaccard-min overlap** edge weights;
- greedy **overlapping set-cover** clustering, auto-sized from each keyframe's bounding box (large outdoors, small indoors);
- merged super-keyframe clouds voxel-decimated (`--decimate-voxel`, view-direction fields carried) to bound the overlap-induced point blow-up.

On a 1000-KF outdoor map this yields ~5 super-KFs (200× fewer active-set switches).

## 2. `mm-kf-bake-kdtrees` — KD-tree persistence
Caches each keyframe's per-cloud 3D KD-tree index inside the `.mm` so it is not rebuilt on every load.

- New opt-in `TCreationOptions::serialize_kdtrees` (default `false`); bumps map serialization to v2 with a **self-describing** per-KF flag byte + KD-tree blob.
- Requires the MRPT KD-tree save/load index API, **feature-detected** via `MRPT_HAS_KDTREE_SAVE_LOAD_INDEX` (see companion MRPT PR MRPT/mrpt#feat/kdtree-save-load-index). When the API is absent this build compiles fine: the option is a no-op on write and readers skip any stored blob, so `.mm` files stay interoperable across MRPT builds.

## Tests
Adds unit tests to `test-mola_metric_maps_keyframemap.cpp`: regroup reduction / single-KF coverage / empty / serialization round-trip, and KD-tree serialization round-trip.

`agents.md` updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metric-map keyframe regrouping workflow with a new command-line tool to generate “super-keyframes”.
  * Added support for embedding per-keyframe KD-tree caches in saved maps, plus a new tool to bake these caches.
* **Bug Fixes**
  * Improved regrouping reliability and verified regrouped maps maintain consistent keyframe/point content after save/load.
* **Documentation**
  * Updated CLI tool documentation with the new regrouping and KD-tree baking utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->