### PR TITLE
feat(mola_metric_maps): approximate cov2cov mode for KeyframePointCloudMap

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -142,6 +142,17 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   (`--decimate-voxel`, view-direction fields carried) to bound the overlap-induced point
   blow-up. On a 1000-KF outdoor map this yields ~5 super-KFs. This is "idea 1" of the
   keyframe-map persistence plan.
+- `KeyframePointCloudMap::TCreationOptions::approximate_cov` (default `false`): for
+  `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e. GICP-style pipelines).
+  When `true`, `icp_get_prepared_as_global()` skips assembling the merged, multi-keyframe
+  submap for the active KF set and instead only warms each active KF's own (already cached)
+  KD-tree and per-point covariances; `nn_search_cov2cov()` then does one KD-tree query per
+  active KF ("N" queries instead of 1 on a merged cloud) and keeps the closest, using that
+  KF's own cached covariance. Trades exactness (covariances are estimated only from
+  within-KF neighbors, not the merged multi-KF cloud) for speed (no merge/KD-tree rebuild).
+  Only affects `nn_search_cov2cov()`; the generic `NearestNeighborsCapable` entry points
+  still require the merged submap. Exposed in `mola_lidar_odometry`'s
+  `pipelines/lidar3d-gicp.yaml` as `MOLA_LOCALMAP_APPROXIMATE_COV`.
 - CLI tool `mm-kf-bake-kdtrees` (in `apps/`): "idea 2" of the same plan. Caches each
   keyframe's per-cloud 3D KD-tree index inside the `.mm` so it is not rebuilt on every load
   (faster localization-only startup). Backed by the `serialize_kdtrees` creationOption of

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -35,6 +35,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <set>
 #include <vector>
 
 namespace mola
@@ -466,6 +467,31 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      *  `false`. Typically enabled offline by the `mm-kf-bake-kdtrees` tool.
      */
     bool serialize_kdtrees = false;
+
+    /** If `true`, `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e.
+     *  GICP-style pipelines) skips building the merged, multi-keyframe submap that
+     *  `icp_get_prepared_as_global()` otherwise assembles for the active KF set.
+     *  Instead, each active keyframe's own already-built KD-tree and per-point
+     *  covariances (both cached at insertion time, in the KF's *local* neighborhood
+     *  only) are queried directly: for every query point, one KD-tree lookup is done
+     *  per active keyframe ("N" lookups instead of 1 on a merged cloud), and the
+     *  overall closest one is kept, together with that keyframe's own cached
+     *  covariance at that point.
+     *
+     *  This trades exactness for speed: the reference covariance at the matched point
+     *  is estimated only from neighbors *within the same source keyframe*, whereas the
+     *  exact (default) mode computes it from neighbors in the merged cloud, which may
+     *  include points contributed by other active keyframes. It also avoids the
+     *  merged-cloud allocation, copy and KD-tree (re)build entirely, which can be a
+     *  significant fraction of `icp_get_prepared_as_global()`'s cost when the active
+     *  set has several sizeable keyframes.
+     *
+     *  Only affects `nn_search_cov2cov()`. The generic `NearestNeighborsCapable`
+     *  entry points (`nn_single_search()`, `nn_multiple_search()`, `nn_radius_search()`)
+     *  still require the merged submap and are not supported in this mode. Default
+     *  `false` (exact, merged-cloud behavior, unchanged).
+     */
+    bool approximate_cov = false;
   };
   TCreationOptions creationOptions;
 
@@ -677,6 +703,12 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
     mutable std::optional<std::set<KeyFrameID>>      icp_search_kfs;
     mutable std::optional<KeyFrame>                  icp_search_submap;
 
+    /// Value of creationOptions.approximate_cov used to build the cache above. Compared
+    /// against the live option in icp_get_prepared_as_global() so that toggling the flag
+    /// (even with an unchanged active KF set) forces a rebuild instead of silently reusing
+    /// a cache built under the other mode.
+    mutable bool icp_search_built_approximate = false;
+
     /// Used for getAsSimplePointsMap only.
     mutable mrpt::maps::CSimplePointsMap::Ptr cachedPoints;
   };
@@ -731,6 +763,15 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
 
   /** Non-thread safe version of transform_map_left_multiply() */
   void transform_map_left_multiply_impl(const mrpt::poses::CPose3D& b);
