### PR TITLE
fix(mola_metric_maps): density-aware nearest-keyframe selection + island merging

### DIFF
--- a/mola_metric_maps/apps/mm-kf-regroup/main.cpp
+++ b/mola_metric_maps/apps/mm-kf-regroup/main.cpp
@@ -117,6 +117,13 @@ int main(int argc, char** argv)
         "If >0, voxel-downsample [m] each merged super-keyframe cloud to bound its size.");
 
     cli.add_option(
+           "--island-merge-fraction", args.params.island_merge_fraction,
+           "Clusters whose point count falls below this fraction of the largest cluster's are "
+           "absorbed into their nearest neighbor instead of being left as standalone, "
+           "under-populated super-keyframes. 0 disables this (default: 0.10).")
+        ->check(CLI::Range(0.0, 1.0));
+
+    cli.add_option(
         "-l,--load-plugins", args.plugins,
         "One or more (comma separated) *.so files to load as plugins");
 

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -294,6 +294,17 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      *  strongly recommended for large maps. Per-point view-direction fields, when
      *  present, are carried over (first point kept per voxel). */
     double merge_decimate_voxel = 0;
+
+    /** Any cluster whose total point count falls below this fraction of the
+     *  largest cluster's point count is treated as an "island": too small to
+     *  usefully stand on its own as a super-keyframe (it would mislead
+     *  proximity-based nearest-keyframe search at runtime -- see
+     *  `TCreationOptions::density_penalty_min_points` -- while contributing
+     *  little real geometry). Islands are absorbed into their nearest
+     *  neighboring cluster (by center distance) instead of being emitted as
+     *  their own super-keyframe. Set to 0 to disable (old behavior: every
+     *  cluster becomes its own super-keyframe, however small). Default 0.10. */
+    double island_merge_fraction = 0.10;
   };
 
   /** Builds a NEW map whose keyframes are "super-keyframes": spatially coherent
@@ -511,6 +522,20 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      *  `false` (exact, merged-cloud behavior, unchanged).
      */
     bool approximate_cov = false;
+
+    /** Below this point count, a keyframe candidate is considered "sparse" for
+     *  proximity ranking in `icp_get_prepared_as_global()`, and gets a distance
+     *  penalty (see `density_penalty_max_m`) linearly scaled by how far below
+     *  this floor its point count is (0 penalty at/above this count, maximum
+     *  penalty at 0 points). Guards against small/leftover keyframes (e.g. an
+     *  under-merged cluster from `regroupKeyframes()`) outranking a much
+     *  better-populated keyframe merely because their pose happens to be
+     *  closer to the query. Default 200000; set to 0 to disable. */
+    uint32_t density_penalty_min_points = 200000;
+
+    /** Maximum proximity-ranking penalty [m] added for a keyframe with (close
+     *  to) zero points; see `density_penalty_min_points`. Default 20.0. */
+    double density_penalty_max_m = 20.0;
   };
   TCreationOptions creationOptions;
 

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -52,6 +52,7 @@
 #include <tbb/parallel_for.h>
 #endif
 
+#include <atomic>
 #include <type_traits>
 
 #if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
@@ -1221,6 +1222,11 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
     const mrpt::aligned_std_vector<float>* view_y = nullptr;
     const mrpt::aligned_std_vector<float>* view_z = nullptr;
   };
+  const bool debugMatchStats = mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_DEBUG_MATCH_STATS", false);
+  std::atomic<size_t> statsNoCandidateInRange{0};
+  std::atomic<size_t> statsRejectedByViewFilter{0};
+  std::atomic<size_t> statsAccepted{0};
+
   std::vector<ActiveKfEntry> entries;
   entries.reserve(activeKfs.size());
   for (const auto kf_id : activeKfs)
