### PR TITLE
feat(mola_viz_imgui): add metric time-series plot windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = mola_viz_imgui/3rdparty/imgui
 	url = https://github.com/ocornut/imgui.git
 	branch = docking
+[submodule "mola_viz_imgui/3rdparty/implot"]
+	path = mola_viz_imgui/3rdparty/implot
+	url = https://github.com/epezent/implot.git

--- a/agents.md
+++ b/agents.md
@@ -88,8 +88,12 @@ All plugin modules derive from these virtual base classes:
   `register_metric()`/`push_metric()` (feature macro
   `MOLA_KERNEL_VIZ_HAS_METRICS`) so any module can stream timestamped scalar
   values ("metrics") to live, autoscrolling plot windows opened from the
-  built-in "Plots" menu; rendered via ImPlot on the `mola_viz_imgui` backend
-  only, no-op on the nanogui `MolaViz` backend.
+  built-in "Plots" menu (gated by the `plots_enabled` param); rendered via
+  ImPlot on the `mola_viz_imgui` backend only, no-op on the nanogui `MolaViz`
+  backend. The top main menu bar itself (host mode only; hosts the "Plots"
+  menu plus any module-installed `set_menu_bar()` menus) can be turned off
+  entirely via `menu_bar_enabled` (default `true`); existing plot/console
+  windows keep working when it is disabled.
 - `Relocalization` — global localization / loop closure
 - `OfflineDatasetSource` — offline dataset handling
 - `KeyframeMapCapable` — mixin for keyframe-based metric maps needing per-KF

--- a/agents.md
+++ b/agents.md
@@ -84,7 +84,12 @@ All plugin modules derive from these virtual base classes:
 - `VizInterface` — visualization (backend-agnostic, updated in v2.6). The
   `mola_viz_imgui` backend auto-exposes a dockable "Console" subwindow that
   aggregates mrpt-logger output from all running modules (gated by the
-  `console_enabled` param, added subsequently).
+  `console_enabled` param, added subsequently). Also exposes
+  `register_metric()`/`push_metric()` (feature macro
+  `MOLA_KERNEL_VIZ_HAS_METRICS`) so any module can stream timestamped scalar
+  values ("metrics") to live, autoscrolling plot windows opened from the
+  built-in "Plots" menu; rendered via ImPlot on the `mola_viz_imgui` backend
+  only, no-op on the nanogui `MolaViz` backend.
 - `Relocalization` — global localization / loop closure
 - `OfflineDatasetSource` — offline dataset handling
 - `KeyframeMapCapable` — mixin for keyframe-based metric maps needing per-KF

--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIB_SRCS
   src/interfaces/FilterBase.cpp
   src/interfaces/FrontEndBase.cpp
   src/interfaces/KeyframeMapCapable.cpp
+  src/interfaces/MetricChannel.cpp
   src/interfaces/NavStateFilter.cpp
   src/interfaces/RawDataSourceBase.cpp
   src/interfaces/SharedKeyframeMap.cpp
@@ -49,6 +50,7 @@ set(LIB_PUBLIC_HDRS
   include/mola_kernel/interfaces/LocalizationSourceBase.h
   include/mola_kernel/interfaces/MapServer.h
   include/mola_kernel/interfaces/MapSourceBase.h
+  include/mola_kernel/interfaces/MetricChannel.h
   include/mola_kernel/interfaces/NavStateFilter.h
   include/mola_kernel/interfaces/OfflineDatasetSource.h
   include/mola_kernel/interfaces/RawDataConsumer.h

--- a/mola_kernel/include/mola_kernel/interfaces/MetricChannel.h
+++ b/mola_kernel/include/mola_kernel/interfaces/MetricChannel.h
@@ -1,0 +1,69 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   MetricChannel.h
+ * @brief  Handle for streaming timestamped scalar values to the visualizer.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+#pragma once
+
+#include <memory>
+
+/** Feature macro: when defined, VizInterface offers register_metric() /
+ *  push_metric() and the mola::MetricChannel handle type, i.e. the streaming
+ *  time-series "metrics" plotting mechanism. Lets out-of-repo modules detect
+ *  the feature at compile time. */
+#define MOLA_KERNEL_VIZ_HAS_METRICS 1
+
+namespace mola
+{
+
+/** Opaque handle a module holds after registering a metric channel via
+ *  `VizInterface::register_metric()`.
+ *
+ *  Thread-safe: `push()` may be called from any thread, at any rate, without
+ *  external synchronization. On backends without plotting support (e.g. the
+ *  nanogui `MolaViz`) the returned handle is a live no-op whose `push()`
+ *  returns immediately. On backends with plotting support, `push()` is
+ *  near-free whenever no plot window is currently displaying the channel.
+ *
+ * \ingroup mola_kernel_interfaces_grp
+ */
+class MetricChannel
+{
+ public:
+  using Ptr = std::shared_ptr<MetricChannel>;
+
+  MetricChannel()          = default;
+  virtual ~MetricChannel() = default;
+
+  MetricChannel(const MetricChannel&)            = default;
+  MetricChannel& operator=(const MetricChannel&) = default;
+  MetricChannel(MetricChannel&&)                 = default;
+  MetricChannel& operator=(MetricChannel&&)      = default;
+
+  /** Appends one sample.
+   *  \param t     Timestamp in seconds, using any monotonic clock consistent
+   *               across calls for this channel. Using wall-clock time
+   *               (`mrpt::Clock::nowDouble()`) is recommended so multiple
+   *               channels can share a common x-axis.
+   *  \param value Sample value.
+   */
+  virtual void push(double t, double value) = 0;
+
+  /** Convenience overload: uses `mrpt::Clock::nowDouble()` as the timestamp. */
+  void push(double value);
+};
+
+}  // namespace mola

--- a/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
+++ b/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
@@ -23,10 +23,13 @@
  *       nanogui-specific create_subwindow() / enqueue_custom_nanogui_code()
  *       APIs.  The old methods are retained but deprecated so that existing
  *       callers continue to compile; they will be removed in a future release.
+ * 2026: Added register_metric() / push_metric() for streaming time-series
+ *       metrics to live plot windows (ImGui backend only; no-op on nanogui).
  */
 #pragma once
 
 #include <mola_kernel/GuiWidgetDescription.h>
+#include <mola_kernel/interfaces/MetricChannel.h>
 #include <mrpt/containers/yaml_frwd.h>
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/math/TPoint3D.h>
@@ -400,6 +403,44 @@ class VizInterface
       const std::string& title, bool save,
       const std::vector<std::pair<std::string, std::string>>& filters = {},
       const std::string& default_path = "", const std::string& parentWindow = "main") = 0;