+
+  /** Implements `nn_search_cov2cov()` for `creationOptions.approximate_cov == true`: queries
+   *  each keyframe in `activeKfs` with its own cached KD-tree instead of a merged submap.
+   *  `localKf`'s pose must already have been set to the query pose by the caller.
+   *  \sa TCreationOptions::approximate_cov
+   */
+  void nn_search_cov2cov_approximate(
+      const KeyFrame& localKf, const std::set<KeyFrameID>& activeKfs, float max_search_distance,
+      mp2p_icp::MatchedPointWithCovList& outPairings) const;
 };
 
 }  // namespace mola

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -1083,7 +1083,16 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
   entries.reserve(activeKfs.size());
   for (const auto kf_id : activeKfs)
   {
-    const auto& kf = keyframes_.at(kf_id);
+    // activeKfs was snapshotted by an earlier icp_get_prepared_as_global() call, under its
+    // own lock acquisition. A concurrent insertObservation() may have evicted this id in the
+    // meantime (see insertionOptions.remove_frames_farther_than), so look it up defensively
+    // instead of keyframes_.at(), which would throw.
+    const auto it = keyframes_.find(kf_id);
+    if (it == keyframes_.end())
+    {
+      continue;
+    }
+    const auto& kf = it->second;
     if (!kf.pointcloud() || kf.pointcloud()->empty())
     {
       continue;

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -618,19 +618,46 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
   kfs_to_search_limited = selectedIds;
 
   // ---------------------------------------------------------------
-  // 4) Rebuild merged submap if the selection changed
+  // 4) Rebuild merged submap if the selection (or the exact/approximate mode) changed
   // ---------------------------------------------------------------
-  if (cached_.icp_search_kfs && *cached_.icp_search_kfs == kfs_to_search_limited)
+  if (cached_.icp_search_kfs && *cached_.icp_search_kfs == kfs_to_search_limited &&
+      cached_.icp_search_built_approximate == creationOptions.approximate_cov)
   {
     return;  // Already up to date.
   }
 
-  cached_.icp_search_kfs = kfs_to_search_limited;
+  cached_.icp_search_kfs               = kfs_to_search_limited;
+  cached_.icp_search_built_approximate = creationOptions.approximate_cov;
 
   // NOTE: Do NOT unlock 'lck' here. The mutex must be held for the entire submap
   // rebuild below, because cached_.icp_search_submap and keyframes_ are both
   // shared mutable state that can be read concurrently by nn_* methods and
   // icp_get_prepared_as_global() itself.
+
+  if (creationOptions.approximate_cov)
+  {
+    // Approximate mode: skip the merged-cloud submap entirely. nn_search_cov2cov()
+    // will instead query each active KF's own cached KD-tree directly. Here we only
+    // need to warm each active KF's per-KF (local) cache and its *global*-frame
+    // structures, so the first ICP align() does not pay that cost on the caller's
+    // thread. See TCreationOptions::approximate_cov.
+    cached_.icp_search_submap.reset();
+
+    for (const auto kf_id : kfs_to_search_limited)
+    {
+      const auto& kf = keyframes_.at(kf_id);
+      if (!kf.pointcloud())
+      {
+        continue;
+      }
+      kf.buildCache();  // local bbox, KD-tree, per-point local covariances
+
+      const auto& globalPoints = kf.pointcloud_global();
+      globalPoints->kdTreeEnsureIndexBuilt3D();
+      kf.covariancesGlobal();
+    }
+    return;
+  }
 
   cached_.icp_search_submap.reset();
   cached_.icp_search_submap.emplace(
@@ -771,10 +798,6 @@ void KeyframePointCloudMap::nn_search_cov2cov(
 {
   auto lck = mrpt::lockHelper(*state_mtx_);
 
-  ASSERTMSG_(
-      cached_.icp_search_submap,
-      "Using this method requires calling icp_get_prepared_as_global() first");
-
   // Enforce local map to recompute its covariances to the new pose:
   const auto* localMapKF = dynamic_cast<const KeyframePointCloudMap*>(&localMap);
   ASSERTMSG_(
@@ -784,6 +807,21 @@ void KeyframePointCloudMap::nn_search_cov2cov(
   auto&      localKf             = const_cast<KeyFrame&>(localMapKF->keyframes_.at(0));
   const auto originalLocalKfPose = localKf.pose();
   localKf.pose(localMapPose);
+
+  if (creationOptions.approximate_cov)
+  {
+    ASSERTMSG_(
+        cached_.icp_search_kfs,
+        "Using this method requires calling icp_get_prepared_as_global() first");
+    nn_search_cov2cov_approximate(
+        localKf, *cached_.icp_search_kfs, max_search_distance, outPairings);
+    localKf.pose(originalLocalKfPose);
+    return;
+  }
+
+  ASSERTMSG_(
+      cached_.icp_search_submap,
+      "Using this method requires calling icp_get_prepared_as_global() first");
 
   const auto& localKfCov        = localKf.covariancesGlobal();
   const auto& localPointsTransf = localKf.pointcloud_global();
@@ -974,6 +1012,196 @@ void KeyframePointCloudMap::nn_search_cov2cov(
   localKf.pose(originalLocalKfPose);
 }
 
+namespace
+{
+/// Best-effort, packed identifier for a (active-KF ordinal, local point index) pair, used as
+/// point_with_cov_pair_t::global_idx in approximate cov2cov mode (see
+/// KeyframePointCloudMap::nn_search_cov2cov_approximate()). Unlike the exact (merged-cloud)
+/// mode, there is no single flat index space to draw from, so 8 bits are reserved for the
+/// active-KF ordinal (creationOptions.max_search_keyframes is never more than a few dozen) and
+/// 24 bits for the local index (post-decimation KF clouds are always far below 16M points).
+/// Collisions beyond those bounds only affect Matcher_Cov2Cov's optional
+/// "allowMatchAlreadyMatchedGlobalPoints" bookkeeping, not correctness of the pairing itself.
+uint32_t packApproxGlobalIdx(uint32_t kf_ordinal, uint32_t local_idx)
+{
+  return ((kf_ordinal & 0xFFu) << 24) | (local_idx & 0x00FFFFFFu);
+}
+}  // namespace
+
+void KeyframePointCloudMap::nn_search_cov2cov_approximate(
+    const KeyFrame& localKf, const std::set<KeyFrameID>& activeKfs, const float max_search_distance,
+    mp2p_icp::MatchedPointWithCovList& outPairings) const
+{
+  const auto& localKfCov        = localKf.covariancesGlobal();
+  const auto& localPointsTransf = localKf.pointcloud_global();
+  const auto& localPoints       = localKf.pointcloud();
+
+  const auto  localPointCount = localPointsTransf->size();
+  const float max_sqr_dist    = mrpt::square(max_search_distance);
+
+  const auto& xs_tf = localPointsTransf->getPointsBufferRef_x();
+  const auto& ys_tf = localPointsTransf->getPointsBufferRef_y();
+  const auto& zs_tf = localPointsTransf->getPointsBufferRef_z();
+
+  const auto& xs = localPoints->getPointsBufferRef_x();
+  const auto& ys = localPoints->getPointsBufferRef_y();
+  const auto& zs = localPoints->getPointsBufferRef_z();
+
+  // View-direction filter setup: see the exact-mode nn_search_cov2cov() above for the full
+  // rationale. Here the same per-pair test is applied against whichever active KF ends up
+  // being the closest one for a given query point.
+  const bool try_view_filter = creationOptions.use_view_direction_filter;
+
+  const mrpt::aligned_std_vector<float>* local_view_x = nullptr;
+  const mrpt::aligned_std_vector<float>* local_view_y = nullptr;
+  const mrpt::aligned_std_vector<float>* local_view_z = nullptr;
+  if (try_view_filter)
+  {
+    local_view_x = localPoints->getPointsBufferRef_float_field("view_x");
+    local_view_y = localPoints->getPointsBufferRef_float_field("view_y");
+    local_view_z = localPoints->getPointsBufferRef_float_field("view_z");
+  }
+  const bool have_local_view_fields =
+      (local_view_x != nullptr) && (local_view_y != nullptr) && (local_view_z != nullptr);
+
+  const double max_view_angle_deg = std::clamp(creationOptions.max_view_angle_deg, 0.0, 180.0);
+  const bool   do_view_filter =
+      try_view_filter && have_local_view_fields && max_view_angle_deg < 180.0;
+  const float view_cos_threshold =
+      do_view_filter ? static_cast<float>(std::cos(mrpt::DEG2RAD(max_view_angle_deg))) : -2.0f;
+
+  // Per-active-KF lookup tables, built once (not per query point).
+  struct ActiveKfEntry
+  {
+    const mrpt::maps::CPointsMap*                  globalPoints = nullptr;
+    const std::vector<mrpt::math::CMatrixFloat33>* globalCov    = nullptr;
+    const mrpt::aligned_std_vector<float>*         view_x       = nullptr;
+    const mrpt::aligned_std_vector<float>*         view_y       = nullptr;
+    const mrpt::aligned_std_vector<float>*         view_z       = nullptr;
+  };
+  std::vector<ActiveKfEntry> entries;
+  entries.reserve(activeKfs.size());
+  for (const auto kf_id : activeKfs)
+  {
+    const auto& kf = keyframes_.at(kf_id);
+    if (!kf.pointcloud() || kf.pointcloud()->empty())
+    {
+      continue;
+    }
+    ActiveKfEntry e;
+    const auto&   gp = kf.pointcloud_global();
+    gp->kdTreeEnsureIndexBuilt3D();
+    e.globalPoints = gp.get();
+    e.globalCov    = &kf.covariancesGlobal();
+    if (do_view_filter)
+    {
+      e.view_x = gp->getPointsBufferRef_float_field("view_x");
+      e.view_y = gp->getPointsBufferRef_float_field("view_y");
+      e.view_z = gp->getPointsBufferRef_float_field("view_z");
+    }
+    entries.push_back(e);
+  }
+
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  tbb::enumerable_thread_specific<mp2p_icp::MatchedPointWithCovList> tls;
+
+  tbb::parallel_for(
+      static_cast<size_t>(0), localPointCount,
+      [&](size_t local_idx)
+#else
+  for (size_t local_idx = 0; local_idx < localPointCount; local_idx++)
+#endif
+      {
+        // "N" KD-tree queries (one per active KF) instead of one on a merged cloud:
+        float  best_dist_sqr = std::numeric_limits<float>::max();
+        size_t best_entry    = 0;
+        size_t best_idx      = 0;
+        bool   found         = false;
+
+        for (size_t e = 0; e < entries.size(); e++)
+        {
+          float      d   = std::numeric_limits<float>::max();
+          const auto idx = entries[e].globalPoints->kdTreeClosestPoint3D(
+              xs_tf[local_idx], ys_tf[local_idx], zs_tf[local_idx], d);
+          if (d < best_dist_sqr)
+          {
+            best_dist_sqr = d;
+            best_entry    = e;
+            best_idx      = idx;
+            found         = true;
+          }
+        }
+
+        if (!found || best_dist_sqr > max_sqr_dist)
+        {
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+          return;  // exit TBB lambda for this index
+#else
+      continue;  // skip to next iteration of the for loop
+#endif
+        }
+
+        const auto& entry = entries[best_entry];
+
+        if (do_view_filter && entry.view_x != nullptr && entry.view_y != nullptr &&
+            entry.view_z != nullptr)
+        {
+          const auto v_local_global =
+              localKf.pose()
+                  .rotateVector(
+                      {(*local_view_x)[local_idx], (*local_view_y)[local_idx],
+                       (*local_view_z)[local_idx]})
+                  .cast<float>();
+
+          const float dot = v_local_global.x * (*entry.view_x)[best_idx] +
+                            v_local_global.y * (*entry.view_y)[best_idx] +
+                            v_local_global.z * (*entry.view_z)[best_idx];
+
+          if (dot < view_cos_threshold)
+          {
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+            return;  // exit TBB lambda for this index
+#else
+        continue;  // skip to next iteration of the for loop
+#endif
+          }
+        }
+
+    // Add pairing:
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+        auto& p = tls.local().emplace_back();
+#else
+    auto& p = outPairings.emplace_back();
+#endif
+
+        const auto& g_xs = entry.globalPoints->getPointsBufferRef_x();
+        const auto& g_ys = entry.globalPoints->getPointsBufferRef_y();
+        const auto& g_zs = entry.globalPoints->getPointsBufferRef_z();
+
+        p.global_idx =
+            packApproxGlobalIdx(static_cast<uint32_t>(best_entry), static_cast<uint32_t>(best_idx));
+        p.local_idx = static_cast<uint32_t>(local_idx);
+        p.local     = {xs[local_idx], ys[local_idx], zs[local_idx]};
+        p.global    = {g_xs[best_idx], g_ys[best_idx], g_zs[best_idx]};
+
+        /* Following GICP \cite segal2009gicp this should be:
+         *  `(COV_{global} + R*COV_{local}*R^T)^{-1}`
+         *  But localKfCov already incorporate R*C*R^T from localKf.pose(p)
+         */
+        p.cov_inv = (entry.globalCov->at(best_idx) + localKfCov.at(local_idx)).inverse();
+      }
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  );
+  // Merge from all threads:
+  for (auto& localVec : tls)
+  {
+    outPairings.insert(
+        outPairings.end(), std::make_move_iterator(localVec.begin()),
+        std::make_move_iterator(localVec.end()));
+  }
+#endif
+}
+
 std::size_t KeyframePointCloudMap::point_count() const
 {
   std::size_t total = 0;
@@ -1123,6 +1351,9 @@ bool KeyframePointCloudMap::trySetCreationOptions(
   // covariances), instead of being read live from `creationOptions`. Propagate the new values
   // to all existing keyframes and invalidate their cached covariances, so they get recomputed
   // with the new parameters next time they are queried.
+  // Note on approximate_cov: icp_get_prepared_as_global() compares
+  // cached_.icp_search_built_approximate against the live option, so a change here (even
+  // with an unchanged active KF set) is picked up and forces a rebuild on the next call.
   TCreationOptions newOpts = creationOptions;
   newOpts.loadFromConfigFile(cfg, section);
   creationOptions = newOpts;
@@ -1813,6 +2044,7 @@ void KeyframePointCloudMap::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR_CS(use_view_direction_filter, bool);
   MRPT_LOAD_CONFIG_VAR_CS(max_view_angle_deg, double);
   MRPT_LOAD_CONFIG_VAR_CS(serialize_kdtrees, bool);
+  MRPT_LOAD_CONFIG_VAR_CS(approximate_cov, bool);
 }
 
 void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out) const
@@ -1827,17 +2059,19 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(use_view_direction_filter, bool);
   LOADABLEOPTS_DUMP_VAR(max_view_angle_deg, double);
   LOADABLEOPTS_DUMP_VAR(serialize_kdtrees, bool);
+  LOADABLEOPTS_DUMP_VAR(approximate_cov, bool);
 }
 
 void KeyframePointCloudMap::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  out.WriteAs<uint8_t>(4);  // version
+  out.WriteAs<uint8_t>(5);  // version
   out << max_search_keyframes << k_correspondences_for_cov;
   out << rotation_distance_weight << num_diverse_keyframes;  // v1
   out << use_view_direction_filter << max_view_angle_deg;  // v2
   out << min_correspondences_for_cov << max_distance_for_cov;  // v3
   out << serialize_kdtrees;  // v4
+  out << approximate_cov;  // v5
 }
 
 void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -1852,6 +2086,7 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
     case 2:
     case 3:
     case 4:
+    case 5:
     {
       in >> max_search_keyframes >> k_correspondences_for_cov;
       if (version >= 1)
@@ -1870,6 +2105,10 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
       if (version >= 4)
       {
         in >> serialize_kdtrees;
+      }
+      if (version >= 5)
+      {
+        in >> approximate_cov;
       }
     }
     break;

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -28,6 +28,7 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -1082,6 +1083,267 @@ void test_default_creation_options()
   ASSERT_NEAR_(m.creationOptions.max_view_angle_deg, 120.0, 1e-9);
   ASSERT_GT_(m.creationOptions.k_correspondences_for_cov, 0U);
   ASSERT_GT_(m.creationOptions.max_search_keyframes, 0U);
+  ASSERT_(m.creationOptions.approximate_cov == false);
+}
+
+// ---------------------------------------------------------------------------
+// approximate_cov: per-active-KF KD-tree queries instead of a merged submap
+// (see TCreationOptions::approximate_cov / nn_search_cov2cov_approximate()).
+// ---------------------------------------------------------------------------
+
+// ── 27. approximate_cov round-trips through serialization ─────────────────
+void test_approximate_cov_option_roundtrip()
+{
+  mola::KeyframePointCloudMap m;
+  m.creationOptions.approximate_cov = true;
+
+  mrpt::io::CMemoryStream buf;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << m;
+  }
+  buf.Seek(0);
+
+  mola::KeyframePointCloudMap m2;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar >> m2;
+  }
+  ASSERT_(m2.creationOptions.approximate_cov == true);
+}
+
+// ── 28. approximate_cov requires icp_get_prepared_as_global() first ───────
+// Mirrors the exact-mode contract: calling nn_search_cov2cov() without a prior
+// icp_get_prepared_as_global() must fail loudly rather than silently no-op.
+void test_approximate_cov_requires_prepared_call()
+{
+  auto global_m                            = makeMapFromCloud(makeCloudWithViews(makeGridPts()));
+  auto local_m                             = makeMapFromCloud(makeCloudWithViews(makeGridPts()));
+  global_m.creationOptions.approximate_cov = true;
+
+  mp2p_icp::MatchedPointWithCovList pairings;
+  bool                              threw = false;
+  try
+  {
+    global_m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), 1.0f, pairings);
+  }
+  catch (const std::exception&)
+  {
+    threw = true;
+  }
+  ASSERT_(threw);
+}
+
+// ── 29. approximate_cov (single active KF) matches exact mode ─────────────
+// With exactly one active KF, the "merged submap" is identical to that KF's own
+// global cloud, and covariances are computed from the very same within-KF
+// neighborhood in both modes. So the two modes must produce numerically
+// equivalent pairings (same count, same points, same covariances).
+void test_approximate_cov_matches_exact_single_kf()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f);
+  auto local_pts  = makeGridPts(kDz, 0.f, 0.f, 1.f);
+
+  auto exact_m                             = makeMapFromCloud(makeCloudWithViews(global_pts));
+  auto approx_m                            = makeMapFromCloud(makeCloudWithViews(global_pts));
+  approx_m.creationOptions.approximate_cov = true;
+
+  auto local_m1 = makeMapFromCloud(makeCloudWithViews(local_pts));
+  auto local_m2 = makeMapFromCloud(makeCloudWithViews(local_pts));
+
+  exact_m.creationOptions.use_view_direction_filter  = false;
+  approx_m.creationOptions.use_view_direction_filter = false;
+
+  exact_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+  approx_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+
+  mp2p_icp::MatchedPointWithCovList exactPairings, approxPairings;
+  exact_m.nn_search_cov2cov(local_m1, mrpt::poses::CPose3D::Identity(), kMaxDist, exactPairings);
+  approx_m.nn_search_cov2cov(local_m2, mrpt::poses::CPose3D::Identity(), kMaxDist, approxPairings);
+
+  ASSERT_EQUAL_(exactPairings.size(), approxPairings.size());
+  ASSERT_EQUAL_(exactPairings.size(), global_pts.size());
+
+  // Sort both lists by local_idx so entries line up (TBB may reorder them).
+  const auto byLocalIdx = [](const auto& a, const auto& b) { return a.local_idx < b.local_idx; };
+  std::sort(exactPairings.begin(), exactPairings.end(), byLocalIdx);
+  std::sort(approxPairings.begin(), approxPairings.end(), byLocalIdx);
+
+  for (size_t i = 0; i < exactPairings.size(); i++)
+  {
+    const auto& e = exactPairings[i];
+    const auto& a = approxPairings[i];
+    ASSERT_EQUAL_(e.local_idx, a.local_idx);
+    ASSERT_NEAR_((e.local - a.local).norm(), 0.f, 1e-5f);
+    ASSERT_NEAR_((e.global - a.global).norm(), 0.f, 1e-5f);
+    ASSERT_NEAR_((e.cov_inv - a.cov_inv).norm(), 0.0f, 1e-3f);
+  }
+}
+
+// ── 30. approximate_cov: distance threshold is still respected ────────────
+void test_approximate_cov_distance_threshold_respected()
+{
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f);
+  auto local_pts  = makeGridPts(5.f, 0.f, 0.f, 1.f);  // 5 m away: beyond any small threshold
+
+  auto global_m = makeMapFromCloud(makeCloudWithViews(global_pts));
+  auto local_m  = makeMapFromCloud(makeCloudWithViews(local_pts));
+
+  global_m.creationOptions.approximate_cov           = true;
+  global_m.creationOptions.use_view_direction_filter = false;
+  global_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+
+  mp2p_icp::MatchedPointWithCovList pairings;
+  global_m.nn_search_cov2cov(
+      local_m, mrpt::poses::CPose3D::Identity(), /*max_search_distance=*/0.5f, pairings);
+
+  ASSERT_EQUAL_(pairings.size(), 0UL);
+}
+
+// ── 31. approximate_cov with multiple active KFs picks the true closest ────
+// Two well-separated keyframes (no overlap) are both in the active set. Each
+// query point must pair with a point from ITS OWN nearby keyframe, proving the
+// "N kd-tree queries, keep the best" logic correctly picks across keyframes
+// rather than only ever using the first (or last) one queried.
+void test_approximate_cov_multi_kf_picks_closest()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+  constexpr float kKf1X    = 100.0f;  // far enough that the two grids never overlap
+
+  mola::KeyframePointCloudMap m;
+  m.creationOptions.k_correspondences_for_cov = 5;
+  m.creationOptions.max_search_keyframes      = 2;
+  m.creationOptions.approximate_cov           = true;
+  m.creationOptions.use_view_direction_filter = false;
+
+  auto obs0        = mrpt::obs::CObservationPointCloud::Create();
+  obs0->pointcloud = makeCloudWithViews(makeGridPts(0.f));
+  m.insertObservation(*obs0, mrpt::poses::CPose3D::Identity());
+
+  auto obs1        = mrpt::obs::CObservationPointCloud::Create();
+  obs1->pointcloud = makeCloudWithViews(makeGridPts(0.f));
+  m.insertObservation(*obs1, mrpt::poses::CPose3D::FromXYZYawPitchRoll(kKf1X, 0, 0, 0, 0, 0));
+
+  m.icp_get_prepared_as_global(mrpt::poses::CPose3D::FromXYZYawPitchRoll(kKf1X / 2, 0, 0, 0, 0, 0));
+
+  // Local query cloud: one grid near KF0, one grid near KF1 (both offset by kDz).
+  auto local_pts = makeGridPts(kDz, 0.f, 0.f, 1.f);
+  for (const auto& p : makeGridPts(kDz, 0.f, 0.f, 1.f))
+  {
+    appendPt(local_pts, p[0] + kKf1X, p[1], p[2], p[3], p[4], p[5]);
+  }
+  auto local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+
+  mp2p_icp::MatchedPointWithCovList pairings;
+  m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), kMaxDist, pairings);
+
+  // Every local point (near either KF) must find a close pairing in its own KF.
+  ASSERT_EQUAL_(pairings.size(), local_pts.size());
+  for (const auto& p : pairings)
+  {
+    const auto  diff = p.global - p.local;
+    const float d2   = diff.sqrNorm();
+    ASSERT_NEAR_(d2, kDz * kDz, 1e-4f);
+  }
+}
+
+// ── 32. approximate_cov: view-direction filter still applies ──────────────
+// Same scenario as test_view_filter_rejects_opposite_view_pairs(), but with
+// approximate_cov=true and a single active KF, confirming the filter logic is
+// preserved by the per-KF code path.
+void test_approximate_cov_view_filter_rejects_opposite_view_pairs()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+  constexpr float kTrapX   = 10.0f;
+  constexpr float kGoodX   = 20.0f;
+
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f);
+  appendPt(global_pts, kTrapX, 0.f, 0.f, 0.f, 0.f, -1.f);  // P_bad: back-face
+  appendPt(global_pts, kGoodX, 0.f, 0.f, 0.f, 0.f, +1.f);  // P_good: front-face
+  const size_t totalPts = global_pts.size();  // 32
+
+  auto local_pts = makeGridPts(kDz, 0.f, 0.f, 1.f);
+  appendPt(local_pts, kTrapX, 0.f, kDz, 0.f, 0.f, +1.f);  // Q_trap: front-face
+  appendPt(local_pts, kGoodX, 0.f, kDz, 0.f, 0.f, +1.f);  // Q_good: front-face
+  ASSERT_EQUAL_(local_pts.size(), totalPts);
+
+  auto global_m = makeMapFromCloud(makeCloudWithViews(global_pts));
+  auto local_m  = makeMapFromCloud(makeCloudWithViews(local_pts));
+
+  global_m.creationOptions.approximate_cov = true;
+  global_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+
+  // ---- filter ON (default 120°) ----
+  global_m.creationOptions.use_view_direction_filter = true;
+  global_m.creationOptions.max_view_angle_deg        = 120.0;
+  {
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), kMaxDist, pairings);
+    ASSERT_EQUAL_(pairings.size(), totalPts - 1);
+  }
+
+  // ---- filter OFF ----
+  global_m.creationOptions.use_view_direction_filter = false;
+  {
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), kMaxDist, pairings);
+    ASSERT_EQUAL_(pairings.size(), totalPts);
+  }
+}
+
+// ── 33. Toggling approximate_cov forces a rebuild even if the KF selection
+//        (active set) does not change ────────────────────────────────────
+// icp_get_prepared_as_global() early-returns when the active-KF-set selection
+// is unchanged. This must NOT short-circuit a switch between exact/approximate
+// mode, or nn_search_cov2cov() would use a stale cache built under the other
+// mode. Toggle the flag with the very same query pose (so the KF selection is
+// identical) and check both modes still work right after the switch.
+void test_approximate_cov_mode_switch_invalidates_cache()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f);
+  auto local_pts  = makeGridPts(kDz, 0.f, 0.f, 1.f);
+
+  auto global_m = makeMapFromCloud(makeCloudWithViews(global_pts));
+  global_m.creationOptions.use_view_direction_filter = false;
+
+  const auto pose = mrpt::poses::CPose3D::Identity();
+
+  // Start in exact mode.
+  global_m.icp_get_prepared_as_global(pose);
+  {
+    auto                              local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, pose, kMaxDist, pairings);
+    ASSERT_EQUAL_(pairings.size(), global_pts.size());
+  }
+
+  // Switch to approximate mode with the SAME pose (same KF selection).
+  global_m.creationOptions.approximate_cov = true;
+  global_m.icp_get_prepared_as_global(pose);
+  {
+    auto                              local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, pose, kMaxDist, pairings);
+    ASSERT_EQUAL_(pairings.size(), global_pts.size());
+  }
+
+  // Switch back to exact mode, again with the same pose.
+  global_m.creationOptions.approximate_cov = false;
+  global_m.icp_get_prepared_as_global(pose);
+  {
+    auto                              local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global_m.nn_search_cov2cov(local_m, pose, kMaxDist, pairings);
+    ASSERT_EQUAL_(pairings.size(), global_pts.size());
+  }
 }
 }  // namespace
 