@@ -1295,6 +1301,10 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
 
         if (!found || best_dist_sqr > max_sqr_dist)
         {
+          if (debugMatchStats)
+          {
+            statsNoCandidateInRange++;
+          }
 #if defined(MOLA_METRIC_MAPS_USE_TBB)
           return;  // exit TBB lambda for this index
 #else
@@ -1326,12 +1336,21 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
 
           if (dot < view_cos_threshold)
           {
+            if (debugMatchStats)
+            {
+              statsRejectedByViewFilter++;
+            }
 #if defined(MOLA_METRIC_MAPS_USE_TBB)
             return;  // exit TBB lambda for this index
 #else
         continue;  // skip to next iteration of the for loop
 #endif
           }
+        }
+
+        if (debugMatchStats)
+        {
+          statsAccepted++;
         }
 
     // Add pairing:
@@ -1368,6 +1387,16 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
         std::make_move_iterator(localVec.end()));
   }
 #endif
+
+  if (debugMatchStats)
+  {
+    printf(
+        "[KeyframePointCloudMap] nn_search_cov2cov_approximate: query_points=%zu "
+        "active_kfs=%zu accepted=%zu no_candidate_in_range=%zu rejected_by_view_filter=%zu "
+        "max_search_distance=%.3f\n",
+        localPointCount, entries.size(), statsAccepted.load(), statsNoCandidateInRange.load(),
+        statsRejectedByViewFilter.load(), static_cast<double>(max_search_distance));
+  }
 }
 
 std::size_t KeyframePointCloudMap::point_count() const

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -655,36 +655,52 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
       double             bestDiversityScore = -1.0;
       const KFCandidate* bestCandidate      = nullptr;
 
-      for (const auto& c : candidates)
+      // Two passes: first restricted to diverseDistLimit (the common case, when
+      // enough nearby candidates exist); if that finds nothing (e.g. only a
+      // handful of widely-spaced super-keyframes cover the map, as produced by
+      // regroupKeyframes()), fall back to the best-diversity candidate regardless
+      // of distance rather than leaving this slot -- and thus the submap -- short
+      // a keyframe. An unfilled diverse slot means ICP runs against a single
+      // keyframe only, which can permanently starve it of correspondences at the
+      // edge of that keyframe's own coverage.
+      for (const bool enforceDistLimit : {true, false})
       {
-        if (selectedIds.count(c.kfId) != 0)
+        if (bestCandidate != nullptr)
         {
-          continue;
-        }
-        if (c.dist > diverseDistLimit)
-        {
-          continue;
+          break;
         }
 
-        // Diversity score: minimum angular difference to any
-        // already-selected frame's angle_to_kf.  We actually
-        // want the frame whose *orientation* (kf.pose()) differs
-        // most from the selected set, so compute pairwise SO(3)
-        // differences would be ideal but expensive; as a cheaper
-        // proxy, use the absolute angle_to_kf difference, which
-        // works well because frames at similar positions but
-        // different orientations will have very different
-        // angle_to_kf values.
-        double minAngDiff = std::numeric_limits<double>::max();
-        for (const double selAngle : selectedAngles)
+        for (const auto& c : candidates)
         {
-          minAngDiff = std::min(minAngDiff, std::abs(c.angle - selAngle));
-        }
+          if (selectedIds.count(c.kfId) != 0)
+          {
+            continue;
+          }
+          if (enforceDistLimit && c.dist > diverseDistLimit)
+          {
+            continue;
+          }
 
-        if (minAngDiff > bestDiversityScore)
-        {
-          bestDiversityScore = minAngDiff;
-          bestCandidate      = &c;
+          // Diversity score: minimum angular difference to any
+          // already-selected frame's angle_to_kf.  We actually
+          // want the frame whose *orientation* (kf.pose()) differs
+          // most from the selected set, so compute pairwise SO(3)
+          // differences would be ideal but expensive; as a cheaper
+          // proxy, use the absolute angle_to_kf difference, which
+          // works well because frames at similar positions but
+          // different orientations will have very different
+          // angle_to_kf values.
+          double minAngDiff = std::numeric_limits<double>::max();
+          for (const double selAngle : selectedAngles)
+          {
+            minAngDiff = std::min(minAngDiff, std::abs(c.angle - selAngle));
+          }
+
+          if (minAngDiff > bestDiversityScore)
+          {
+            bestDiversityScore = minAngDiff;
+            bestCandidate      = &c;
+          }
         }
       }
 
