### PR TITLE
style: clang-format fix in MolaVizImGui_handlers.cpp

### DIFF
--- a/mola_viz_imgui/src/MolaVizImGui_handlers.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui_handlers.cpp
@@ -151,9 +151,8 @@ void handler_images(
     obj->load();
     imgToShow = obj->image.makeShallowCopy();
   }
-  else if (
-      auto obj3D = std::dynamic_pointer_cast<mrpt::obs::CObservation3DRangeScan>(o);
-      obj3D && obj3D->hasIntensityImage)
+  else if (auto obj3D = std::dynamic_pointer_cast<mrpt::obs::CObservation3DRangeScan>(o);
+           obj3D && obj3D->hasIntensityImage)
   {
     imgToShow = obj3D->intensityImage.makeShallowCopy();
   }


### PR DESCRIPTION
## Summary
- `develop` HEAD (3de93af2) has a clang-format-14 violation in `mola_viz_imgui/src/MolaVizImGui_handlers.cpp` (an `else if (init; cond)` statement whose wrapping doesn't match clang-format-14's output), currently failing `CI clang-format` on `develop` itself.
- This blocks that check from ever going green on any PR against this repo until fixed.
- Pure formatting fix, no behavior change.

## Test plan
- [x] `clang-format-14 --dry-run --Werror` clean
- [x] `colcon build --packages-select mola_viz_imgui` (Release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted image selection logic for improved code readability.
  * No changes to application behavior or visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->