### PR TITLE
feat(mola_metric_maps): persist per-KF covariances + query baked local KD-tree in approximate cov2cov

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -153,16 +153,36 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   Only affects `nn_search_cov2cov()`; the generic `NearestNeighborsCapable` entry points
   still require the merged submap. Exposed in `mola_lidar_odometry`'s
   `pipelines/lidar3d-gicp.yaml` as `MOLA_LOCALMAP_APPROXIMATE_COV`.
-- CLI tool `mm-kf-bake-kdtrees` (in `apps/`): "idea 2" of the same plan. Caches each
-  keyframe's per-cloud 3D KD-tree index inside the `.mm` so it is not rebuilt on every load
-  (faster localization-only startup). Backed by the `serialize_kdtrees` creationOption of
-  `KeyframePointCloudMap` (default false; bumps map serialization to v2, writing a
-  self-describing per-KF flag byte + KD-tree blob). Requires the MRPT KD-tree save/load
-  index API (`mrpt::math::KDTreeCapable::kdtree_save_index_3D()` / `kdtree_load_index_3D()`,
-  feature-detected via the `MRPT_HAS_KDTREE_SAVE_LOAD_INDEX` macro); when absent the option
-  is a no-op on write and the reader skips any stored blob, so `.mm` files stay
-  interoperable across MRPT builds. On the 5-super-KF outdoor map above (9.4M points),
-  baking adds ~58 MB of index data and the load path installs the indices with no rebuild.
+  **Queries the per-KF *local*-frame cloud/KD-tree directly** (`kf.pointcloud()`, which is
+  what `mm-kf-bake-kdtrees` bakes on disk): the query point is transformed into each active
+  KF's local frame (`pose^{-1}`) before the lookup, and the match is composed back to global
+  for the output pairing. A KD-tree's structure is invariant under the rigid KF pose, so this
+  avoids ever materializing a per-KF *global*-frame cloud or rebuilding a KD-tree on it — the
+  reason the baked (local) index previously did not accelerate this path, and why a fresh KF
+  entering the active set used to stall the LiDAR worker for seconds. Also robust to online KF
+  pose nudges (e.g. LIO gravity-tilt correction), which no longer invalidate a global cloud.
+- CLI tool `mm-kf-bake-kdtrees` (in `apps/`): "idea 2" of the same plan. Caches heavy
+  per-keyframe structures inside the `.mm` so they are not rebuilt on every load (faster
+  localization-only startup). Two independent, self-describing caches (each gated by a flag
+  byte, so `.mm` files stay interoperable across MRPT builds):
+  - **KD-trees** (`serialize_kdtrees` creationOption, default false): each keyframe's
+    per-cloud 3D KD-tree index (on the *local*-frame cloud). Requires the MRPT KD-tree
+    save/load index API (`mrpt::math::KDTreeCapable::kdtree_save_index_3D()` /
+    `kdtree_load_index_3D()`, feature-detected via the `MRPT_HAS_KDTREE_SAVE_LOAD_INDEX`
+    macro); when absent the option is a no-op on write and the reader skips any stored blob.
+    On the 5-super-KF outdoor map above (9.4M points), baking adds ~58 MB. This is the same
+    local index the `approximate_cov` path now queries directly (see above), so baking finally
+    accelerates the localization hot path, not just startup.
+  - **Covariances** (`serialize_covariances` creationOption, default false): each keyframe's
+    per-point *local*-frame covariances (the plane-regularized SVD result). Needs **no special
+    MRPT API** (works on any build). Covariance computation (one K-NN + 3×3 SVD per point) is
+    the single most expensive part of warming a keyframe, so persisting it removes the
+    multi-second stall paid the first time each KF becomes active. The cheap per-pose global
+    rotation is still done at runtime.
+
+  Bumps map serialization to v3 (v2 = KD-tree byte/blob after each KF cloud; v3 adds a
+  covariance byte + per-point matrices after that). The tool bakes both by default; use
+  `--no-kdtrees` / `--no-covariances` to select, or `--disable` to strip both.
 
 ---
 

--- a/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-bake-kdtrees/main.cpp
@@ -36,16 +36,19 @@ struct Args
   std::string output;
   std::string layer;  // empty: process all KeyframePointCloudMap layers
   std::string plugins;