@@ -2009,6 +2025,11 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
     const auto clusterCenter = [&](const std::vector<size_t>& members)
     { return kfs[members.front()].center; };
 
+    // Clusters whose nearest neighbor turns out to be farther than a reasonable bound (see
+    // below) are left standalone rather than glued to a spatially disjoint cluster; track
+    // them by their (stable) seed index so the smallest-first search does not retry them.
+    std::unordered_set<size_t> unmergeableSeeds;
+
     size_t numIslandsAbsorbed = 0;
     for (;;)
     {
@@ -2030,6 +2051,10 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
       size_t smallestPts = 0;
       for (size_t i = 0; i < clusters.size(); i++)
       {
+        if (unmergeableSeeds.count(clusters[i].front()) != 0)
+        {
+          continue;
+        }
         const size_t pts = clusterPoints(clusters[i]);
         if (static_cast<double>(pts) < minPoints &&
             (smallestIdx == clusters.size() || pts < smallestPts))
@@ -2040,7 +2065,7 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
       }
       if (smallestIdx == clusters.size())
       {
-        break;  // no island left
+        break;  // no (mergeable) island left
       }
 
       // Find the nearest other cluster by center distance:
@@ -2061,6 +2086,18 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
         }
       }
       ASSERT_(nearestIdx != clusters.size());
+
+      // Reject absorption into a spatially disjoint neighbor: cap the merge distance at
+      // extent_factor times the sum of both clusters' (seed) sensing radii, the same
+      // scale used to cap a super-keyframe's own extent during growth (step 5 above).
+      const double mergeDistCap =
+          params.extent_factor *
+          (kfs[clusters[smallestIdx].front()].radius + kfs[clusters[nearestIdx].front()].radius);
+      if (nearestDist > mergeDistCap)
+      {
+        unmergeableSeeds.insert(clusters[smallestIdx].front());
+        continue;
+      }
 
       // Absorb: append the island's members into its nearest neighbor, then drop it.
       clusters[nearestIdx].insert(

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -157,6 +157,9 @@ void rotateViewDirectionFieldsOrFallback(Pts& pts, const Pose& tf)
 const thread_local auto ENV_DO_PROFILE_COV =
     mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_PROFILE_COV", false);
 
+const thread_local auto ENV_DEBUG_ACTIVE_KFS =
+    mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_DEBUG_ACTIVE_KFS", false);
+
 // #define DO_VIZ_DEBUG 1
 
 #if DO_VIZ_DEBUG
@@ -412,6 +415,24 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
   // Restore the monotonic id counter so future insertions don't collide
   // with already-loaded ids.
   next_free_kf_id_ = keyframes_.empty() ? 0 : (keyframes_.rbegin()->first + 1);
+
+  if (mrpt::get_env<bool>("MOLA_KEYFRAME_MAP_DEBUG_DUMP_KFS_ON_LOAD", false))
+  {
+    for (const auto& [kf_id, kf] : keyframes_)
+    {
+      const auto& p    = kf.pose();
+      const auto  bbox = kf.localBoundingBox();
+      const auto  diag = (bbox.max - bbox.min).norm();
+      printf(
+          "[KeyframePointCloudMap] loaded KF id=%llu pose=[x=%.3f y=%.3f z=%.3f yaw=%.2f "
+          "pitch=%.2f roll=%.2f] points=%zu local_bbox_diag=%.2f local_bbox=[%.2f,%.2f,%.2f]-["
+          "%.2f,%.2f,%.2f]\n",
+          static_cast<unsigned long long>(kf_id), p.x(), p.y(), p.z(), mrpt::RAD2DEG(p.yaw()),
+          mrpt::RAD2DEG(p.pitch()), mrpt::RAD2DEG(p.roll()),
+          kf.pointcloud() ? kf.pointcloud()->size() : 0, diag, bbox.min.x, bbox.min.y, bbox.min.z,
+          bbox.max.x, bbox.max.y, bbox.max.z);
+    }
+  }
 }
 
 ///  === KeyframePointCloudMap ===
