### PR TITLE
Make the REP-105 stale-odom fallback loud on first occurrence

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1764,10 +1764,38 @@ void BridgeROS2::publishLocalizationTf(const LocalizationSourceBase::Localizatio
         const auto ref_to_trgFrame_latest =
             tf_buffer_->lookupTransform(l.child_frame, params_.odom_frame, tf2::TimePointZero);
         tf2::fromMsg(ref_to_trgFrame_latest.transform, odomOnBase_tf);
-        MRPT_LOG_THROTTLE_WARN_STREAM(
-            60.0, "publish_localization_following_rep105: exact sensor-stamp tf '"
-                      << params_.odom_frame << "' -> '" << l.child_frame << "' unavailable ("
-                      << ex.what() << "); using latest available transform instead.");
+
+        // This fallback composes map->odom against a STALE odom transform, which
+        // biases the published TF by the robot's motion over the stamp gap
+        // (motion-correlated jitter, worst mid-turn). It used to be warned only
+        // on a 60 s throttle, which hid a persistent timing violation for a long
+        // time. Emit a loud, explanatory warning the first time it happens (with
+        // the recommended fix), then fall back to the throttled steady-state
+        // warning so logs are not flooded.
+        static bool warnedStaleOdomOnce = false;
+        if (!warnedStaleOdomOnce)
+        {
+          warnedStaleOdomOnce = true;
+          MRPT_LOG_WARN_STREAM(
+              "publish_localization_following_rep105: exact sensor-stamp tf '"
+              << params_.odom_frame << "' -> '" << l.child_frame << "' is unavailable ("
+              << ex.what()
+              << "), so map->odom is being composed against the LATEST (stale) odom "
+                 "transform. This injects motion-correlated jitter into the published "
+                 "map->odom and is expected whenever the localizer stamp leads the odom "
+                 "TF (the normal case for an estimate extrapolated to 'now'). To avoid "
+                 "the composition entirely, have the state estimator publish map->odom "
+                 "directly (StateEstimationSmoother param 'publish_map_to_odom_tf') and "
+                 "route the bridge's TF source filter to that '/map_odom' method. "
+                 "Further occurrences are throttled.");
+        }
+        else
+        {
+          MRPT_LOG_THROTTLE_WARN_STREAM(
+              60.0, "publish_localization_following_rep105: exact sensor-stamp tf '"
+                        << params_.odom_frame << "' -> '" << l.child_frame << "' unavailable ("
+                        << ex.what() << "); using latest (stale) odom transform instead.");
+        }
       }
       catch (const tf2::TransformException& ex2)
       {


### PR DESCRIPTION
## Motivation

In `publish_localization_following_rep105` mode, `publishLocalizationTf()` builds
`map->odom` by composing `(map->base_link)(t) * (odom->base_link)^-1`, looking up
`odom->base_link` at the localization stamp `t`. When that exact-stamp transform
is unavailable, it falls back to the **latest** available odom transform. That
fallback composes against a *stale* odom transform, biasing the published
`map->odom` by the robot's motion over the stamp gap — motion-correlated jitter,
worst mid-turn.

This is not an edge case: it is the normal path whenever the localizer publishes
an estimate extrapolated to "now" while `odom->base_link` only exists up to
"now minus sensor latency". The warning for it was throttled to 60 s, so this
persistent timing violation was effectively invisible in logs.

## What changed

Emit a **loud, explanatory warning the first time** the fallback fires — naming
the consequence (stale-odom composition → jitter) and the recommended fix — then
fall back to the existing throttled steady-state warning so logs are not flooded.

The recommended fix (available upstream in `mola_state_estimation`): have the
state estimator publish `map->odom` **directly** from its own `T_map_to_odom`
graph variable (`StateEstimationSmoother` param `publish_map_to_odom_tf`, method
suffix `/map_odom`), and route the bridge's TF source filter to that method. The
bridge then forwards it verbatim (its `child_frame != base_link` path), with no
composition and no stale lookup.

**No behavior change** to the published transform itself — this is a diagnostics
improvement only.

## Notes

- The composed-transform math is unchanged; only the logging around the fallback
  is louder and clearer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings when localization transform data is unavailable.
  * Added a clear first-time warning with guidance, followed by throttled notifications for recurring issues.
  * Preserved existing fallback behavior when the exact transform cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->