@@ -1166,6 +1428,27 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_viz_color_by_kf ...\n";
     test_viz_color_by_kf();
+
+    std::cout << "test_approximate_cov_option_roundtrip ...\n";
+    test_approximate_cov_option_roundtrip();
+
+    std::cout << "test_approximate_cov_requires_prepared_call ...\n";
+    test_approximate_cov_requires_prepared_call();
+
+    std::cout << "test_approximate_cov_matches_exact_single_kf ...\n";
+    test_approximate_cov_matches_exact_single_kf();
+
+    std::cout << "test_approximate_cov_distance_threshold_respected ...\n";
+    test_approximate_cov_distance_threshold_respected();
+
+    std::cout << "test_approximate_cov_multi_kf_picks_closest ...\n";
+    test_approximate_cov_multi_kf_picks_closest();
+
+    std::cout << "test_approximate_cov_view_filter_rejects_opposite_view_pairs ...\n";
+    test_approximate_cov_view_filter_rejects_opposite_view_pairs();
+
+    std::cout << "test_approximate_cov_mode_switch_invalidates_cache ...\n";
+    test_approximate_cov_mode_switch_invalidates_cache();
 
     std::cout << "\nAll tests passed.\n";
   }


### PR DESCRIPTION
## Summary
- Add `KeyframePointCloudMap::TCreationOptions::approximate_cov` (default `false`). When enabled, `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e. GICP-style pipelines) skips building the merged, multi-keyframe submap that `icp_get_prepared_as_global()` normally assembles for the active KF set, and instead queries each active keyframe's own already-cached KD-tree + per-point covariances directly ("N" per-KF KD-tree lookups instead of one on a merged cloud, keeping the closest).
- This trades a small amount of covariance exactness (estimated only from within-KF neighbors instead of the merged multi-KF cloud) for speed (no merge/KD-tree rebuild on `icp_get_prepared_as_global()`).
- Fixed a latent cache-staleness edge case along the way: `icp_get_prepared_as_global()`'s "selection unchanged, skip rebuild" early-return now also checks that the cache was built under the same exact/approximate mode, so toggling `approximate_cov` at runtime with an unchanged active KF set is picked up correctly.
- Updated `agents.md` per repo convention.

## Test plan
- [x] `colcon build --packages-select mola_metric_maps --cmake-args -DBUILD_TESTING=ON`
- [x] `test-mola_metric_maps_keyframemap` — all tests pass, including 7 new tests covering: option serialization round-trip, the "must call `icp_get_prepared_as_global()` first" contract, numerical equivalence vs. exact mode with a single active KF, distance-threshold enforcement, correct closest-KF selection across multiple active KFs, the view-direction filter, and runtime mode-switch cache invalidation.
- [x] `clang-format` applied to all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vMS2X5d6Xu3Zo8NCQbCdN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional approximate covariance matching mode for keyframe point-cloud searches.
  * Exposed the setting in documentation and configuration (including persistence via text/binary serialization).

* **Bug Fixes**
  * Improved prepared-cache handling so switching between exact/approximate modes forces correct rebuilds.
  * Ensured existing distance thresholding and view-direction filtering behavior remains consistent in approximate mode.

* **Tests**
  * Added unit tests for serialization round-trip, “must prepare first” behavior, single- vs multi-keyframe matching correctness, filtering, and cache refresh when toggling modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->