+
+  /** @} */
+
+  // =========================================================================
+  /** @name Metrics / time-series plotting
+   *
+   * Generic mechanism for any module to stream timestamped scalar values
+   * ("metrics": CPU %, per-frame delay, ICP uncertainties, residuals, queue
+   * depth, temperatures, ...) to the visualizer for display in live,
+   * autoscrolling plot windows.
+   *
+   * This is an ImGui-backend feature (rendered via ImPlot). The nanogui
+   * `MolaViz` backend implements both methods as no-ops: `register_metric()`
+   * returns a live handle whose `push()` is a no-op, so callers can use the
+   * API unconditionally without checking `gui_backend()`.
+   * @{ */
+
+  /**
+   * \brief Registers (or returns the existing) metric channel by unique name.
+   *
+   * Idempotent: repeated calls with the same name return the same channel.
+   *
+   * \param name Unique id, also the default legend label. Use a namespaced
+   *             form like "lidar_odom/icp_delay_ms" to avoid collisions.
+   * \param unit Optional unit string shown on axis/legend (e.g. "ms", "%").
+   * \return     A channel handle; never null (no-op handle on backends
+   *             without plotting).
+   */
+  virtual MetricChannel::Ptr register_metric(
+      const std::string& name, const std::string& unit = "") = 0;
+
+  /**
+   * \brief One-shot convenience: register-if-needed then push.
+   *
+   * For rarely-updated metrics; prefer holding the handle returned by
+   * register_metric() on hot paths to avoid a name lookup per sample.
+   */
+  virtual void push_metric(const std::string& name, double t, double value) = 0;
 
   /** @} */
 

--- a/mola_kernel/src/interfaces/MetricChannel.cpp
+++ b/mola_kernel/src/interfaces/MetricChannel.cpp
@@ -1,0 +1,28 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   MetricChannel.cpp
+ * @brief  Handle for streaming timestamped scalar values to the visualizer.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+
+#include <mola_kernel/interfaces/MetricChannel.h>
+#include <mrpt/core/Clock.h>
+
+namespace mola
+{
+
+void MetricChannel::push(double value) { push(mrpt::Clock::nowDouble(), value); }
+
+}  // namespace mola

--- a/mola_viz/include/mola_viz/MolaViz.h
+++ b/mola_viz/include/mola_viz/MolaViz.h
@@ -103,6 +103,14 @@ class MolaViz : public ExecutableBase, public VizInterface
       const mola::gui::MenuBar& bar,
       const std::string&        parentWindow = DEFAULT_WINDOW_NAME) override;
 
+  /** Metrics plotting is an ImGui-backend feature. Returns a no-op handle
+   *  whose push() does nothing. */
+  MetricChannel::Ptr register_metric(
+      const std::string& name, const std::string& unit = "") override;
+
+  /** Does nothing in nanogui backend. */
+  void push_metric(const std::string& name, double t, double value) override;
+
   /** @} */
 
   // =========================================================================

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -2180,3 +2180,27 @@ std::future<void> MolaViz::set_menu_bar(
   p.set_value();
   return p.get_future();
 }
+
+namespace
+{
+/** No-op metric channel handle for the nanogui backend, which does not
+ *  implement metric plotting. */
+class NoOpMetricChannel : public MetricChannel
+{
+ public:
+  void push(double /*t*/, double /*value*/) override {}
+};
+}  // namespace
+
+MetricChannel::Ptr MolaViz::register_metric(
+    const std::string& /*name*/, const std::string& /*unit*/)
+{
+  // Note: nanogui backend does not support metric plotting.
+  static const MetricChannel::Ptr noOpChannel = std::make_shared<NoOpMetricChannel>();
+  return noOpChannel;
+}
+
+void MolaViz::push_metric(const std::string& /*name*/, double /*t*/, double /*value*/)
+{
+  // Note: nanogui backend does not support metric plotting.
+}

--- a/mola_viz_imgui/3rdparty/imgui_static/CMakeLists.txt
+++ b/mola_viz_imgui/3rdparty/imgui_static/CMakeLists.txt
@@ -1,23 +1,34 @@
 # ------------------------------------------------------------------------------
-# Static library target wrapping Dear ImGui (docking branch).
+# Static library target wrapping Dear ImGui (docking branch) + ImPlot.
 #
 # Expected layout:
-#   <this file's parent>/../../3rdparty/imgui/   ← git submodule
+#   <this file's parent>/../../3rdparty/imgui/    ← git submodule
+#   <this file's parent>/../../3rdparty/implot/   ← git submodule
 #
-# The submodule must be the "docking" branch of
+# The imgui submodule must be the "docking" branch of
 # https://github.com/ocornut/imgui
