### PR TITLE
fix(mola_viz_imgui): Console log window perf/config follow-ups

### DIFF
--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -66,6 +66,11 @@ class ConsoleLogSink
   void                        note_source(const std::string& s);
   std::vector<std::string>    sources() const;
 
+  /** Bumped on every push()/clear(). Lock-free, so callers that re-render
+   *  every frame (e.g. the Console window) can skip the snapshot()/lock/copy
+   *  entirely when nothing changed since their last cached copy. */
+  uint64_t version() const { return version_.load(std::memory_order_relaxed); }
+
   std::atomic<size_t> max_entries{5000};
   std::atomic<double> window_seconds{120.0};
 
@@ -73,6 +78,7 @@ class ConsoleLogSink
   mutable std::mutex          mtx_;
   std::deque<ConsoleLogEntry> entries_;
   std::set<std::string>       sources_;
+  std::atomic<uint64_t>       version_{0};
 };
 
 /** Core rendering and state-management logic for the Dear ImGui MOLA viz backend.
@@ -355,9 +361,16 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   /** Rolling time window (seconds): entries older than this are dropped. */
   double console_window_seconds_ = 120.0;
 
-  /** Verbosity threshold used when registering module log callbacks.
-   *  Default DEBUG so the UI can reveal all levels. */
-  mrpt::system::VerbosityLevel console_capture_level_ = mrpt::system::LVL_DEBUG;
+  /** Verbosity threshold used when registering module log callbacks (i.e.
+   *  what gets captured pipeline-wide, as opposed to `console_level_enabled_`
+   *  below, which only filters what the already-captured entries display).
+   *  Default INFO: capturing DEBUG from every module forces every
+   *  MRPT_LOG_DEBUG_STREAM() callsite in the whole pipeline to always format
+   *  its message just to feed the sink, even if the UI ends up hiding it.
+   *  Runtime-adjustable from the Console window's "Capture" combo; atomic
+   *  because it's written from the GUI thread and read from the module's
+   *  own spin thread (see `MolaVizImGui::console_check_new_modules()`). */
+  std::atomic<mrpt::system::VerbosityLevel> console_capture_level_{mrpt::system::LVL_INFO};
 
   /** Sink shared with the per-module logger callbacks; always allocated,
    *  populated only while `console_enabled_` is true. */
@@ -481,6 +494,12 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   std::string console_filter_text_;
   bool        console_level_enabled_[4] = {false, true, true, true};  // D,I,W,E
   bool        console_autoscroll_       = true;
+
+  // Cached copy of the sink's entries, refreshed only when `ConsoleLogSink::
+  // version()` changes -- avoids a full deque-of-strings copy under the
+  // sink's mutex on every rendered frame when nothing new was logged.
+  std::deque<ConsoleLogEntry> console_cached_entries_;
+  uint64_t                    console_cached_version_ = 0;
 
   // Selected source filter, keyed by name (empty == "all"), not by an index
   // into `ConsoleLogSink::sources()` -- that set is sorted and its order

--- a/mola_viz_imgui/src/ConsoleLogSink.cpp
+++ b/mola_viz_imgui/src/ConsoleLogSink.cpp
@@ -41,6 +41,8 @@ void ConsoleLogSink::push(const ConsoleLogEntry& e)
   {
     entries_.pop_front();
   }
+
+  version_.fetch_add(1, std::memory_order_relaxed);
 }
 
 std::deque<ConsoleLogEntry> ConsoleLogSink::snapshot() const
@@ -53,6 +55,7 @@ void ConsoleLogSink::clear()
 {
   std::lock_guard<std::mutex> lk(mtx_);
   entries_.clear();
+  version_.fetch_add(1, std::memory_order_relaxed);
 }
 
 void ConsoleLogSink::note_source(const std::string& s)

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -427,17 +427,24 @@ void MolaVizImGui::console_check_new_modules()
   auto sink = core_ptr_->console_sink_;
   if (!sink) return;
 