@@ -556,9 +577,27 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
     const double dist_to_kf  = query_local.norm();
     const double angle_to_kf = mrpt::poses::Lie::SO<3>::log(query_local.getRotationMatrix()).norm();
 
+    // Density penalty: a keyframe with few points (e.g. an under-merged, leftover
+    // cluster from regroupKeyframes()) can sit geometrically closer to the query
+    // than a much better-populated keyframe, yet contribute almost no usable
+    // geometry for ICP correspondences. Without this term, pure pose-distance
+    // ranking can pick that sparse keyframe over one that would actually match,
+    // starving the ICP submap of real points. Penalty ramps linearly from 0 (at
+    // or above density_penalty_min_points) to density_penalty_max_m (at 0 points).
+    double densityPenalty = 0.0;
+    if (creationOptions.density_penalty_min_points > 0)
+    {
+      const auto minPts = static_cast<double>(creationOptions.density_penalty_min_points);
+      const auto nPts   = static_cast<double>(kf.pointcloud()->size());
+      if (nPts < minPts)
+      {
+        densityPenalty = (1.0 - nPts / minPts) * creationOptions.density_penalty_max_m;
+      }
+    }
+
     // Additive metric: prevents the zero-distance degeneracy of multiplicative forms,
     // and gives a clean meters-equivalent score that is easy to reason about.
-    const double m = dist_to_kf + rotW * angle_to_kf;
+    const double m = dist_to_kf + rotW * angle_to_kf + densityPenalty;
 
     candidates.push_back({kf_id, dist_to_kf, angle_to_kf, m});
   }
@@ -658,6 +697,28 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
   }
 
   kfs_to_search_limited = selectedIds;
+
+  if (ENV_DEBUG_ACTIVE_KFS)
+  {
+    std::string s;
+    for (const auto kf_id : kfs_to_search_limited)
+    {
+      s += std::to_string(kf_id) + " ";
+    }
+    printf(
+        "[KeyframePointCloudMap] ICP active KFs (%zu): %s | query_pose=[x=%.3f y=%.3f z=%.3f "
+        "yaw=%.2f]\n",
+        kfs_to_search_limited.size(), s.c_str(), icp_ref_point.x(), icp_ref_point.y(),
+        icp_ref_point.z(), mrpt::RAD2DEG(icp_ref_point.yaw()));
+    for (const auto& c : candidates)
+    {
+      printf(
+          "[KeyframePointCloudMap]   candidate KF id=%llu dist=%.2f angle_deg=%.2f metric=%.2f "
+          "%s\n",
+          static_cast<unsigned long long>(c.kfId), c.dist, mrpt::RAD2DEG(c.angle), c.metric,
+          kfs_to_search_limited.count(c.kfId) ? "[SELECTED]" : "");
+    }
+  }
 
   // ---------------------------------------------------------------
   // 4) Rebuild merged submap if the selection (or the exact/approximate mode) changed
@@ -1927,6 +1988,97 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
       "[regroup] %zu keyframes -> %zu super-keyframes (%.2fx reduction)", n, clusters.size(),
       clusters.empty() ? 0.0 : static_cast<double>(n) / static_cast<double>(clusters.size())));
 