+# The implot submodule is https://github.com/epezent/implot (master; a tagged
+# release predates the imgui 1.92 texture-API changes).
 # ------------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.5)
 project(imgui_static LANGUAGES CXX)
 
-# Locate the submodule root relative to this file
+# Locate the submodule roots relative to this file
 get_filename_component(_IMGUI_ROOT
     "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/imgui" ABSOLUTE)
+get_filename_component(_IMPLOT_ROOT
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/implot" ABSOLUTE)
 
 if(NOT EXISTS "${_IMGUI_ROOT}/imgui.h")
   message(FATAL_ERROR
     "Dear ImGui submodule not found at ${_IMGUI_ROOT}.\n"
+    "Run:  git submodule update --init --recursive")
+endif()
+
+if(NOT EXISTS "${_IMPLOT_ROOT}/implot.h")
+  message(FATAL_ERROR
+    "ImPlot submodule not found at ${_IMPLOT_ROOT}.\n"
     "Run:  git submodule update --init --recursive")
 endif()
 
@@ -34,6 +45,8 @@ set(_IMGUI_SRCS
   ${_IMGUI_ROOT}/misc/cpp/imgui_stdlib.cpp   # std::string InputText support
   ${_IMGUI_ROOT}/backends/imgui_impl_glfw.cpp
   ${_IMGUI_ROOT}/backends/imgui_impl_opengl3.cpp
+  ${_IMPLOT_ROOT}/implot.cpp
+  ${_IMPLOT_ROOT}/implot_items.cpp
 )
 
 add_library(imgui_static STATIC ${_IMGUI_SRCS})
@@ -44,6 +57,7 @@ target_include_directories(imgui_static
     ${_IMGUI_ROOT}
     ${_IMGUI_ROOT}/backends
     ${_IMGUI_ROOT}/misc/cpp
+    ${_IMPLOT_ROOT}
 )
 
 # Enable the docking branch feature set.

--- a/mola_viz_imgui/CMakeLists.txt
+++ b/mola_viz_imgui/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(3rdparty/imgui_static imgui_static_build)
 # -- Module sources -----------------------------------------------------------
 set(LIB_SRCS
   src/ConsoleLogSink.cpp
+  src/MetricsRegistry.cpp
   src/MolaVizImGuiCore.cpp
   src/MolaVizImGui_handlers.cpp
   src/MolaVizImGui.cpp

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -31,6 +31,10 @@
 #include <string>
 #include <thread>
 
+// Forward declaration: implot.h is only pulled in by the .cpp files that
+// need it, so it is not forced on every consumer of this public header.
+struct ImPlotContext;
+
 namespace mola
 {
 
@@ -136,6 +140,16 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
       const mola::gui::MenuBar& bar, const std::string& parentWindow = DEFAULT_WINDOW_NAME) override
   {
     return core_ptr_->set_menu_bar(bar, parentWindow);
+  }
+
+  MetricChannel::Ptr register_metric(const std::string& name, const std::string& unit = "") override
+  {
+    return core_ptr_->register_metric(name, unit);
+  }
+
+  void push_metric(const std::string& name, double t, double value) override
+  {
+    core_ptr_->push_metric(name, t, value);
   }
 
   /** @} */
@@ -315,7 +329,8 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   // ---------------------------------------------------------------------------
   std::thread       guiThread_;
   std::atomic<bool> guiThreadShutdown_{false};
-  ImGuiContext*     imgui_ctx_ = nullptr;
+  ImGuiContext*     imgui_ctx_  = nullptr;
+  ImPlotContext*    implot_ctx_ = nullptr;
 
   void                             gui_thread();
   MolaVizImGuiCore::PerWindowData& create_and_add_window(const window_name_t& name);

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -387,6 +387,12 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
    *  populated only while `console_enabled_` is true. */
   std::shared_ptr<ConsoleLogSink> console_sink_ = std::make_shared<ConsoleLogSink>();
 
+  /** Top main menu bar (host mode only): master enable. When false, no menu
+   *  bar is created at all (including the built-in "Plots" menu and any
+   *  module-installed menu via `set_menu_bar()`). Existing plot/console
+   *  windows are unaffected; only the top strip and its menus disappear. */
+  bool menu_bar_enabled_ = true;
+
   /** Plot windows: master enable for the "Plots" menu and metric registration.
    *  When false, register_metric()/push_metric() still return valid (no-op)
    *  channels so callers never need to guard the call. */

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -37,13 +37,19 @@
 #include <string>
 #include <vector>
 
-// Forward declaration: only GLFWwindow* pointers appear in this header, so the
-// GLFW/OpenGL backend headers are pulled in by the .cpp implementation files
-// instead of being forced on every consumer of the public API.
+// Forward declarations: only pointers to these types appear in this header,
+// so the GLFW/OpenGL/ImPlot headers are pulled in by the .cpp implementation
+// files instead of being forced on every consumer of the public API.
 struct GLFWwindow;
+struct ImPlotContext;
 
 namespace mola
 {
+
+// Defined in MetricsRegistry.h (kept out of the public include dir; only
+// this Core uses the concrete type). The public handle modules interact
+// with is the kernel's mola::MetricChannel.
+class MetricsRegistry;
 
 /** One captured log line, tagged with its originating module and severity. */
 struct ConsoleLogEntry
@@ -228,6 +234,11 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
       const mola::gui::MenuBar& bar,
       const std::string&        parentWindow = DEFAULT_WINDOW_NAME) override;
 
+  MetricChannel::Ptr register_metric(
+      const std::string& name, const std::string& unit = "") override;
+
+  void push_metric(const std::string& name, double t, double value) override;
+
   /** @} */
   // =========================================================================
   /** @name VizInterface — 3-D scene API
@@ -376,6 +387,21 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
    *  populated only while `console_enabled_` is true. */
   std::shared_ptr<ConsoleLogSink> console_sink_ = std::make_shared<ConsoleLogSink>();
 
+  /** Plot windows: master enable for the "Plots" menu and metric registration.
+   *  When false, register_metric()/push_metric() still return valid (no-op)
+   *  channels so callers never need to guard the call. */
+  bool plots_enabled_ = true;
+
+  /** Default rolling-history cap (seconds) for a newly-registered channel. */
+  double plots_default_retention_seconds_ = 10.0;
+
+  /** Default horizontal span (seconds) of a newly-created plot window. */
+  double plots_default_span_seconds_ = 5.0;
+
+  /** Registry of metric channels shared with the per-module producer handles;
+   *  always allocated, like `console_sink_`. See MetricsRegistry.h. */
+  std::shared_ptr<MetricsRegistry> metrics_;
+
   /** @} */
 
   // =========================================================================
@@ -407,6 +433,26 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
     std::shared_ptr<mrpt::opengl::CPointCloudColoured> cloud;
     mrpt::opengl::CSetOfObjects::Ptr container;  // owning container at insert time
     float                            initial_alpha = 1.0f;
+  };
+
+  /** One live plot window: which channels it overlays and its display options.
+   *  Opened from the built-in "Plots" menu; independently closable/reopenable
+   *  via its native `[x]` button and the same menu, mirroring how the Console
+   *  window's visibility is toggled. */
+  struct PlotWindowState
+  {
+    std::string title;  // e.g. "Plot 1"; unique within a PerWindowData
+    bool        open = true;  // drives ImGui::Begin(title, &open) -> [x] button
+
+    std::vector<std::string> channels;  // subscribed channel names (overlaid)
+
+    float span_seconds = 5.0f;  // horizontal window shown, one of {1,2,5,10}
+    bool  show_grid_x  = true;
+    bool  show_grid_y  = true;
+    bool  show_legend  = true;
+    bool  lines        = true;  // true=solid lines, false=ticks/markers only
+    bool  y_autoscale  = true;
+    bool  paused       = false;  // freeze the view for inspection
   };
 
   struct PerWindowData
@@ -441,6 +487,15 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
     size_t                    max_decaying_clouds = 100;
 
     mola::gui::MenuBar menu_bar;
+
+    /** Drives the Console window's native `[x]` button; the "Plots" menu's
+     *  checklist re-opens it, same mechanism as the plot windows below. */
+    bool console_open = true;
+
+    /** Open plot windows for this parent window; created via the "Plots"
+     *  menu, each independently closable/reopenable. */
+    std::vector<PlotWindowState> plot_windows;
+    int                          next_plot_id = 1;
   };
 
   std::map<window_name_t, PerWindowData> windows_;
