### PR TITLE
feat(mola_metric_maps): debug env var to color each keyframe distinctly

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -601,8 +601,14 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
 
     /** Builds (or get cached) visualization of the cloud in this KF, already transformed to its
      * global pose.
+     *
+     * If `overrideColor` is set, ALL points are painted that single color instead of the
+     * normal per-field colormap, and the result is NOT cached (used by the per-keyframe
+     * debug coloring, see `MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF`).
      */
-    std::shared_ptr<mrpt::opengl::CPointCloudColoured> getViz(const TRenderOptions& ro) const;
+    std::shared_ptr<mrpt::opengl::CPointCloudColoured> getViz(
+        const TRenderOptions&                   ro,
+        const std::optional<mrpt::img::TColor>& overrideColor = std::nullopt) const;
 
     std::shared_ptr<mrpt::opengl::CSetOfObjects> getCovarianceEllipsoidViz(
         const TRenderOptions& ro) const;

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -24,6 +24,7 @@
 #endif
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/core/get_env.h>
+#include <mrpt/img/TColor.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/math/TOrientedBox.h>
 #include <mrpt/obs/CObservationPointCloud.h>
@@ -1001,6 +1002,29 @@ std::string KeyframePointCloudMap::asString() const
   return o.str();
 }
 
+namespace
+{
+/// Maps HSV (h,s,v all in [0,1]) to an 8-bit RGB color (switch-free formulation).
+mrpt::img::TColor hsvToColor(double h, double s, double v)
+{
+  const auto chan = [&](double n)
+  {
+    const double k = std::fmod(n + h * 6.0, 6.0);
+    return v - v * s * std::max(0.0, std::min({k, 4.0 - k, 1.0}));
+  };
+  const auto u8 = [](double x) { return static_cast<uint8_t>(std::clamp(x, 0.0, 1.0) * 255.0); };
+  return mrpt::img::TColor(u8(chan(5.0)), u8(chan(3.0)), u8(chan(1.0)));
+}
+
+/// Deterministic, well-separated color for the i-th key-frame (golden-ratio hue
+/// spacing keeps consecutive key-frames visually distinct).
+mrpt::img::TColor distinctKfColor(size_t i)
+{
+  const double hue = std::fmod(static_cast<double>(i) * 0.618033988749895, 1.0);
+  return hsvToColor(hue, 0.75, 0.98);
+}
+}  // namespace
+
 void KeyframePointCloudMap::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
 {
   MRPT_START
@@ -1017,12 +1041,25 @@ void KeyframePointCloudMap::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   const thread_local auto ENV_KEYFRAMES_SHOW_COV =
       mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_VIZ_SHOW_COV", false);
 
+  // Debug aid: paint each key-frame a distinct color so regrouped
+  // super-keyframes / clusters are easy to tell apart visually.
+  const thread_local auto ENV_KEYFRAMES_COLOR_BY_KF =
+      mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF", false);
+
   auto lck = mrpt::lockHelper(*state_mtx_);
 
   // Create one visualization object per KF:
+  size_t kf_ordinal = 0;
   for (const auto& [kf_id, kf] : keyframes_)
   {
-    auto obj = kf.getViz(renderOptions);
+    std::optional<mrpt::img::TColor> overrideColor;
+    if (ENV_KEYFRAMES_COLOR_BY_KF)
+    {
+      overrideColor = distinctKfColor(kf_ordinal);
+    }
+    ++kf_ordinal;
+
+    auto obj = kf.getViz(renderOptions, overrideColor);
 
     float      pointSize  = renderOptions.point_size;
     const bool isActiveKF = (cached_.icp_search_kfs && cached_.icp_search_kfs->count(kf_id) != 0);
@@ -2320,9 +2357,10 @@ void KeyframePointCloudMap::KeyFrame::updateCovariancesGlobal() const
 }
 
 std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFrame::getViz(
-    const TRenderOptions& ro) const
+    const TRenderOptions& ro, const std::optional<mrpt::img::TColor>& overrideColor) const
 {
-  if (cached_viz_)
+  // The cache only holds the normal (non-overridden) visualization.
+  if (!overrideColor && cached_viz_)
   {
     return cached_viz_;
   }
@@ -2333,6 +2371,20 @@ std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFra
   obj->loadFromPointsMap(pointcloud().get());
 
   obj->setPose(pose());
+
+  // Debug path: paint the whole key-frame a single, uniform color so different
+  // key-frames (e.g. regrouped super-keyframes / clusters) are easy to tell
+  // apart. Not cached, so toggling the env var takes effect on the next render.
+  if (overrideColor)
+  {
+    const auto&  c = *overrideColor;
+    const size_t n = obj->size();
+    for (size_t i = 0; i < n; i++)
+    {
+      obj->setPointColor_u8_fast(i, c.R, c.G, c.B, alpha_u8);
+    }
+    return obj;
+  }
 
   if (ro.color.A != 1.0f)
   {

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -23,10 +23,13 @@
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/opengl/CPointCloudColoured.h>
+#include <mrpt/opengl/CSetOfObjects.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
 
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <set>
 
@@ -1025,6 +1028,52 @@ void test_kdtree_serialization_roundtrip()
   ASSERT_LT_(dsqr, 4.0f);
 }
 
+// ── 22. Debug per-keyframe coloring env var ───────────────────────────────
+/// With MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF=1 every keyframe must be rendered
+/// with a single, uniform color, and different keyframes must get different
+/// colors (so regrouped clusters are visually distinguishable).
+void test_viz_color_by_kf()
+{
+  constexpr size_t nkf = 3;
+  auto             m   = makeLinearMap(nkf, 5.0);
+
+  // Note: getVisualizationInto() caches the env var value in a thread_local,
+  // so this test must be the only one that reads it (it is).
+  setenv("MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF", "1", 1);
+  auto glObj = m.getVisualization();
+  unsetenv("MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF");
+
+  ASSERT_(glObj);
+
+  // Collect the (uniform) color of each point-cloud child object.
+  std::set<uint32_t> distinctColors;
+  size_t             cloudObjs = 0;
+  for (const auto& child : *glObj)
+  {
+    auto pc = std::dynamic_pointer_cast<mrpt::opengl::CPointCloudColoured>(child);
+    if (!pc || pc->size() == 0)
+    {
+      continue;
+    }
+    ++cloudObjs;
+
+    const auto c0 = pc->getPointColor(0);
+    for (size_t i = 1; i < pc->size(); ++i)
+    {
+      const auto ci = pc->getPointColor(i);
+      ASSERT_EQUAL_(ci.R, c0.R);
+      ASSERT_EQUAL_(ci.G, c0.G);
+      ASSERT_EQUAL_(ci.B, c0.B);
+    }
+    distinctColors.insert(
+        (static_cast<uint32_t>(c0.R) << 16) | (static_cast<uint32_t>(c0.G) << 8) |
+        static_cast<uint32_t>(c0.B));
+  }
+
+  ASSERT_EQUAL_(cloudObjs, nkf);
+  ASSERT_EQUAL_(distinctColors.size(), nkf);
+}
+
 // ── 20. Default filter parameters are sane ────────────────────────────────
 void test_default_creation_options()
 {
@@ -1114,6 +1163,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_kdtree_serialization_roundtrip ...\n";
     test_kdtree_serialization_roundtrip();
+
+    std::cout << "test_viz_color_by_kf ...\n";
+    test_viz_color_by_kf();
 
     std::cout << "\nAll tests passed.\n";
   }


### PR DESCRIPTION
## Summary

Adds an optional debug environment variable, `MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF`, to `KeyframePointCloudMap`. When set (e.g. `MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF=1`), each keyframe is rendered with a single, visually distinct color instead of the usual per-field colormap.

This makes it easy to visually inspect keyframe boundaries and, in particular, the results of the recently added keyframe **regrouping** (super-keyframes / zones) — each cluster shows up as its own solid color.

## Details

- Colors are assigned per keyframe using golden-ratio hue spacing, so consecutive keyframes stay well separated (HSV → RGB, saturation 0.75, value 0.98).
- `KeyFrame::getViz()` gains an optional `overrideColor` argument. When present, all points are painted that uniform color and the result is **not** cached, so toggling the env var takes effect on the next render (the normal, cached colormap path is untouched).
- No behavior change when the env var is unset — the default remains the per-field colormap visualization.

## Usage

```bash
MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF=1 mola-viz ...   # or any tool that renders the map
```

## Testing

- New unit test `test_viz_color_by_kf`: builds a 3-keyframe map, enables the env var, renders, and asserts each keyframe's point cloud is uniformly colored and that all 3 keyframes get distinct colors.
- Full `test-mola_metric_maps_keyframemap` suite passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-keyframe coloring for map visualizations, with stable distinct colors for each keyframe.
  * Enabled an override color mode to render a keyframe with a single uniform color when needed.

* **Tests**
  * Added coverage for the new visualization coloring behavior to verify consistent coloring per keyframe and unique colors across keyframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->