-  bool        disable = false;  // if set, strip cached kd-trees instead of adding them
+  bool        disable     = false;  // if set, strip cached data instead of adding it
+  bool        kdtrees     = true;  // bake per-KF KD-tree indices
+  bool        covariances = true;  // bake per-point covariances
 };
 
 void run_bake(const Args& args)
 {
 #if !defined(MRPT_HAS_KDTREE_SAVE_LOAD_INDEX)
-  if (!args.disable)
+  if (!args.disable && args.kdtrees)
   {
     std::cout << "[mm-kf-bake-kdtrees] WARNING: this MRPT build lacks the KD-tree save/load "
-                 "index API; baking is a no-op and no KD-tree data will be written."
+                 "index API; KD-tree baking is a no-op and no KD-tree data will be written "
+                 "(covariance baking, if enabled, is unaffected)."
               << std::endl;
   }
 #endif
@@ -57,10 +60,14 @@ void run_bake(const Args& args)
       [&](const std::string& layerName, const mola::KeyframePointCloudMap::Ptr& kfMap,
           mrpt::maps::CMetricMap::Ptr& /*layerSlot*/)
       {
-        kfMap->creationOptions.serialize_kdtrees = !args.disable;
+        kfMap->creationOptions.serialize_kdtrees     = !args.disable && args.kdtrees;
+        kfMap->creationOptions.serialize_covariances = !args.disable && args.covariances;
         std::cout << "[mm-kf-bake-kdtrees] Layer '" << layerName << "': serialize_kdtrees -> "
                   << (kfMap->creationOptions.serialize_kdtrees ? "true" : "false")
-                  << " (KD-trees are (re)built on save only if not already current)." << std::endl;
+                  << ", serialize_covariances -> "
+                  << (kfMap->creationOptions.serialize_covariances ? "true" : "false")
+                  << " (cached data is (re)built on save only if not already current)."
+                  << std::endl;
       });
 
   std::cout << "[mm-kf-bake-kdtrees] Writing output map to: '" << args.output << "'..."