+  // Read once per tick: the user may have changed it at runtime via the
+  // Console window's "Capture" combo (MolaVizImGuiCore::render_console_window).
+  const auto captureLevel = core_ptr_->console_capture_level_.load();
+
   for (auto& module : findService<ExecutableBase>())
   {
     if (module.get() == this) continue;  // never hook ourselves (recursion)
+
+    // Re-applied every tick (not just at hook time) so a runtime change to
+    // the capture level propagates to already-hooked modules too. Does not
+    // change what actually prints to the terminal, only what's forwarded to
+    // the console callback -- see setVerbosityLevelForCallbacks() docs.
+    module->setVerbosityLevelForCallbacks(captureLevel);
 
     const std::string name = module->getModuleInstanceName();
     if (consoleHookedModules_.count(name)) continue;
     consoleHookedModules_.insert(name);
     sink->note_source(name);
-
-    // Capture all levels for the UI filter; does not change console verbosity.
-    module->setVerbosityLevelForCallbacks(core_ptr_->console_capture_level_);
 
     // shared_ptr capture keeps the sink alive as long as the module's logger
     // holds this callback; 'name' (not loggerName) is captured for a stable id.

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -588,6 +588,18 @@ void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
     console_selected_source_name_ = selCombo > 0 ? srcs[static_cast<size_t>(selCombo - 1)] : "";
   ImGui::SameLine();
 
+  static const char* kCaptureLevelNames[] = {"Debug", "Info", "Warn", "Error"};
+  int                captureIdx           = static_cast<int>(console_capture_level_.load());
+  ImGui::SetNextItemWidth(100);
+  if (ImGui::Combo("Capture", &captureIdx, kCaptureLevelNames, IM_ARRAYSIZE(kCaptureLevelNames)))
+    console_capture_level_.store(static_cast<mrpt::system::VerbosityLevel>(captureIdx));
+  if (ImGui::IsItemHovered())
+    ImGui::SetTooltip(
+        "Verbosity threshold sent by every module to this console (pipeline-wide).\n"
+        "Raising it to Debug makes ALL modules pay the cost of formatting debug\n"
+        "log lines, even ones the Levels filter below then hides.\n"
+        "The Levels checkboxes only filter what's already been captured.");
+
   ImGui::TextUnformatted("Levels:");
   ImGui::SameLine();
   ImGui::Checkbox("D", &console_level_enabled_[0]);
@@ -603,9 +615,27 @@ void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
   ImGui::Separator();
 
   // ---- Log area -------------------------------------------------------------
+  // Re-snapshot the sink only when it actually changed (version bump on
+  // push()/clear()). Producer threads (module loggers) and this GUI thread
+  // both contend on the sink's mutex; a plain snapshot() on every rendered
+  // frame -- regardless of whether new entries arrived -- copies the whole
+  // (up to `max_entries`) deque under that lock at up to `target_fps_` Hz,
+  // which is wasted work when logging is idle or between bursts, and briefly
+  // blocks any module trying to push() a new line while the copy runs.
+  // Read the version *before* copying: if a push() races in between and
+  // lands in the copy anyway, we'll just re-snapshot once more than strictly
+  // needed next frame -- reading it after the copy could instead record a
+  // version newer than what was actually captured, permanently hiding that
+  // entry until the next push happens to change the version again.
+  if (const uint64_t v = console_sink_->version(); v != console_cached_version_)
+  {
+    console_cached_entries_ = console_sink_->snapshot();
+    console_cached_version_ = v;
+  }
+
   ImGui::BeginChild("##log", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
 
-  for (const auto& e : console_sink_->snapshot())
+  for (const auto& e : console_cached_entries_)
   {
     if (!console_entry_passes_filters(e)) continue;
 


### PR DESCRIPTION
## Summary
Follow-up hardening for the Console log window added in #167/coderabbitai-reviewed already. Three issues found while auditing `ConsoleLogSink`/`render_console_window`:

- **Capture level defaulted to DEBUG pipeline-wide.** `console_check_new_modules()` called `setVerbosityLevelForCallbacks(LVL_DEBUG)` on every discovered module, which via `isLoggingLevelVisible()` forces every `MRPT_LOG_DEBUG_STREAM()` callsite in the *entire* pipeline to always format its message -- even though the Console UI hides Debug entries by default. Default is now INFO, and it's runtime-adjustable from a new "Capture" combo in the toolbar (tooltip clarifies it's pipeline-wide capture, distinct from the Levels checkboxes which only filter what's already captured). Re-applied to already-hooked modules every discovery tick so a runtime change takes effect immediately, not just for newly-discovered modules.
- **`snapshot()` copied under lock on every rendered frame.** `render_console_window()` called `console_sink_->snapshot()` (full deque-of-strings copy under `ConsoleLogSink`'s mutex) unconditionally, up to `target_fps_` times/sec, contending with module threads trying to `push()` new lines. Added a lock-free `version()` counter (bumped on `push()`/`clear()`); the window now only re-snapshots when the sink actually changed.
- Related: [MRPT/mrpt#1375](https://github.com/MRPT/mrpt/pull/1375) fixes an unsynchronized concurrent access to `COutputLogger`'s callback list in MRPT itself, triggered by this window's pattern of registering a callback on an already-running module from the GUI thread.

## Test plan
- [x] `colcon build --packages-select mola_viz_imgui` clean (no new warnings).
- [x] Verified interactively with a throwaway repro harness (GLFW window + `MolaVizImGuiCore` + multiple threads hammering `logStr()` while a separate thread registers callbacks mid-flight, mirroring `console_check_new_modules()`): Capture combo defaults to Info, changing it live updates capture immediately, autoscroll/coloring/multi-line/long-line rendering all correct, no regressions from the snapshot caching.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dnw8SX9MWvxpwoTgkR155K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Capture** verbosity setting in the console, letting you control which log messages are captured at runtime.
  * Console log display now updates more efficiently by refreshing only when new log activity appears.

* **Bug Fixes**
  * Runtime changes to the console capture level now apply consistently to already-connected modules.
  * Console logging and display are now better synchronized when logs are added or cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->