+  // ---- 5.5) Absorb tiny "island" clusters into their nearest neighbor ----
+  // A cluster whose total point count is a small fraction of the largest cluster's
+  // is too sparse to usefully stand on its own: at runtime, its pose can still win
+  // proximity-based nearest-keyframe search (see TCreationOptions::density_penalty_*)
+  // over a much better-populated neighbor, starving ICP of real geometry. Rather than
+  // leave it as a standalone super-keyframe, fold it into its nearest neighbor cluster.
+  if (params.island_merge_fraction > 0 && clusters.size() > 1)
+  {
+    const auto clusterPoints = [&](const std::vector<size_t>& members) -> size_t
+    {
+      size_t total = 0;
+      for (const size_t m : members)
+      {
+        total += globals[m]->size();
+      }
+      return total;
+    };
+    // The seed (first member) center is used as the cluster's representative position.
+    const auto clusterCenter = [&](const std::vector<size_t>& members)
+    { return kfs[members.front()].center; };
+
+    size_t numIslandsAbsorbed = 0;
+    for (;;)
+    {
+      if (clusters.size() <= 1)
+      {
+        break;
+      }
+
+      size_t maxPoints = 0;
+      for (const auto& c : clusters)
+      {
+        maxPoints = std::max(maxPoints, clusterPoints(c));
+      }
+      const double minPoints = params.island_merge_fraction * static_cast<double>(maxPoints);
+
+      // Find the smallest cluster below threshold (process smallest-first so a
+      // chain of tiny islands absorbs into progressively larger neighbors).
+      size_t smallestIdx = clusters.size();
+      size_t smallestPts = 0;
+      for (size_t i = 0; i < clusters.size(); i++)
+      {
+        const size_t pts = clusterPoints(clusters[i]);
+        if (static_cast<double>(pts) < minPoints &&
+            (smallestIdx == clusters.size() || pts < smallestPts))
+        {
+          smallestIdx = i;
+          smallestPts = pts;
+        }
+      }
+      if (smallestIdx == clusters.size())
+      {
+        break;  // no island left
+      }
+
+      // Find the nearest other cluster by center distance:
+      const auto islandCenter = clusterCenter(clusters[smallestIdx]);
+      size_t     nearestIdx   = clusters.size();
+      double     nearestDist  = std::numeric_limits<double>::max();
+      for (size_t j = 0; j < clusters.size(); j++)
+      {
+        if (j == smallestIdx)
+        {
+          continue;
+        }
+        const double d = (clusterCenter(clusters[j]) - islandCenter).norm();
+        if (d < nearestDist)
+        {
+          nearestDist = d;
+          nearestIdx  = j;
+        }
+      }
+      ASSERT_(nearestIdx != clusters.size());
+
+      // Absorb: append the island's members into its nearest neighbor, then drop it.
+      clusters[nearestIdx].insert(
+          clusters[nearestIdx].end(), clusters[smallestIdx].begin(), clusters[smallestIdx].end());
+      clusters.erase(clusters.begin() + static_cast<std::ptrdiff_t>(smallestIdx));
+
+      numIslandsAbsorbed++;
+    }
+
+    if (numIslandsAbsorbed > 0)
+    {
+      log(mrpt::format(
+          "[regroup] absorbed %zu isolated/undersized cluster(s) into their nearest neighbor "
+          "(island_merge_fraction=%.2f) -> %zu super-keyframes remain",
+          numIslandsAbsorbed, params.island_merge_fraction, clusters.size()));
+    }
+  }
+
   // ---- 6) Build the output map: one super-keyframe per cluster ----
   // Building each super-keyframe cloud (merge + voxel-decimate) is by far the
   // most expensive part of this function and fully independent across
@@ -2157,6 +2309,8 @@ void KeyframePointCloudMap::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR_CS(serialize_kdtrees, bool);
   MRPT_LOAD_CONFIG_VAR_CS(serialize_covariances, bool);
   MRPT_LOAD_CONFIG_VAR_CS(approximate_cov, bool);
+  MRPT_LOAD_CONFIG_VAR_CS(density_penalty_min_points, uint64_t);
+  MRPT_LOAD_CONFIG_VAR_CS(density_penalty_max_m, double);
 }
 
 void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out) const