@@ -458,6 +513,12 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   // destructor to warn the caller if they forgot to release GL resources.
   bool embed_active_ = false;
 
+  // Embed mode only: the host owns the ImGui context but has no reason to
+  // know about ImPlot, so the Core creates/destroys its own ImPlot context
+  // here. Host mode (MolaVizImGui) instead owns an ImPlot context alongside
+  // its ImGui context (see MolaVizImGui::gui_thread()).
+  ImPlotContext* embed_implot_ctx_ = nullptr;
+
   // Per-frame rendering helpers
   void render_menu_bar(PerWindowData& win);
   void render_background_scene(PerWindowData& win);
@@ -465,6 +526,9 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   void render_sensor_windows(const window_name_t& parentName, PerWindowData& win);
   void render_console_overlay(PerWindowData& win);
   void render_console_window(PerWindowData& win);
+  void render_plots_menu(PerWindowData& win);
+  void render_plot_windows(PerWindowData& win);
+  void render_plot_toolbar(PlotWindowState& st);
   void render_widget_description(const mola::gui::WindowDescription& desc, SubWindowState& sw);
   void render_tab(const mola::gui::Tab& tab, const std::string& ctx);
   void render_any_widget(const mola::gui::AnyWidget& w, const std::string& ctx);
@@ -506,6 +570,11 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   // shifts as new modules register mid-session, so an index alone would
   // silently start pointing at a different source.
   std::string console_selected_source_name_;
+
+  // Plot windows: buffers reused across channels/frames to avoid a
+  // heap allocation per PlotLine() call.
+  std::vector<double> plot_scratch_xs_;
+  std::vector<double> plot_scratch_ys_;
 };
 
 }  // namespace mola