@@ -97,7 +104,18 @@ int main(int argc, char** argv)
 
     cli.add_flag(
         "--disable", args.disable,
-        "Instead of baking, strip any cached KD-trees (sets serialize_kdtrees=false).");
+        "Instead of baking, strip any cached data (sets serialize_kdtrees=false and "
+        "serialize_covariances=false).");
+
+    cli.add_flag(
+        "--kdtrees,!--no-kdtrees", args.kdtrees,
+        "Bake per-keyframe KD-tree indices (default: on). Requires an MRPT build with the "
+        "KD-tree save/load API.");
+
+    cli.add_flag(
+        "--covariances,!--no-covariances", args.covariances,
+        "Bake per-point covariances so they are not recomputed on load (default: on). Works on "
+        "any MRPT build.");
 
     cli.add_option(
         "-l,--load-plugins", args.plugins,

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -468,6 +468,23 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      */
     bool serialize_kdtrees = false;
 
+    /** If `true`, each keyframe's per-point covariances (the `cached_cov_local_`
+     *  produced by the plane-regularized SVD in `computeCovariancesAndDensity()`)
+     *  are serialized alongside its points, so they do NOT have to be recomputed
+     *  when the map is loaded. Covariance computation (one K-NN query + 3×3 SVD
+     *  per point) is the single most expensive part of warming a freshly-loaded
+     *  keyframe for ICP, so persisting it removes the multi-second stall paid the
+     *  first time each keyframe becomes active in localization-only operation.
+     *
+     *  Unlike `serialize_kdtrees`, this needs no special MRPT API and works on
+     *  any build. The stored covariances are the *local-frame* ones; the cheap
+     *  per-pose global rotation (`updateCovariancesGlobal()`) is still done at
+     *  runtime. Trades a larger `.mm` file (one 3×3 float matrix per point) for
+     *  faster startup. Default `false`. Typically enabled offline by the
+     *  `mm-kf-bake-kdtrees` tool.
+     */
+    bool serialize_covariances = false;
+
     /** If `true`, `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e.
      *  GICP-style pipelines) skips building the merged, multi-keyframe submap that
      *  `icp_get_prepared_as_global()` otherwise assembles for the active KF set.
@@ -623,6 +640,32 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
       computeCovariancesAndDensity();  // will reuse cached if possible
       updateCovariancesGlobal();  // (idem)
       return cached_cov_global_;
+    }
+
+    /** Ensures the per-point *local-frame* covariances are computed and returns
+     *  them. Used to bake them into the serialized map (see
+     *  `TCreationOptions::serialize_covariances`). */
+    const std::vector<mrpt::math::CMatrixFloat33>& covariancesLocal() const
+    {
+      computeCovariancesAndDensity();
+      return cached_cov_local_;
+    }
+
+    /** Installs precomputed per-point *local-frame* covariances loaded from a
+     *  baked `.mm`, so `computeCovariancesAndDensity()` becomes a no-op (it
+     *  early-returns when `cached_cov_local_.size() == pointcloud size`). The
+     *  global-frame rotation is invalidated so it is recomputed for the current
+     *  pose. No-op (covariances left to be computed lazily) if `covs` does not
+     *  match the current point count. Must be called after `pointcloud()`, which
+     *  clears all caches. */
+    void installCovariancesLocal(std::vector<mrpt::math::CMatrixFloat33>&& covs) const
+    {
+      if (!pointcloud_ || covs.size() != pointcloud_->size())
+      {
+        return;  // size mismatch: fall back to lazy recomputation
+      }
+      cached_cov_local_ = std::move(covs);
+      cached_cov_global_.clear();  // invalidate: rotated lazily for current pose
     }
 
     /** Builds (or get cached) visualization of the cloud in this KF, already transformed to its

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -326,6 +326,7 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
     case 0:
     case 1:
     case 2:
+    case 3:
     {
       // params:
       creationOptions.readFromStream(in);
@@ -386,7 +387,7 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
             const auto hasCov = in.ReadAs<uint8_t>();
             if (hasCov != 0)
             {
-              const auto                               nCov = in.ReadAs<uint32_t>();
+              const auto                              nCov = in.ReadAs<uint32_t>();
               std::vector<mrpt::math::CMatrixFloat33> covs(nCov);
               for (uint32_t c = 0; c < nCov; c++)
               {
@@ -1272,7 +1273,7 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
         p.local_idx = static_cast<uint32_t>(local_idx);
         p.local     = {xs[local_idx], ys[local_idx], zs[local_idx]};
         p.global    = {
-            static_cast<float>(g_pt.x), static_cast<float>(g_pt.y), static_cast<float>(g_pt.z)};
+               static_cast<float>(g_pt.x), static_cast<float>(g_pt.y), static_cast<float>(g_pt.z)};
 
         /* Following GICP \cite segal2009gicp this should be:
          *  `(COV_{global} + R*COV_{local}*R^T)^{-1}`

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -27,6 +27,7 @@
 #include <mrpt/img/TColor.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/math/TOrientedBox.h>
+#include <mrpt/math/matrix_serialization.h>  // CArchive << CMatrixFloat33 (cov baking)
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/customizable_obs_viz.h>
 #include <mrpt/opengl/CEllipsoid3D.h>
@@ -236,7 +237,7 @@ IMPLEMENTS_SERIALIZABLE(KeyframePointCloudMap, CMetricMap, mola)
 // Serialization
 // =====================================
 
-uint8_t KeyframePointCloudMap::serializeGetVersion() const { return 2; }
+uint8_t KeyframePointCloudMap::serializeGetVersion() const { return 3; }
 void    KeyframePointCloudMap::serializeTo(mrpt::serialization::CArchive& out) const
 {
   auto lck = mrpt::lockHelper(*state_mtx_);
@@ -280,6 +281,27 @@ void    KeyframePointCloudMap::serializeTo(mrpt::serialization::CArchive& out) c
       if (hasKdTree != 0)
       {
         out << kdBlob;
+      }
+
+      // v3: optionally cache the per-point local-frame covariances so they do not
+      // have to be recomputed (K-NN + SVD per point) on load. Self-describing: a
+      // flag byte precedes any data, so readers stay stream-aligned regardless of
+      // the write-time option. See TCreationOptions::serialize_covariances.
+      uint8_t hasCov = 0;
+      if (creationOptions.serialize_covariances)
+      {
+        hasCov = 1;
+      }
+      out.WriteAs<uint8_t>(hasCov);
+      if (hasCov != 0)
+      {
+        // Ensures cached_cov_local_ is populated (computes it if needed).
+        const auto& covs = kf.covariancesLocal();
+        out.WriteAs<uint32_t>(covs.size());
+        for (const auto& c : covs)
+        {
+          out << c;
+        }
       }
     }
     else
@@ -352,6 +374,25 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
               // outdated), so this must come after kf.pointcloud(pc).
               pc->kdtree_load_index_3D(ss);
 #endif
+            }
+          }
+
+          // v3: optional cached per-point local-frame covariances (see
+          // serializeTo). Always consume the flag byte + data so the stream stays
+          // aligned. Install them (after kf.pointcloud(pc), which cleared caches)
+          // so computeCovariancesAndDensity() becomes a no-op.
+          if (version >= 3)
+          {
+            const auto hasCov = in.ReadAs<uint8_t>();
+            if (hasCov != 0)
+            {
+              const auto                               nCov = in.ReadAs<uint32_t>();
+              std::vector<mrpt::math::CMatrixFloat33> covs(nCov);
+              for (uint32_t c = 0; c < nCov; c++)
+              {
+                in >> covs[c];
+              }
+              kf.installCovariancesLocal(std::move(covs));
             }
           }
         }
@@ -637,10 +678,22 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
   if (creationOptions.approximate_cov)
   {
     // Approximate mode: skip the merged-cloud submap entirely. nn_search_cov2cov()
-    // will instead query each active KF's own cached KD-tree directly. Here we only
-    // need to warm each active KF's per-KF (local) cache and its *global*-frame
-    // structures, so the first ICP align() does not pay that cost on the caller's
-    // thread. See TCreationOptions::approximate_cov.
+    // will instead query each active KF's own cached, *local*-frame KD-tree
+    // directly. A KD-tree's structure is invariant under the rigid keyframe pose,
+    // so rather than materializing a per-KF global-frame cloud and rebuilding a
+    // KD-tree on it (which the baked, on-disk index cannot accelerate, since the
+    // baked index lives on the local cloud), the matcher transforms the query
+    // point into each KF's local frame and queries the local (baked) index.
+    //
+    // Here we only warm each active KF's per-KF cache so the first ICP align()
+    // does not pay that cost on the caller's thread:
+    //   - buildCache(): local bbox, local KD-tree (installed from disk when
+    //     serialize_kdtrees was baked; otherwise built once), and the per-point
+    //     local covariances (installed from disk when serialize_covariances was
+    //     baked; otherwise computed once).
+    //   - covariancesGlobal(): the cheap per-pose rotation of those covariances.
+    // No global-frame cloud or KD-tree is built at all. See
+    // TCreationOptions::approximate_cov / serialize_covariances.
     cached_.icp_search_submap.reset();
 
     for (const auto kf_id : kfs_to_search_limited)
@@ -651,10 +704,7 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
         continue;
       }
       kf.buildCache();  // local bbox, KD-tree, per-point local covariances
-
-      const auto& globalPoints = kf.pointcloud_global();
-      globalPoints->kdTreeEnsureIndexBuilt3D();
-      kf.covariancesGlobal();
+      kf.covariancesGlobal();  // rotate covariances to the current global pose
     }
     return;
   }
@@ -1071,13 +1121,27 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
       do_view_filter ? static_cast<float>(std::cos(mrpt::DEG2RAD(max_view_angle_deg))) : -2.0f;
 
   // Per-active-KF lookup tables, built once (not per query point).
+  //
+  // Each active KF is queried through its OWN local-frame cloud and KD-tree
+  // (`kf.pointcloud()`), which is the one baked on disk by mm-kf-bake-kdtrees. The
+  // query point (in the global frame) is transformed into the KF's local frame via
+  // `poseInv` before the KD-tree lookup, and the matched local point is composed
+  // back to the global frame via `pose` for the output pairing. This avoids ever
+  // materializing a per-KF global-frame cloud or rebuilding a KD-tree on it.
   struct ActiveKfEntry
   {
-    const mrpt::maps::CPointsMap*                  globalPoints = nullptr;
-    const std::vector<mrpt::math::CMatrixFloat33>* globalCov    = nullptr;
-    const mrpt::aligned_std_vector<float>*         view_x       = nullptr;
-    const mrpt::aligned_std_vector<float>*         view_y       = nullptr;
-    const mrpt::aligned_std_vector<float>*         view_z       = nullptr;
+    const mrpt::maps::CPointsMap*                  localPoints = nullptr;  // baked KD-tree
+    mrpt::poses::CPose3D                           pose;  // KF pose (local->global)
+    mrpt::poses::CPose3D                           poseInv;  // its inverse (global->local)
+    const std::vector<mrpt::math::CMatrixFloat33>* globalCov = nullptr;  // per-pose rotated
+    // Local-frame coordinate buffers, parallel to the KD-tree points:
+    const mrpt::aligned_std_vector<float>* xs = nullptr;
+    const mrpt::aligned_std_vector<float>* ys = nullptr;
+    const mrpt::aligned_std_vector<float>* zs = nullptr;
+    // Local-frame view fields (rotated to global on the fly when filtering):
+    const mrpt::aligned_std_vector<float>* view_x = nullptr;
+    const mrpt::aligned_std_vector<float>* view_y = nullptr;
+    const mrpt::aligned_std_vector<float>* view_z = nullptr;
   };
   std::vector<ActiveKfEntry> entries;
   entries.reserve(activeKfs.size());
@@ -1093,20 +1157,25 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
       continue;
     }
     const auto& kf = it->second;
-    if (!kf.pointcloud() || kf.pointcloud()->empty())
+    const auto& lp = kf.pointcloud();
+    if (!lp || lp->empty())
     {
       continue;
     }
+    lp->kdTreeEnsureIndexBuilt3D();  // baked on disk when serialize_kdtrees was used
     ActiveKfEntry e;
-    const auto&   gp = kf.pointcloud_global();
-    gp->kdTreeEnsureIndexBuilt3D();
-    e.globalPoints = gp.get();
-    e.globalCov    = &kf.covariancesGlobal();
+    e.localPoints = lp.get();
+    e.pose        = kf.pose();
+    e.poseInv     = mrpt::poses::CPose3D::Identity() - kf.pose();  // == pose^{-1}
+    e.globalCov   = &kf.covariancesGlobal();
+    e.xs          = &lp->getPointsBufferRef_x();
+    e.ys          = &lp->getPointsBufferRef_y();
+    e.zs          = &lp->getPointsBufferRef_z();
     if (do_view_filter)
     {
-      e.view_x = gp->getPointsBufferRef_float_field("view_x");
-      e.view_y = gp->getPointsBufferRef_float_field("view_y");
-      e.view_z = gp->getPointsBufferRef_float_field("view_z");
+      e.view_x = lp->getPointsBufferRef_float_field("view_x");
+      e.view_y = lp->getPointsBufferRef_float_field("view_y");
+      e.view_z = lp->getPointsBufferRef_float_field("view_z");
     }
     entries.push_back(e);
   }
@@ -1129,9 +1198,14 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
 
         for (size_t e = 0; e < entries.size(); e++)
         {
+          // Transform the (global-frame) query point into this KF's local frame,
+          // then query its baked local KD-tree. Rigid transforms preserve
+          // distances, so best_dist_sqr remains comparable across keyframes.
+          const auto ql = entries[e].poseInv.composePoint(
+              mrpt::math::TPoint3D(xs_tf[local_idx], ys_tf[local_idx], zs_tf[local_idx]));
           float      d   = std::numeric_limits<float>::max();
-          const auto idx = entries[e].globalPoints->kdTreeClosestPoint3D(
-              xs_tf[local_idx], ys_tf[local_idx], zs_tf[local_idx], d);
+          const auto idx = entries[e].localPoints->kdTreeClosestPoint3D(
+              static_cast<float>(ql.x), static_cast<float>(ql.y), static_cast<float>(ql.z), d);
           if (d < best_dist_sqr)
           {
             best_dist_sqr = d;
@@ -1162,9 +1236,15 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
                        (*local_view_z)[local_idx]})
                   .cast<float>();
 
-          const float dot = v_local_global.x * (*entry.view_x)[best_idx] +
-                            v_local_global.y * (*entry.view_y)[best_idx] +
-                            v_local_global.z * (*entry.view_z)[best_idx];
+          // The reference view fields are in the KF's *local* frame; rotate them
+          // to the global frame by the KF pose before comparing (mirrors what the
+          // pre-baked global cloud used to store).
+          const auto ref_view_global = entry.pose.rotateVector(mrpt::math::TVector3D(
+              (*entry.view_x)[best_idx], (*entry.view_y)[best_idx], (*entry.view_z)[best_idx]));
+
+          const float dot = v_local_global.x * static_cast<float>(ref_view_global.x) +
+                            v_local_global.y * static_cast<float>(ref_view_global.y) +
+                            v_local_global.z * static_cast<float>(ref_view_global.z);
 
           if (dot < view_cos_threshold)
           {
@@ -1183,15 +1263,16 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
     auto& p = outPairings.emplace_back();
 #endif
 
-        const auto& g_xs = entry.globalPoints->getPointsBufferRef_x();
-        const auto& g_ys = entry.globalPoints->getPointsBufferRef_y();
-        const auto& g_zs = entry.globalPoints->getPointsBufferRef_z();
+        // Compose the matched local-frame reference point back to the global frame.
+        const auto g_pt = entry.pose.composePoint(mrpt::math::TPoint3D(
+            (*entry.xs)[best_idx], (*entry.ys)[best_idx], (*entry.zs)[best_idx]));
 
         p.global_idx =
             packApproxGlobalIdx(static_cast<uint32_t>(best_entry), static_cast<uint32_t>(best_idx));
         p.local_idx = static_cast<uint32_t>(local_idx);
         p.local     = {xs[local_idx], ys[local_idx], zs[local_idx]};
-        p.global    = {g_xs[best_idx], g_ys[best_idx], g_zs[best_idx]};
+        p.global    = {
+            static_cast<float>(g_pt.x), static_cast<float>(g_pt.y), static_cast<float>(g_pt.z)};
 
         /* Following GICP \cite segal2009gicp this should be:
          *  `(COV_{global} + R*COV_{local}*R^T)^{-1}`
@@ -2053,6 +2134,7 @@ void KeyframePointCloudMap::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR_CS(use_view_direction_filter, bool);
   MRPT_LOAD_CONFIG_VAR_CS(max_view_angle_deg, double);
   MRPT_LOAD_CONFIG_VAR_CS(serialize_kdtrees, bool);
+  MRPT_LOAD_CONFIG_VAR_CS(serialize_covariances, bool);
   MRPT_LOAD_CONFIG_VAR_CS(approximate_cov, bool);
 }
 
@@ -2068,19 +2150,21 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(use_view_direction_filter, bool);
   LOADABLEOPTS_DUMP_VAR(max_view_angle_deg, double);
   LOADABLEOPTS_DUMP_VAR(serialize_kdtrees, bool);
+  LOADABLEOPTS_DUMP_VAR(serialize_covariances, bool);
   LOADABLEOPTS_DUMP_VAR(approximate_cov, bool);
 }
 
 void KeyframePointCloudMap::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  out.WriteAs<uint8_t>(5);  // version
+  out.WriteAs<uint8_t>(6);  // version
   out << max_search_keyframes << k_correspondences_for_cov;
   out << rotation_distance_weight << num_diverse_keyframes;  // v1
   out << use_view_direction_filter << max_view_angle_deg;  // v2
   out << min_correspondences_for_cov << max_distance_for_cov;  // v3
   out << serialize_kdtrees;  // v4
   out << approximate_cov;  // v5
+  out << serialize_covariances;  // v6
 }
 
 void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -2096,6 +2180,7 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
     case 3:
     case 4:
     case 5:
+    case 6:
     {
       in >> max_search_keyframes >> k_correspondences_for_cov;
       if (version >= 1)
@@ -2118,6 +2203,10 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
       if (version >= 5)
       {
         in >> approximate_cov;
+      }
+      if (version >= 6)
+      {
+        in >> serialize_covariances;
       }
     }
     break;

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -1044,13 +1044,13 @@ void test_covariance_serialization_roundtrip()
   auto local_pts  = makeGridPts(kDz, 0.f, 0.f, 1.f, 10, 10);
 
   // Reference map: covariances computed at runtime.
-  auto ref_m                                      = makeMapFromCloud(makeCloudWithViews(global_pts));
-  ref_m.creationOptions.approximate_cov           = true;
+  auto ref_m                            = makeMapFromCloud(makeCloudWithViews(global_pts));
+  ref_m.creationOptions.approximate_cov = true;
   ref_m.creationOptions.use_view_direction_filter = false;
 
   // Baked map: same points, covariances serialized into the stream.
-  auto bake_m                                      = makeMapFromCloud(makeCloudWithViews(global_pts));
-  bake_m.creationOptions.approximate_cov           = true;
+  auto bake_m                            = makeMapFromCloud(makeCloudWithViews(global_pts));
+  bake_m.creationOptions.approximate_cov = true;
   bake_m.creationOptions.use_view_direction_filter = false;
   bake_m.creationOptions.serialize_covariances     = true;
 

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -1029,6 +1029,70 @@ void test_kdtree_serialization_roundtrip()
   ASSERT_LT_(dsqr, 4.0f);
 }
 
+// ── 34. serialize_covariances round-trips and yields identical covariances ──
+// A map baked with serialize_covariances must, after load, produce the exact same
+// cov-to-cov pairings (including cov_inv) as one that computed its covariances at
+// runtime. This proves both that the persisted covariances are installed and used
+// (not silently recomputed), and that the approximate_cov path querying each KF's
+// own local (baked) KD-tree yields the same result as before.
+void test_covariance_serialization_roundtrip()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+
+  auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f, 10, 10);
+  auto local_pts  = makeGridPts(kDz, 0.f, 0.f, 1.f, 10, 10);
+
+  // Reference map: covariances computed at runtime.
+  auto ref_m                                      = makeMapFromCloud(makeCloudWithViews(global_pts));
+  ref_m.creationOptions.approximate_cov           = true;
+  ref_m.creationOptions.use_view_direction_filter = false;
+
+  // Baked map: same points, covariances serialized into the stream.
+  auto bake_m                                      = makeMapFromCloud(makeCloudWithViews(global_pts));
+  bake_m.creationOptions.approximate_cov           = true;
+  bake_m.creationOptions.use_view_direction_filter = false;
+  bake_m.creationOptions.serialize_covariances     = true;
+
+  mrpt::io::CMemoryStream buf;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << bake_m;
+  }
+  buf.Seek(0);
+  mola::KeyframePointCloudMap loaded_m;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar >> loaded_m;
+  }
+
+  ASSERT_(loaded_m.creationOptions.serialize_covariances == true);
+  ASSERT_EQUAL_(loaded_m.point_count(), global_pts.size());
+
+  const auto run = [&](mola::KeyframePointCloudMap& m)
+  {
+    auto local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+    m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+    mp2p_icp::MatchedPointWithCovList ps;
+    m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), kMaxDist, ps);
+    const auto byLocalIdx = [](const auto& a, const auto& b) { return a.local_idx < b.local_idx; };
+    std::sort(ps.begin(), ps.end(), byLocalIdx);
+    return ps;
+  };
+
+  auto refPs    = run(ref_m);
+  auto loadedPs = run(loaded_m);
+
+  ASSERT_EQUAL_(refPs.size(), loadedPs.size());
+  ASSERT_GT_(refPs.size(), 0UL);
+  for (size_t i = 0; i < refPs.size(); i++)
+  {
+    ASSERT_EQUAL_(refPs[i].local_idx, loadedPs[i].local_idx);
+    ASSERT_NEAR_((refPs[i].global - loadedPs[i].global).norm(), 0.f, 1e-5f);
+    ASSERT_NEAR_((refPs[i].cov_inv - loadedPs[i].cov_inv).norm(), 0.0f, 1e-4f);
+  }
+}
+
 // ── 22. Debug per-keyframe coloring env var ───────────────────────────────
 /// With MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF=1 every keyframe must be rendered
 /// with a single, uniform color, and different keyframes must get different
@@ -1084,6 +1148,8 @@ void test_default_creation_options()
   ASSERT_GT_(m.creationOptions.k_correspondences_for_cov, 0U);
   ASSERT_GT_(m.creationOptions.max_search_keyframes, 0U);
   ASSERT_(m.creationOptions.approximate_cov == false);
+  ASSERT_(m.creationOptions.serialize_kdtrees == false);
+  ASSERT_(m.creationOptions.serialize_covariances == false);
 }
 
 // ---------------------------------------------------------------------------
@@ -1425,6 +1491,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_kdtree_serialization_roundtrip ...\n";
     test_kdtree_serialization_roundtrip();
+
+    std::cout << "test_covariance_serialization_roundtrip ...\n";
+    test_covariance_serialization_roundtrip();
 
     std::cout << "test_viz_color_by_kf ...\n";
     test_viz_color_by_kf();


### PR DESCRIPTION
## Motivation

In localization-only operation on a baked `.mm` (regrouped super-keyframes with `MOLA_LOCALMAP_APPROXIMATE_COV=true`), LIO ran smoothly except for **occasional 2–3 s stalls** (vs. ~20–30 ms average). Investigation showed the precomputed KD-trees/covariances were **not** actually accelerating the hot path:

1. **KD-tree baked on the wrong cloud.** `mm-kf-bake-kdtrees` saves each KF's *local*-frame KD-tree (`kf.pointcloud()`), but `nn_search_cov2cov_approximate()` queried a *separate*, deep-copied **global-frame** clone (`kf.pointcloud_global()`) whose KD-tree was rebuilt from scratch on first activation. The baked index never touched the query path.
2. **Covariances never persisted.** The plane-regularized K-NN + SVD pass (`computeCovariancesAndDensity()`) ran on every KF activation — the dominant cost.

With `max_search_keyframes=2` only the initial active set is warmed at load; each time the robot drives into a fresh super-KF, that KF paid (global-tree rebuild + covariance SVD) **inline on the LiDAR worker thread** (`mp2p_icp::ICP::align()` → `icp_get_prepared_as_global()`), i.e. the 2–3 s spikes — roughly once per super-KF.

## Changes

**A) Query the baked local KD-tree directly (approximate cov2cov).**
`nn_search_cov2cov_approximate()` now transforms each query point into every active KF's *local* frame (`pose⁻¹`), queries that KF's own local KD-tree (the one baked on disk), and composes the match back to global for the pairing. A KD-tree's structure is invariant under the rigid KF pose, so no per-KF global cloud/tree is ever materialized. `icp_get_prepared_as_global()`'s approximate branch is warmed accordingly (local tree + covariance rotation only). Bonus: robust to online KF pose nudges (LIO gravity-tilt correction), which no longer invalidate a global cloud.

**B) `serialize_covariances` creationOption (map serialization → v3).**
Bakes each KF's per-point *local* covariances into the `.mm` so they are installed on load instead of recomputed. Needs **no special MRPT API** (works on any build, unlike `serialize_kdtrees`). The cheap per-pose global rotation is still done at runtime.

**Tooling.** `mm-kf-bake-kdtrees` now bakes both KD-trees and covariances by default; `--no-kdtrees` / `--no-covariances` to select, `--disable` to strip both.

**Tests.** New round-trip test asserts a covariance-baked map yields byte-identical cov2cov pairings (points + `cov_inv`) to a runtime-computed one. Existing approximate-cov exact-match / multi-KF / view-filter tests continue to cover the reworked local-tree path.

## Compatibility

- Serialization stays backward-readable: v2 (KD-tree byte/blob) and v3 (adds covariance byte + per-point matrices) are self-describing; older files load unchanged.
- Exact (non-approximate) mode is untouched.
- Both baked caches are opt-in and independently gated by a per-KF flag byte, so `.mm` files remain interoperable across MRPT builds.

## Notes for reviewers

- Covariances are stored as full 3×3 float matrices (36 B/pt). A compact plane-normal encoding (`I − (1−ε)·nnᵀ`, ~12 B/pt) would be exact for the current regularization and is a possible follow-up if `.mm` size matters.
- Not built locally (colcon workspace is the maintainer's to build); please run `mola_metric_maps` tests to confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to persist and reuse per-keyframe covariance data in saved maps.
  * Updated keyframe matching in approximate-cov mode to query each keyframe’s local stored structures directly, improving robustness to live pose nudges.
* **Bug Fixes**
  * Matching consistency is preserved across save/load, validated by new round-trip tests.
* **Documentation**
  * Updated map format notes (serialization v3) and added CLI controls to enable/disable KD-tree and covariance caching independently (`--kdtrees/--no-kdtrees`, `--covariances/--no-covariances`, `--disable`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->