@@ -2173,12 +2327,14 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(serialize_kdtrees, bool);
   LOADABLEOPTS_DUMP_VAR(serialize_covariances, bool);
   LOADABLEOPTS_DUMP_VAR(approximate_cov, bool);
+  LOADABLEOPTS_DUMP_VAR(density_penalty_min_points, int);
+  LOADABLEOPTS_DUMP_VAR(density_penalty_max_m, double);
 }
 
 void KeyframePointCloudMap::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  out.WriteAs<uint8_t>(6);  // version
+  out.WriteAs<uint8_t>(7);  // version
   out << max_search_keyframes << k_correspondences_for_cov;
   out << rotation_distance_weight << num_diverse_keyframes;  // v1
   out << use_view_direction_filter << max_view_angle_deg;  // v2
@@ -2186,6 +2342,7 @@ void KeyframePointCloudMap::TCreationOptions::writeToStream(
   out << serialize_kdtrees;  // v4
   out << approximate_cov;  // v5
   out << serialize_covariances;  // v6
+  out << density_penalty_min_points << density_penalty_max_m;  // v7
 }
 
 void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -2202,6 +2359,7 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
     case 4:
     case 5:
     case 6:
+    case 7:
     {
       in >> max_search_keyframes >> k_correspondences_for_cov;
       if (version >= 1)
@@ -2228,6 +2386,10 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
       if (version >= 6)
       {
         in >> serialize_covariances;
+      }
+      if (version >= 7)
+      {
+        in >> density_penalty_min_points >> density_penalty_max_m;
       }
     }
     break;


### PR DESCRIPTION
## Summary
- `KeyframePointCloudMap::icp_get_prepared_as_global()` ranked keyframe candidates purely by pose distance, so a sparse/under-merged keyframe (e.g. a leftover cluster from `regroupKeyframes()`) could win the nearest-keyframe slot over a much better-populated one just for being geometrically closer, starving ICP of real geometry and eventually stalling localization with zero correspondences.
- `regroupKeyframes()` could leave tiny, disconnected clusters as their own standalone "super-keyframes" instead of folding them into a nearby, well-populated cluster.

## Changes
- Added `TCreationOptions::density_penalty_min_points` / `density_penalty_max_m`: keyframes below the point-count floor get a proximity-ranking penalty, so sparse keyframes no longer outrank dense ones.
- Added `RegroupParams::island_merge_fraction`: clusters whose point count falls below this fraction of the largest cluster are absorbed into their nearest neighbor instead of being emitted standalone. Exposed as `mm-kf-regroup --island-merge-fraction`.
- Added two env-gated debug traces used to diagnose this (`MOLA_KEYFRAME_MAP_DEBUG_ACTIVE_KFS`, `MOLA_KEYFRAME_MAP_DEBUG_DUMP_KFS_ON_LOAD`), off by default.

## Test plan
- [x] Reproduced permanent tracking loss on a real localization run (Sletvej dataset): a 39K-point orphan keyframe was selected over multi-million-point keyframes at the exact failure location, causing `NoPairings` and a frozen pose forever.
- [x] Rebuilt the map with `mm-kf-regroup --island-merge-fraction 0.10` (10 keyframes -> 5, absorbing 5 undersized islands) and reran with the density penalty active: the same location now selects two well-populated keyframes, ICP quality ~1.0, no `NoPairings`.
- [x] Re-ran the full bag end-to-end with no permanent tracking loss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mm-kf-regroup` CLI option `--island-merge-fraction` to control regrouping island absorption.
  * Added regrouping and keyframe-creation tuning knobs for density-based behavior (`density_penalty_min_points`, `density_penalty_max_m`, and default island handling).
* **Bug Fixes**
  * Improved keyframe candidate selection in sparse cases, including a fallback when no diverse candidate is found and a density-based deprioritization for very low-point keyframes.
* **Documentation**
  * Added help text for the new CLI option and updated exposed configuration defaults/serialization to include the new tuning fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->