--- a/mola_viz_imgui/src/MetricsRegistry.cpp
+++ b/mola_viz_imgui/src/MetricsRegistry.cpp
@@ -1,0 +1,108 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   MetricsRegistry.cpp
+ * @brief  Thread-safe rolling store of metric channels for the ImGui plot windows.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+
+#include "MetricsRegistry.h"
+
+namespace mola
+{
+
+void MetricChannelImpl::push(double t, double value)
+{
+  // Cheap, lock-free early-out: nobody is plotting anything at all.
+  if (!any_window_open_->load(std::memory_order_relaxed))
+  {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lk(mtx_);
+  ring_.push_back({t, static_cast<float>(value)});
+  prune_older_than_locked(t - retention_seconds.load(std::memory_order_relaxed));
+  version_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void MetricChannelImpl::prune_older_than_locked(double cutoff)
+{
+  while (!ring_.empty() && ring_.front().t < cutoff)
+  {
+    ring_.pop_front();
+  }
+}
+
+void MetricChannelImpl::copy_span(
+    double t_min, std::vector<double>& xs, std::vector<double>& ys) const
+{
+  xs.clear();
+  ys.clear();
+
+  std::lock_guard<std::mutex> lk(mtx_);
+  for (const auto& s : ring_)
+  {
+    if (s.t < t_min)
+    {
+      continue;
+    }
+    xs.push_back(s.t);
+    ys.push_back(s.v);
+  }
+}
+
+namespace
+{
+/** Round-robin palette assigned to newly-registered channels. Matches
+ *  ImPlot's default qualitative colormap so plot legends and any future
+ *  per-channel swatch controls line up visually. */
+constexpr ImVec4 kPalette[] = {
+    {0.00f, 0.75f, 0.75f, 1.0f}, {1.00f, 0.49f, 0.06f, 1.0f}, {0.55f, 0.36f, 0.83f, 1.0f},
+    {0.17f, 0.63f, 0.17f, 1.0f}, {0.84f, 0.15f, 0.16f, 1.0f}, {0.09f, 0.47f, 0.72f, 1.0f},
+    {0.74f, 0.74f, 0.13f, 1.0f}, {0.89f, 0.47f, 0.76f, 1.0f},
+};
+}  // namespace
+
+MetricChannelImpl::Ptr MetricsRegistry::get_or_create(
+    const std::string& name, const std::string& unit)
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  if (const auto it = channels_.find(name); it != channels_.end())
+  {
+    return it->second;
+  }
+
+  const ImVec4 color = kPalette[channels_.size() % (sizeof(kPalette) / sizeof(kPalette[0]))];
+  auto         ch    = std::make_shared<MetricChannelImpl>(name, unit, color, any_window_open_);
+  channels_.emplace(name, ch);
+  return ch;
+}
+
+std::vector<std::string> MetricsRegistry::channel_names() const
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  std::vector<std::string>    names;
+  names.reserve(channels_.size());
+  for (const auto& [name, ch] : channels_) names.push_back(name);
+  return names;
+}
+
+MetricChannelImpl::Ptr MetricsRegistry::find(const std::string& name) const
+{
+  std::lock_guard<std::mutex> lk(mtx_);
+  const auto                  it = channels_.find(name);
+  return it != channels_.end() ? it->second : nullptr;
+}
+
+}  // namespace mola

--- a/mola_viz_imgui/src/MetricsRegistry.h
+++ b/mola_viz_imgui/src/MetricsRegistry.h
@@ -1,0 +1,118 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   MetricsRegistry.h
+ * @brief  Thread-safe rolling store of metric channels for the ImGui plot windows.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+#pragma once
+
+#include <imgui.h>
+#include <mola_kernel/interfaces/MetricChannel.h>
+
+#include <atomic>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace mola
+{
+
+/** One (t, value) sample. Value is stored as `float` to halve the memory
+ *  footprint of the rolling buffer (the plotted span rarely needs more
+ *  precision than that). */
+struct MetricSample
+{
+  double t;
+  float  v;
+};
+
+/** Concrete `MetricChannel`: a bounded, thread-safe rolling buffer of samples.
+ *
+ *  Modelled on `ConsoleLogSink`: a shared_ptr sink written to by producer
+ *  threads and read by the GUI thread, a rolling buffer bounded by time, a
+ *  lock-free `version()` change hint, and an atomic gate letting producers
+ *  early-out cheaply while nobody is plotting.
+ */
+class MetricChannelImpl : public MetricChannel
+{
+ public:
+  using Ptr = std::shared_ptr<MetricChannelImpl>;
+
+  MetricChannelImpl(
+      std::string channelName, std::string channelUnit, ImVec4 channelColor,
+      std::shared_ptr<std::atomic<bool>> anyWindowOpen)
+      : name(std::move(channelName)),
+        unit(std::move(channelUnit)),
+        color(channelColor),
+        any_window_open_(std::move(anyWindowOpen))
+  {
+  }
+
+  void push(double t, double value) override;
+
+  /** Appends the samples with `t >= t_min` to the (caller-owned, reused)
+   *  output buffers, oldest first. Both buffers use `double` -- ImPlot's
+   *  PlotLine()/PlotScatter() require the x and y arrays to share one type. */
+  void copy_span(double t_min, std::vector<double>& xs, std::vector<double>& ys) const;
+
+  /** Bumped on every push(). Lock-free, so the renderer can skip
+   *  copy_span() when nothing changed since the last rendered frame. */
+  uint64_t version() const { return version_.load(std::memory_order_relaxed); }
+
+  const std::string name;
+  const std::string unit;
+  const ImVec4      color;
+
+  /** Rolling history length; the widest span among all plot windows
+   *  currently showing this channel (capped by nothing here -- callers
+   *  decide the cap; default 10 s, see `MolaVizImGuiCore::plots_default_retention_seconds_`). */
+  std::atomic<double> retention_seconds{10.0};
+
+ private:
+  mutable std::mutex                 mtx_;
+  std::deque<MetricSample>           ring_;
+  std::atomic<uint64_t>              version_{0};
+  std::shared_ptr<std::atomic<bool>> any_window_open_;
+
+  void prune_older_than_locked(double cutoff);
+};
+
+/** Owns the set of named metric channels for one `MolaVizImGuiCore` instance. */
+class MetricsRegistry
+{
+ public:
+  /** Idempotent: returns the existing channel if `name` was already registered. */
+  MetricChannelImpl::Ptr get_or_create(const std::string& name, const std::string& unit);
+
+  /** Sorted list of registered channel names, for the "add channel" combo. */
+  std::vector<std::string> channel_names() const;
+
+  MetricChannelImpl::Ptr find(const std::string& name) const;
+
+  /** Shared gate: producers early-out on push() when this is false. The
+   *  renderer recomputes it once per frame from the set of open plot
+   *  windows with >=1 channel. */
+  std::shared_ptr<std::atomic<bool>> any_window_open() const { return any_window_open_; }
+
+ private:
+  mutable std::mutex                            mtx_;
+  std::map<std::string, MetricChannelImpl::Ptr> channels_;
+  std::shared_ptr<std::atomic<bool>> any_window_open_ = std::make_shared<std::atomic<bool>>(false);
+};
+
+}  // namespace mola

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -24,6 +24,7 @@
 #include <GLFW/glfw3.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
