### PR TITLE
mm-kf-regroup: parallelize super-keyframe cloud building with TBB

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -150,7 +150,10 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   bounding box (large outdoors, small indoors). Merged clouds are voxel-decimated
   (`--decimate-voxel`, view-direction fields carried) to bound the overlap-induced point
   blow-up. On a 1000-KF outdoor map this yields ~5 super-KFs. This is "idea 1" of the
-  keyframe-map persistence plan.
+  keyframe-map persistence plan. Building each super-KF cloud (the merge +
+  voxel-decimate step) is the most expensive part of `regroupKeyframes()` and is
+  parallelized across clusters with TBB (`tbb::parallel_for`, gated by
+  `MOLA_METRIC_MAPS_USE_TBB`, falling back to a serial loop when TBB is absent).
 - `KeyframePointCloudMap::TCreationOptions::approximate_cov` (default `false`): for
   `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e. GICP-style pipelines).
   When `true`, `icp_get_prepared_as_global()` skips assembling the merged, multi-keyframe

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -1928,13 +1928,33 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
       clusters.empty() ? 0.0 : static_cast<double>(n) / static_cast<double>(clusters.size())));
 
   // ---- 6) Build the output map: one super-keyframe per cluster ----
-  KeyFrameID nextId = 0;
-  for (const auto& members : clusters)
-  {
-    const auto& seed = kfs[members.front()];
+  // Building each super-keyframe cloud (merge + voxel-decimate) is by far the
+  // most expensive part of this function and fully independent across
+  // clusters, so it is parallelized; the actual insertion into `out` (which
+  // assigns sequential KF ids) is kept single-threaded below.
+  std::vector<mrpt::maps::CPointsMap::Ptr> superKfClouds(clusters.size());
 
-    auto localCloud =
-        buildSuperKeyframeCloud(members, globals, seed.pose, params.merge_decimate_voxel);
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  tbb::parallel_for(
+      static_cast<size_t>(0), clusters.size(),
+      [&](size_t i)
+#else
+  for (size_t i = 0; i < clusters.size(); i++)
+#endif
+      {
+        const auto& members = clusters[i];
+        const auto& seed    = kfs[members.front()];
+        superKfClouds[i] =
+            buildSuperKeyframeCloud(members, globals, seed.pose, params.merge_decimate_voxel);
+      }
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  );
+#endif
+
+  KeyFrameID nextId = 0;
+  for (size_t i = 0; i < clusters.size(); i++)
+  {
+    const auto& seed = kfs[clusters[i].front()];
 
     // Insert as a new super-keyframe (caches build lazily on first use / load).
     auto [it, isNew] = out->keyframes_.try_emplace(
@@ -1943,7 +1963,7 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
     KeyFrame& nkf = it->second;
     nkf.timestamp = seed.timestamp;
     nkf.pose(seed.pose);
-    nkf.pointcloud(localCloud);
+    nkf.pointcloud(superKfClouds[i]);
     out->last_inserted_kf_id_ = nextId;
     nextId++;
   }


### PR DESCRIPTION
## Summary
- `KeyframePointCloudMap::regroupKeyframes()` (backing the `mm-kf-regroup` CLI tool) builds one merged/voxel-decimated point cloud per output super-keyframe cluster; this was the most expensive step of the tool but ran on a single CPU thread.
- Each cluster's cloud is independent of the others, so the build step now runs via `tbb::parallel_for`, gated by `MOLA_METRIC_MAPS_USE_TBB` (TBB is already a `mola_metric_maps` dependency, used elsewhere in this file), with a serial fallback when TBB is not available.
- Insertion of the built clouds into the output map (which assigns sequential keyframe ids) stays single-threaded.
- Updated `agents.md` to document the change.

## Test plan
- [x] `colcon build --packages-select mola_metric_maps`
- [x] Run existing `mola_metric_maps` gtests
- [x] Run `mm-kf-regroup` on a multi-super-KF map and confirm identical output map (KF count, point counts) to before, with reduced wall-clock time on a multi-core machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved keyframe regrouping by building super-keyframe point clouds in parallel when supported, with a serial fallback when not available.
  * Reduced time spent creating merged/decimated clouds before inserting results into the map.

* **Documentation**
  * Updated the release notes to reflect the new parallel processing behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->