### PR TITLE
GUI: add optional fixed_width to ComboBox (both backends)

### DIFF
--- a/mola_kernel/include/mola_kernel/GuiWidgetDescription.h
+++ b/mola_kernel/include/mola_kernel/GuiWidgetDescription.h
@@ -439,8 +439,10 @@ struct SliderInt
  * `initial_index` - zero-based index of the initially selected item.
  * `on_change`     - called with the new index from the GUI thread.
  *
- * nanogui : nanogui::ComboBox.
- * ImGui   : ImGui::Combo.
+ * nanogui : nanogui::ComboBox; `fixed_width` (if > 0) via setFixedWidth().
+ * ImGui   : ImGui::Combo; `fixed_width` (if > 0) via SetNextItemWidth(),
+ *           otherwise defaults to ImGui's item width (which scales with the
+ *           window, so long option labels grow the widget on resize).
  */
 struct ComboBox
 {
@@ -448,6 +450,7 @@ struct ComboBox
   std::vector<std::string> items;
   int                      initial_index = 0;
   std::function<void(int)> on_change;
+  int                      fixed_width = 0;  ///< 0 = auto (toolkit default)
 };
 
 /**

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -879,6 +879,10 @@ void build_leaf_widget(
           auto* cb = parent->add<nanogui::ComboBox>();
           cb->setItems(widget.items);
           cb->setSelectedIndex(widget.initial_index);
+          if (widget.fixed_width > 0)
+          {
+            cb->setFixedWidth(widget.fixed_width);
+          }
           if (widget.on_change)
           {
             cb->setCallback(widget.on_change);

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -215,7 +215,7 @@ MolaVizImGuiCore::PerWindowData& MolaVizImGui::create_and_add_window(const windo
   {
     title += " [" + core_ptr_->imgui_app_name_ + "]";
   }
-  GLFWwindow*       win   = glfwCreateWindow(1280, 800, title.c_str(), nullptr, nullptr);
+  GLFWwindow* win = glfwCreateWindow(1280, 800, title.c_str(), nullptr, nullptr);
   if (!win) throw std::runtime_error("MolaVizImGui: glfwCreateWindow failed");
 
   {

--- a/mola_viz_imgui/src/MolaVizImGui_widgets.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui_widgets.cpp
@@ -199,6 +199,8 @@ void MolaVizImGuiCore::render_leaf_widget(const mola::gui::LeafWidget& w, const 
           }
           items_str += '\0';
           const std::string id = widget.label.empty() ? ("##combo_" + key) : widget.label;
+          if (widget.fixed_width > 0)
+            ImGui::SetNextItemWidth(static_cast<float>(widget.fixed_width));
           if (ImGui::Combo(id.c_str(), &it->second, items_str.c_str()) && widget.on_change)
             widget.on_change(it->second);
         }


### PR DESCRIPTION
## Summary
- `mola::gui::ComboBox` gets an optional `fixed_width` field (0 = auto, matching every other sizeable widget: `Label`, `SliderFloat`, `SliderInt`).
- ImGui backend: `ImGui::SetNextItemWidth()` before `ImGui::Combo` when set.
- nanogui backend: `setFixedWidth()` on the created `nanogui::ComboBox` when set.

Motivated by mola_mapper packing a `ComboBox` next to a checkbox in a `Row`
(GUI "View" tab): without an explicit width, ImGui's combo defaults to an
item width that tracks the available content width, so a short option list
visibly balloons as the sub-window is resized.

No version bump included; the field is purely additive (default 0 preserves
current behavior on both backends). Downstream code can feature-detect it at
compile time (e.g. via a `decltype`-based trait) to keep building against
older `mola_kernel` headers without needing a version-number gate.

## Test plan
- [x] `colcon build --packages-select mola_kernel mola_viz mola_viz_imgui`
- [x] Downstream `mola_mapper` build against the updated overlay (adds two
      `ComboBox`es with `fixed_width` set) compiles and its 22 unit tests pass.
- [x] Manual visual check of nanogui + ImGui combo box widths on a live run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional fixed-width setting for combo boxes.
  * Combo boxes now apply the configured width consistently across supported interfaces.
  * When no width is specified, combo boxes continue to size automatically.
* **Documentation**
  * Expanded combo box documentation to clarify how fixed width is applied in each supported interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->