+#include <implot.h>
 #include <mola_kernel/assets/mola_icon_64x64.h>
 #include <mola_viz_imgui/MolaVizImGui.h>
 #include <mola_yaml/yaml_helpers.h>
@@ -261,6 +262,7 @@ void MolaVizImGui::gui_thread()
 
   imgui_ctx_ = ImGui::CreateContext();
   ImGui::SetCurrentContext(imgui_ctx_);
+  implot_ctx_ = ImPlot::CreateContext();
 
   create_and_add_window(DEFAULT_WINDOW_NAME);
 
@@ -307,6 +309,9 @@ void MolaVizImGui::gui_thread()
     wd.glfw_window = nullptr;
   }
   core_ptr_->windows_.clear();
+
+  ImPlot::DestroyContext(implot_ctx_);
+  implot_ctx_ = nullptr;
 
   ImGui::DestroyContext(imgui_ctx_);
   imgui_ctx_ = nullptr;

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -147,6 +147,14 @@ void MolaVizImGui::initialize(const Yaml& c)
   core_ptr_->console_window_seconds_ =
       cfg.getOrDefault("console_window_seconds", core_ptr_->console_window_seconds_);
 
+  core_ptr_->plots_enabled_ = cfg.getOrDefault("plots_enabled", core_ptr_->plots_enabled_);
+  core_ptr_->plots_default_retention_seconds_ = cfg.getOrDefault(
+      "plots_default_retention_seconds", core_ptr_->plots_default_retention_seconds_);
+  core_ptr_->plots_default_span_seconds_ =
+      cfg.getOrDefault("plots_default_span_seconds", core_ptr_->plots_default_span_seconds_);
+
+  core_ptr_->menu_bar_enabled_ = cfg.getOrDefault("menu_bar_enabled", core_ptr_->menu_bar_enabled_);
+
   core_ptr_->console_sink_->max_entries    = core_ptr_->console_max_entries_;
   core_ptr_->console_sink_->window_seconds = core_ptr_->console_window_seconds_;
 

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -303,15 +303,22 @@ void MolaVizImGuiCore::render_frame(const window_name_t& name, PerWindowData& wd
   ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
-  constexpr ImGuiWindowFlags dockspace_flags =
-      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_MenuBar |
-      ImGuiWindowFlags_NoBackground;
+  ImGuiWindowFlags dockspace_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
+                                     ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                                     ImGuiWindowFlags_NoBringToFrontOnFocus |
+                                     ImGuiWindowFlags_NoBackground;
+  if (menu_bar_enabled_)
+  {
+    dockspace_flags |= ImGuiWindowFlags_MenuBar;
+  }
 
   ImGui::Begin("##DockSpaceRoot", nullptr, dockspace_flags);
   ImGui::PopStyleVar(3);
 
-  render_menu_bar(wd);
+  if (menu_bar_enabled_)
+  {
+    render_menu_bar(wd);
+  }
 
   ImGuiID dockspace_id = ImGui::GetID("MainDockSpace");
   ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -21,6 +21,7 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 #include <imgui_stdlib.h>
+#include <implot.h>
 #include <mola_viz_imgui/MolaVizImGuiCore.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/lock_helper.h>
@@ -36,6 +37,8 @@
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
+
+#include "MetricsRegistry.h"
 
 using namespace mola;
 
@@ -107,7 +110,10 @@ const std::string& MolaVizImGuiCore::gui_backend() const noexcept
 // Constructor / destructor
 // ---------------------------------------------------------------------------
 
-MolaVizImGuiCore::MolaVizImGuiCore() { setLoggerName("MolaVizImGuiCore"); }
+MolaVizImGuiCore::MolaVizImGuiCore() : metrics_(std::make_shared<MetricsRegistry>())
+{
+  setLoggerName("MolaVizImGuiCore");
+}
 
 MolaVizImGuiCore::~MolaVizImGuiCore()
 {
@@ -141,6 +147,10 @@ void MolaVizImGuiCore::init_for_embed(const window_name_t& name)
   wd.background_scene = mrpt::opengl::COpenGLScene::Create();
   // No background_scene_view — the embed host renders via its own CImGuiSceneView.
   embed_active_ = true;
+
+  // The embed host owns the ImGui context but not ImPlot's; create our own,
+  // once per Core instance, matching MolaVizImGui::gui_thread() in host mode.
+  if (!embed_implot_ctx_) embed_implot_ctx_ = ImPlot::CreateContext();
 }
 
 void MolaVizImGuiCore::shutdown_for_embed()
@@ -168,6 +178,12 @@ void MolaVizImGuiCore::shutdown_for_embed()
     wd.background_scene_view.reset();
   }
   windows_.clear();
+
+  if (embed_implot_ctx_)
+  {
+    ImPlot::DestroyContext(embed_implot_ctx_);
+    embed_implot_ctx_ = nullptr;
+  }
 
   embed_active_ = false;
 }
@@ -255,6 +271,10 @@ void MolaVizImGuiCore::spin_one_frame(const window_name_t& name)
   {
     render_console_window(wd);
   }
+  if (plots_enabled_)
+  {
+    render_plot_windows(wd);
+  }
   render_console_overlay(wd);
   internal_handle_decaying_clouds(wd);
 }
@@ -312,6 +332,10 @@ void MolaVizImGuiCore::render_frame(const window_name_t& name, PerWindowData& wd
   {
     render_console_window(wd);
   }
+  if (plots_enabled_)
+  {
+    render_plot_windows(wd);
+  }
   render_console_overlay(wd);
   internal_handle_decaying_clouds(wd);
 
@@ -362,10 +386,15 @@ void MolaVizImGuiCore::internal_drain_task_queue()
 
 void MolaVizImGuiCore::render_menu_bar(PerWindowData& wd)
 {
-  if (wd.menu_bar.menus.empty()) return;
-
+  // The built-in "Plots" menu is always available, even if no module has
+  // installed a custom menu bar via set_menu_bar().
   if (ImGui::BeginMenuBar())
   {
+    if (plots_enabled_)
+    {
+      render_plots_menu(wd);
+    }
+
     for (const auto& menu : wd.menu_bar.menus)
     {
       if (ImGui::BeginMenu(menu.label.c_str()))
@@ -386,6 +415,39 @@ void MolaVizImGuiCore::render_menu_bar(PerWindowData& wd)
     }
     ImGui::EndMenuBar();
   }
+}
+
+void MolaVizImGuiCore::render_plots_menu(PerWindowData& wd)
+{
+  if (!ImGui::BeginMenu("Plots"))
+  {
+    return;
+  }
+
+  if (ImGui::MenuItem("New plot window"))
+  {
+    PlotWindowState st;
+    st.title        = "Plot " + std::to_string(wd.next_plot_id++);
+    st.span_seconds = static_cast<float>(plots_default_span_seconds_);
+    wd.plot_windows.push_back(std::move(st));
+  }
+
+  if (!wd.plot_windows.empty() || console_enabled_)
+  {
+    ImGui::Separator();
+  }
+
+  if (console_enabled_)
+  {
+    ImGui::MenuItem("Console", nullptr, &wd.console_open);
+  }
+
+  for (auto& st : wd.plot_windows)
+  {
+    ImGui::MenuItem(st.title.c_str(), nullptr, &st.open);
+  }
+
+  ImGui::EndMenu();
 }
 
 void MolaVizImGuiCore::render_background_scene(PerWindowData& wd)
@@ -544,12 +606,15 @@ void MolaVizImGuiCore::console_save_to_file()
   MRPT_LOG_INFO_STREAM("Console: saved log to '" << fname << "'.");
 }
 
-void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
+void MolaVizImGuiCore::render_console_window(PerWindowData& wd)
 {
-  if (!console_sink_) return;
+  if (!console_sink_ || !wd.console_open)
+  {
+    return;
+  }
 
   ImGui::SetNextWindowSize(ImVec2(700, 300), ImGuiCond_FirstUseEver);
-  if (!ImGui::Begin("Console"))
+  if (!ImGui::Begin("Console", &wd.console_open))
   {
     ImGui::End();
     return;
@@ -652,6 +717,141 @@ void MolaVizImGuiCore::render_console_window(PerWindowData& /*wd*/)
   ImGui::End();
 
   if (wantSave) console_save_to_file();
+}
+
+void MolaVizImGuiCore::render_plot_toolbar(PlotWindowState& st)
+{
+  static constexpr float       kSpans[]      = {1.0f, 2.0f, 5.0f, 10.0f};
+  static constexpr const char* kSpanLabels[] = {"1s", "2s", "5s", "10s"};
+
+  int spanIdx = 2;  // fall back to 5s if span_seconds doesn't match a preset
+  for (size_t i = 0; i < IM_ARRAYSIZE(kSpans); i++)
+  {
+    if (std::abs(kSpans[i] - st.span_seconds) < 1e-3f) spanIdx = static_cast<int>(i);
+  }
+  ImGui::SetNextItemWidth(70);
+  if (ImGui::Combo("Span", &spanIdx, kSpanLabels, IM_ARRAYSIZE(kSpanLabels)))
+  {
+    st.span_seconds = kSpans[spanIdx];
+  }
+  ImGui::SameLine();
+
+  // "Add channel" combo, populated with channels not already shown here.
+  const std::vector<std::string> allNames = metrics_->channel_names();
+  std::vector<std::string>       avail;
+  for (const auto& n : allNames)
+  {
+    if (std::find(st.channels.begin(), st.channels.end(), n) == st.channels.end())
+    {
+      avail.push_back(n);
+    }
+  }
+  std::vector<const char*> availLabels;
+  availLabels.reserve(avail.size());
+  for (const auto& n : avail) availLabels.push_back(n.c_str());
+
+  int addIdx = -1;
+  ImGui::SetNextItemWidth(200);
+  if (ImGui::Combo(
+          "Add channel", &addIdx, availLabels.data(), static_cast<int>(availLabels.size())) &&
+      addIdx >= 0)
+  {
+    st.channels.push_back(avail[static_cast<size_t>(addIdx)]);
+  }
+
+  ImGui::Checkbox("Grid X", &st.show_grid_x);
+  ImGui::SameLine();
+  ImGui::Checkbox("Grid Y", &st.show_grid_y);
+  ImGui::SameLine();
+  ImGui::Checkbox("Legend", &st.show_legend);
+  ImGui::SameLine();
+  ImGui::Checkbox("Lines", &st.lines);
+  ImGui::SameLine();
+  ImGui::Checkbox("Y autoscale", &st.y_autoscale);
+  ImGui::SameLine();
+  ImGui::Checkbox("Pause", &st.paused);
+
+  // One removable "chip" per subscribed channel.
+  for (size_t i = 0; i < st.channels.size();)
+  {
+    ImGui::SameLine();
+    const std::string label = st.channels[i] + " x##rm_" + st.channels[i];
+    if (ImGui::SmallButton(label.c_str()))
+    {
+      st.channels.erase(st.channels.begin() + static_cast<long>(i));
+      continue;
+    }
+    ++i;
+  }
+}
+
+void MolaVizImGuiCore::render_plot_windows(PerWindowData& wd)
+{
+  bool anyOpenWithChannels = false;
+
+  for (auto& st : wd.plot_windows)
+  {
+    if (!st.open) continue;
+
+    ImGui::SetNextWindowSize(ImVec2(480, 320), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin(st.title.c_str(), &st.open))
+    {
+      render_plot_toolbar(st);
+      if (!st.channels.empty()) anyOpenWithChannels = true;
+
+      const double now  = mrpt::Clock::nowDouble();
+      const double tmin = now - static_cast<double>(st.span_seconds);
+
+      // Widen (never shrink) each shown channel's retention to cover this
+      // window's span, so copy_span() below always finds the full history.
+      const double wantRetention =
+          std::max(plots_default_retention_seconds_, static_cast<double>(st.span_seconds));
+      for (const auto& chName : st.channels)
+      {
+        auto ch = metrics_->find(chName);
+        if (!ch) continue;
+        if (wantRetention > ch->retention_seconds.load(std::memory_order_relaxed))
+          ch->retention_seconds.store(wantRetention, std::memory_order_relaxed);
+      }
+
+      const ImPlotFlags plotFlags = st.show_legend ? ImPlotFlags_None : ImPlotFlags_NoLegend;
+      if (ImPlot::BeginPlot(("##" + st.title).c_str(), ImVec2(-1, -1), plotFlags))
+      {
+        const ImPlotAxisFlags xFlags =
+            st.show_grid_x ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines;
+        const ImPlotAxisFlags yFlags =
+            (st.show_grid_y ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) |
+            (st.y_autoscale ? ImPlotAxisFlags_AutoFit : ImPlotAxisFlags_None);
+        ImPlot::SetupAxes("t [s]", nullptr, xFlags, yFlags);
+        if (!st.paused) ImPlot::SetupAxisLimits(ImAxis_X1, tmin, now, ImPlotCond_Always);
+
+        for (const auto& chName : st.channels)
+        {
+          auto ch = metrics_->find(chName);
+          if (!ch) continue;
+
+          ch->copy_span(tmin, plot_scratch_xs_, plot_scratch_ys_);
+          if (plot_scratch_xs_.empty()) continue;
+
+          ImPlotSpec spec;
+          spec.LineColor      = ch->color;
+          const auto        n = static_cast<int>(plot_scratch_xs_.size());
+          const std::string label =
+              ch->unit.empty() ? ch->name : (ch->name + " [" + ch->unit + "]");
+          if (st.lines)
+            ImPlot::PlotLine(
+                label.c_str(), plot_scratch_xs_.data(), plot_scratch_ys_.data(), n, spec);
+          else
+            ImPlot::PlotScatter(
+                label.c_str(), plot_scratch_xs_.data(), plot_scratch_ys_.data(), n, spec);
+        }
+        ImPlot::EndPlot();
+      }
+    }
+    ImGui::End();
+  }
+
+  metrics_->any_window_open()->store(anyOpenWithChannels, std::memory_order_relaxed);
 }
 
 void MolaVizImGuiCore::render_subwindow(SubWindowState& sw)
@@ -801,6 +1001,19 @@ std::future<void> MolaVizImGuiCore::set_menu_bar(
         }
         it->second.menu_bar = bar;
       });
+}
+
+MetricChannel::Ptr MolaVizImGuiCore::register_metric(
+    const std::string& name, const std::string& unit)
+{
+  auto ch = metrics_->get_or_create(name, unit);
+  ch->retention_seconds.store(plots_default_retention_seconds_, std::memory_order_relaxed);
+  return ch;
+}
+
+void MolaVizImGuiCore::push_metric(const std::string& name, double t, double value)
+{
+  metrics_->get_or_create(name, "")->push(t, value);
 }
 
 std::future<std::optional<std::string>> MolaVizImGuiCore::open_file_dialog(


### PR DESCRIPTION
## Summary
- Adds a backend-agnostic `register_metric()`/`push_metric()` API to `VizInterface` (guarded by `MOLA_KERNEL_VIZ_HAS_METRICS`) so any MOLA module can stream timestamped scalar values to live, autoscrolling plot windows.
- New built-in **"Plots"** menu in the `mola_viz_imgui` (ImGui/ImPlot) backend: create plot windows, add/remove channels, span/grid/legend/lines/pause/y-autoscale controls. This also gives the Console window its first working close/reopen toggle.
- `nanogui` `MolaViz` backend implements the API as a no-op, mirroring the `set_menu_bar` precedent.
- Vendors ImPlot as a git submodule under `mola_viz_imgui/3rdparty/implot`, built into the existing `imgui_static` CMake target.

Companion PR in `mola_lidar_odometry` adds a first real producer (ICP time/goodness).

## Test plan
- [x] `colcon build` for `mola_kernel`, `mola_viz`, `mola_viz_imgui` (Release) — clean
- [x] `colcon build` for `mola_bridge_ros2`, `mola_launcher` — clean
- [x] Ran `mola-cli` against a real MulRan sequence through `mola_lidar_odometry` for 1+ minute (ICP pushing metrics every scan) — no crash
- [x] Manual UI check of the Plots menu (could not verify visually in this environment — X session locked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric streaming and plotting support, including registering metrics and pushing timestamped samples.
  * The ImGui-based visualizer can now display live plots with selectable channels, time spans, and plot options.
  * The visualizer documentation now includes the new metrics and console-related capabilities.

* **Bug Fixes**
  * The non-plotting backend now safely accepts metric calls without affecting the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->