### PR TITLE
mola_yaml: new `$define` directive to set variables for a subtree

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -121,7 +121,10 @@ Other key types:
 - `MinimalModuleContainer` — module loading and lifecycle
 
 ### `mola_yaml` — YAML Parser
-Features: variable substitution (`$var`), file includes (`@include`), C++17 filesystem.
+Features: variable substitution (`$var`), file includes (`@include`), deep-merge
+`$import`, and the `$define` map directive (binds `${NAME}` variables for the subtree
+it appears in, including sibling `$import`ed files; priority `env > $define > |default`),
+C++17 filesystem.
 Tests: `mola_yaml/tests/test-yaml-parser.cpp`
 
 ### `mola_launcher` — CLI Entry Point

--- a/docs/source/concept-slam-configuration-file.rst
+++ b/docs/source/concept-slam-configuration-file.rst
@@ -235,7 +235,9 @@ Key properties:
   imported files and the plain sibling keys.  A nested ``$define`` (in this file
   or in an imported one) **shadows** an outer one for its own subtree.
 - ``$define`` **values are themselves expanded**, so they may be built from
-  ``${}`` / ``$()`` expressions.
+  ``${}`` / ``$()`` expressions.  They are expanded against the **outer** scope
+  only: entries of the same ``$define`` block cannot reference each other (this
+  keeps the result independent of the order in which they are written).
 - The ``$define`` key is stripped from the resulting configuration.
 
 .. tip::

--- a/docs/source/concept-slam-configuration-file.rst
+++ b/docs/source/concept-slam-configuration-file.rst
@@ -70,7 +70,8 @@ is run through a lightweight pre-processor that expands special ``$``\ -prefixed
 expressions.  The three expansion passes are always applied in the following
 fixed order:
 
-1. :ref:`yaml_include` - ``$include{path}``
+1. :ref:`yaml_include` - ``$include{path}``, plus the :ref:`yaml_import` and
+   :ref:`yaml_define` map directives
 2. :ref:`yaml_cmd` - ``$(command)``
 3. :ref:`yaml_vars` - ``${VAR}`` / ``${VAR|default}``
 
@@ -196,6 +197,57 @@ Equivalent multi-file base, where ``overrides.yaml`` wins over ``base.yaml``:
    file as a base **plus** local overrides.
 
 
+.. _yaml_define:
+
+Set variables for a subtree: ``$define``
+------------------------------------------
+
+Most shared MOLA parameter files already expose their tunable settings as
+``${VAR|default}`` hooks (see :ref:`yaml_vars`).  The ``$define`` **map key**
+lets a file **bind those variables** for the subtree of the map it appears in --
+**including the files pulled in by a sibling** ``$import`` **or**
+``$include{}``.
+
+Its value is a map of ``NAME: VALUE`` pairs:
+
+.. code-block:: yaml
+
+    modules:
+      - type: mola::LidarOdometry
+        name: lidar_odom
+
+        $define:
+          MOLA_DESKEW_METHOD: "MotionCompensationMethod::IMU"
+          MOLA_LO_INITIAL_LOCALIZATION_METHOD: "InitLocalization::PitchAndRollFromIMU"
+
+        $import: lidar3d-default.yaml
+
+Key properties:
+
+- **Priority is** ``environment > $define > inline |default``.  ``$define`` acts
+  as a *file-level default*: a variable exported on the command line still
+  overrides it, so ``MOLA_DESKEW_METHOD=... mola-cli my-system.yaml`` keeps
+  working as before.
+- **It is not** ``setenv``.  The bindings are scoped to the YAML subtree and
+  never leak into the real process environment, into ``$()`` sub-processes, or
+  into a sibling module's ``$import``.
+- **Scope is the map it appears in, and everything below it** -- both the
+  imported files and the plain sibling keys.  A nested ``$define`` (in this file
+  or in an imported one) **shadows** an outer one for its own subtree.
+- ``$define`` **values are themselves expanded**, so they may be built from
+  ``${}`` / ``$()`` expressions.
+- The ``$define`` key is stripped from the resulting configuration.
+
+.. tip::
+
+   ``$define`` is the way to patch a value that lives **inside a YAML sequence**
+   of an imported file.  ``$import``'s deep-merge replaces sequences *wholesale*
+   (see :ref:`yaml_import`), so overriding one field of one list item otherwise
+   forces you to duplicate the entire sequence verbatim.  If the imported file
+   exposes that field as a ``${VAR|default}`` hook, a one-line ``$define``
+   replaces the whole copy-paste.
+
+
 .. _yaml_cmd:
 
 Run an external command: ``$(command)``
@@ -243,7 +295,8 @@ order (first match wins):
    ``YAMLParseOptions::includesBasePath`` when called programmatically).
 3. **Caller-supplied variables** - entries in the
    ``YAMLParseOptions::variables`` map, which allows C++ code to inject
-   arbitrary name/value pairs at load time.
+   arbitrary name/value pairs at load time.  A :ref:`yaml_define` block binds
+   variables into this same slot, from the YAML file itself.
 4. **Inline default** - if the token has the form ``${NAME|default_value}``,
    the literal text after ``|`` is used as a fallback.  The default may be
    empty (``${NAME|}`` resolves to an empty string).
@@ -323,6 +376,10 @@ when a token falls inside a comment:
      - Left verbatim
    * - ``$import`` (map key)
      - Imported file(s), with sibling keys overriding
+     - 1st
+     - n/a (a map key, not a scalar token)
+   * - ``$define`` (map key)
+     - Nothing (binds ``${NAME}`` vars for its subtree)
      - 1st
      - n/a (a map key, not a scalar token)
    * - ``$(command)``

--- a/mola_yaml/include/mola_yaml/yaml_helpers.h
+++ b/mola_yaml/include/mola_yaml/yaml_helpers.h
@@ -69,7 +69,9 @@ namespace mola
  *     $import: lidar3d-default.yaml
  *     ```
  *     Priority is `real environment > $define > inline |default`, so a variable
- *     exported on the command line still overrides the YAML file.
+ *     exported on the command line still overrides the YAML file. Values are
+ *     expanded against the OUTER scope only, so entries of the same `$define`
+ *     block cannot reference each other (order-independent by design).
  *  2. **`$(cmd)`** - replaced with the trimmed stdout of the shell command
  *     `cmd` (exit code ≠ 0 throws).
  *  3. **`${VAR}`** or **`${VAR|default}`** - replaced with the value of

--- a/mola_yaml/include/mola_yaml/yaml_helpers.h
+++ b/mola_yaml/include/mola_yaml/yaml_helpers.h
@@ -58,6 +58,18 @@ namespace mola
  *       $import: shared-params.yaml   # base (a path, or a sequence of paths)
  *       max_rate_hz: 10.0             # override one entry of the imported base
  *     ```
+ *     Also resolved in this pass: the **`$define`** map directive, which binds
+ *     `${NAME}` variables for the subtree of the map it appears in, INCLUDING
+ *     the files pulled in by a sibling `$import` / `$include{}`. This lets a
+ *     launcher drive the `${VAR|default}` hooks an imported file already
+ *     exposes, instead of duplicating a block just to change one nested value:
+ *     ```
+ *     $define:
+ *       MOLA_DESKEW_METHOD: "MotionCompensationMethod::IMU"
+ *     $import: lidar3d-default.yaml
+ *     ```
+ *     Priority is `real environment > $define > inline |default`, so a variable
+ *     exported on the command line still overrides the YAML file.
  *  2. **`$(cmd)`** - replaced with the trimmed stdout of the shell command
  *     `cmd` (exit code ≠ 0 throws).
  *  3. **`${VAR}`** or **`${VAR|default}`** - replaced with the value of
@@ -86,6 +98,9 @@ struct YAMLParseOptions
    * Entries in this map are checked *after* the real environment variables
    * and the built-in `CURRENT_YAML_FILE_PATH` token, but *before* the
    * `|default` fallback syntax.
+   *
+   * A `$define` block in a YAML file binds variables into this same slot for
+   * the subtree it appears in.
    */
   std::map<std::string, std::string> variables;
 

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -467,6 +467,127 @@ void deepMergeNode(yaml::node_t& base, const yaml::node_t& overlay)
  * @note  Recursion here is over the YAML node tree (depth bounded by the
  *        document structure), not over the string - safe in practice.
  */
+void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opts);
+
+/**
+ * Handle the directives of a MAP node: the `$import` merge, or plain recursion
+ * into the children. Split out of `recursiveProcessIncludes()` so that the
+ * `$define` scope handling can wrap it (the `$import` branch returns early).
+ */
+void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
+{
+  auto& m = n.asMap();
+
+  // `$import` directive: a map whose `$import` key names one (scalar) or
+  // several (sequence) external YAML files is REPLACED by the deep-merge of
+  // those files (in listed order) with the map's REMAINING keys overlaid on
+  // top. So the imported file(s) act as a base, and the sibling entries
+  // OVERRIDE particular entries (nested maps merge deeply; scalars/sequences
+  // replace). This is what lets `params:` reference a shared file and then
+  // tweak just a few keys, instead of duplicating the whole block.
+  // NOTE: parens-init (NOT braces): `node_t{std::string}` would bind to the
+  // initializer_list<node_t> constructor and build a 1-element SEQUENCE node
+  // instead of a scalar, which then throws in operator<'s internalAsStr().
+  const yaml::node_t importKey(std::string("$import"));
+  if (const auto itImport = m.find(importKey); itImport != m.end())
+  {
+    std::vector<std::string> importPaths;
+    const auto&              importVal = itImport->second;
+    if (importVal.isScalar())
+    {
+      importPaths.push_back(importVal.as<std::string>());
+    }
+    else if (importVal.isSequence())
+    {
+      for (const auto& element : importVal.asSequence())
+      {
+        importPaths.push_back(element.as<std::string>());
+      }
+    }
+    else
+    {
+      THROW_EXCEPTION("`$import` value must be a file path string or a sequence of paths.");
+    }
+
+    // Base: deep-merge of the imported file(s), in the order listed.
+    yaml::node_t merged = yaml::Map();
+    for (const auto& path : importPaths)
+    {
+      const yaml::node_t loaded = loadExternalYaml(path, opts);
+      deepMergeNode(merged, loaded);
+    }
+
+    // Overlay: the remaining sibling keys (recursively pre-processed first),
+    // which override the imported base.
+    for (auto& [key, value] : m)
+    {
+      if (key.isScalar() && key.as<std::string>() == "$import")
+      {
+        continue;
+      }
+      recursiveProcessIncludes(value, opts);
+      yaml::node_t single = yaml::Map();
+      single.asMap()[key] = value;
+      deepMergeNode(merged, single);
+    }
+
+    n = merged;
+    return;
+  }
+
+  for (auto& [key, value] : m)
+  {
+    recursiveProcessIncludes(value, opts);
+  }
+}
+
+/**
+ * Consume a `$define` key from map `m`, returning a copy of `opts` augmented
+ * with its `NAME: VALUE` pairs as `${NAME}` variables, and erasing the key from
+ * `m` so it does not reach the output. Returns `std::nullopt` when the map has
+ * no `$define` key.
+ *
+ * The values may themselves contain `${}` / `$()` expressions; they are resolved
+ * against the OUTER scope, so the result never depends on the order in which the
+ * map entries happen to be visited.
+ */
+[[nodiscard]] std::optional<mola::YAMLParseOptions> consumeDefineBlock(
+    yaml::map_t& m, const mola::YAMLParseOptions& opts)
+{
+  const yaml::node_t defineKey(std::string("$define"));
+  const auto         itDefine = m.find(defineKey);
+  if (itDefine == m.end())
+  {
+    return std::nullopt;
+  }
+
+  auto scopedOpts = opts;
+
+  if (!itDefine->second.isMap())
+  {
+    THROW_EXCEPTION("`$define` value must be a map of `NAME: VALUE` entries.");
+  }
+
+  // Expand the values with the outer scope, but without the include pass: the
+  // values are plain scalars, not YAML documents.
+  auto valueOpts       = opts;
+  valueOpts.doIncludes = false;
+
+  for (const auto& [key, value] : itDefine->second.asMap())
+  {
+    if (!key.isScalar() || !value.isScalar())
+    {
+      THROW_EXCEPTION("`$define` entries must be scalar `NAME: VALUE` pairs.");
+    }
+    scopedOpts.variables[key.as<std::string>()] =
+        trimWSNL(mola::parse_yaml(value.as<std::string>(), valueOpts));
+  }
+
+  m.erase(itDefine);
+
+  return scopedOpts;
+}
+
 void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opts)
 {
   if (n.isScalar())
@@ -499,68 +620,29 @@ void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opt
   }
   else if (n.isMap())
   {
-    auto& m = n.asMap();
+    // `$define` directive: a sibling map of `NAME: VALUE` pairs that become
+    // `${NAME}` variables for this map's whole subtree, including the files
+    // pulled in by a sibling `$import` / `$include{}`. This lets a launcher
+    // select a variant of an imported pipeline through the `${VAR|default}`
+    // hooks that file already exposes, instead of duplicating a whole block
+    // just to change one nested value.
+    // The resolution order in parseVars() is unchanged, so the effective
+    // priority is: real environment > `$define` > inline `|default`. A variable
+    // exported on the command line therefore still overrides the YAML file.
+    const auto  defineOpts = consumeDefineBlock(n.asMap(), opts);
+    const auto& scopedOpts = defineOpts.has_value() ? *defineOpts : opts;
 
-    // `$import` directive: a map whose `$import` key names one (scalar) or
-    // several (sequence) external YAML files is REPLACED by the deep-merge of
-    // those files (in listed order) with the map's REMAINING keys overlaid on
-    // top. So the imported file(s) act as a base, and the sibling entries
-    // OVERRIDE particular entries (nested maps merge deeply; scalars/sequences
-    // replace). This is what lets `params:` reference a shared file and then
-    // tweak just a few keys, instead of duplicating the whole block.
-    // NOTE: parens-init (NOT braces): `node_t{std::string}` would bind to the
-    // initializer_list<node_t> constructor and build a 1-element SEQUENCE node
-    // instead of a scalar, which then throws in operator<'s internalAsStr().
-    const yaml::node_t importKey(std::string("$import"));
-    if (const auto itImport = m.find(importKey); itImport != m.end())
+    processMapDirectives(n, scopedOpts);
+
+    if (defineOpts.has_value())
     {
-      std::vector<std::string> importPaths;
-      const auto&              importVal = itImport->second;
-      if (importVal.isScalar())
-      {
-        importPaths.push_back(importVal.as<std::string>());
-      }
-      else if (importVal.isSequence())
-      {
-        for (const auto& element : importVal.asSequence())
-        {
-          importPaths.push_back(element.as<std::string>());
-        }
-      }
-      else
-      {
-        THROW_EXCEPTION("`$import` value must be a file path string or a sequence of paths.");
-      }
-
-      // Base: deep-merge of the imported file(s), in the order listed.
-      yaml::node_t merged = yaml::Map();
-      for (const auto& path : importPaths)
-      {
-        const yaml::node_t loaded = loadExternalYaml(path, opts);
-        deepMergeNode(merged, loaded);
-      }
-
-      // Overlay: the remaining sibling keys (recursively pre-processed first),
-      // which override the imported base.
-      for (auto& [key, value] : m)
-      {
-        if (key.isScalar() && key.as<std::string>() == "$import")
-        {
-          continue;
-        }
-        recursiveProcessIncludes(value, opts);
-        yaml::node_t single = yaml::Map();
-        single.asMap()[key] = value;
-        deepMergeNode(merged, single);
-      }
-
-      n = merged;
-      return;
-    }
-
-    for (auto& [key, value] : m)
-    {
-      recursiveProcessIncludes(value, opts);
+      // The variable pass runs later over the whole document with the OUTER
+      // options, so it would not see these definitions: expand them now, over
+      // this subtree only. Includes/commands were already resolved above.
+      auto varOpts       = scopedOpts;
+      varOpts.doIncludes = false;
+      varOpts.doCmdRuns  = false;
+      n = yaml::FromText(mola::parse_yaml(mola::yaml_to_string(yaml(n)), varOpts)).node();
     }
   }
 }

--- a/mola_yaml/tests/test-yaml-parser.cpp
+++ b/mola_yaml/tests/test-yaml-parser.cpp
@@ -630,6 +630,135 @@ void test_parseImportMissingFile()
   ASSERT_(did_throw);
 }
 
+// ---------------------------------------------------------------------------
+// 13. `$define` directive: bind ${VAR} variables for a subtree
+//
+// A `$define` map key binds `${NAME}` variables for the whole subtree of the
+// map it appears in, INCLUDING the files pulled in by a sibling `$import` /
+// `$include{}`. Priority: real environment > $define > inline `|default`.
+// ---------------------------------------------------------------------------
+void test_parseDefine()
+{
+  using mrpt::containers::yaml;
+
+  mola::YAMLParseOptions opts;
+  opts.includesBasePath = MOLA_MODULE_SOURCE_DIR;
+
+  // --- the imported file's ${VAR|default} hooks are driven by $define ---
+  {
+    const std::string input =
+        "params:\n"
+        "  $define:\n"
+        "    MOLA_TEST_DEFINE_METHOD: from_define\n"
+        "    MOLA_TEST_DEFINE_DEEP: deep_from_define\n"
+        "  $import: test_define_base.yaml\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+
+    ASSERT_EQUAL_(y["params"]["method"].as<std::string>(), "from_define");
+    ASSERT_EQUAL_(y["params"]["nested"]["deep"].as<std::string>(), "deep_from_define");
+    // Untouched hooks keep their inline default:
+    ASSERT_EQUAL_(y["params"]["gain"].as<std::string>(), "1.0");
+    // Reaches inside sequences too - which plain $import overrides cannot patch:
+    ASSERT_EQUAL_(y["params"]["steps"](0)["mode"].as<std::string>(), "from_define");
+    ASSERT_EQUAL_(y["params"]["steps"](1)["mode"].as<std::string>(), "fixed");
+    // The directive itself must not survive into the output:
+    ASSERT_(!y["params"].has("$define"));
+  }
+
+  // --- without $define, the imported file falls back to its inline defaults ---
+  {
+    const std::string input = "params:\n  $import: test_define_base.yaml\n";
+    const auto        y     = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["params"]["method"].as<std::string>(), "default_method");
+  }
+
+  // --- a real environment variable still wins over $define ---
+  {
+    MOLA_TEST_SETENV("MOLA_TEST_DEFINE_METHOD", "from_env");
+
+    const std::string input =
+        "params:\n"
+        "  $define:\n"
+        "    MOLA_TEST_DEFINE_METHOD: from_define\n"
+        "  $import: test_define_base.yaml\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["params"]["method"].as<std::string>(), "from_env");
+
+    MOLA_TEST_UNSETENV("MOLA_TEST_DEFINE_METHOD");
+  }
+
+  // --- $define also reaches SIBLING keys of the same map, not just imports ---
+  {
+    const std::string input =
+        "params:\n"
+        "  $define:\n"
+        "    MY_VAR: sibling_value\n"
+        "  local: '${MY_VAR}'\n"
+        "  deeper:\n"
+        "    also: '${MY_VAR}'\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["params"]["local"].as<std::string>(), "sibling_value");
+    ASSERT_EQUAL_(y["params"]["deeper"]["also"].as<std::string>(), "sibling_value");
+  }
+
+  // --- scope is limited to the subtree: a sibling map does NOT see it ---
+  {
+    const std::string input =
+        "a:\n"
+        "  $define:\n"
+        "    SCOPED_VAR: inside\n"
+        "  v: '${SCOPED_VAR}'\n"
+        "b:\n"
+        "  v: '${SCOPED_VAR|outside}'\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["a"]["v"].as<std::string>(), "inside");
+    ASSERT_EQUAL_(y["b"]["v"].as<std::string>(), "outside");
+  }
+
+  // --- $define values may themselves use ${} / $() expressions ---
+  {
+    mola::YAMLParseOptions o2 = opts;
+    o2.variables["OUTER"]     = "composed";
+
+    const std::string input =
+        "params:\n"
+        "  $define:\n"
+        "    INNER: '${OUTER}-suffix'\n"
+        "  v: '${INNER}'\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), o2);
+    ASSERT_EQUAL_(y["params"]["v"].as<std::string>(), "composed-suffix");
+  }
+
+  // --- nested scopes: an inner $define shadows the outer one ---
+  {
+    const std::string input =
+        "$define:\n"
+        "  MOLA_TEST_DEFINE_METHOD: from_outer\n"
+        "top:\n"
+        "  $import: test_define_nested.yaml\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    // test_define_nested.yaml re-defines the variable for its `inner` subtree
+    // only; `outer` inherits the top-level definition.
+    ASSERT_EQUAL_(y["top"]["inner"]["method"].as<std::string>(), "from_inner_file");
+    ASSERT_EQUAL_(y["top"]["outer"]["method"].as<std::string>(), "from_outer");
+  }
+
+  // --- a non-map $define value is an error ---
+  {
+    bool did_throw = false;
+    try
+    {
+      const auto y = mola::parse_yaml(yaml::FromText("p:\n  $define: not_a_map\n"), opts);
+      (void)y;
+    }
+    catch (const std::exception&)
+    {
+      did_throw = true;
+    }
+    ASSERT_(did_throw);
+  }
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -652,6 +781,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_yaml2stringAdditional();
     test_parseImportOverride();
     test_parseImportMissingFile();
+    test_parseDefine();
 
     std::cout << "Test successful.\n";
   }

--- a/mola_yaml/tests/test_define_base.yaml
+++ b/mola_yaml/tests/test_define_base.yaml
@@ -1,0 +1,12 @@
+# base file exercising $define: every value is driven by a ${VAR|default} hook,
+# as the real MOLA pipeline files are.
+---
+method: "${MOLA_TEST_DEFINE_METHOD|default_method}"
+gain: "${MOLA_TEST_DEFINE_GAIN|1.0}"
+nested:
+  deep: "${MOLA_TEST_DEFINE_DEEP|deep_default}"
+steps:
+  - name: step1
+    mode: "${MOLA_TEST_DEFINE_METHOD|default_method}"
+  - name: step2
+    mode: fixed

--- a/mola_yaml/tests/test_define_nested.yaml
+++ b/mola_yaml/tests/test_define_nested.yaml
@@ -1,0 +1,9 @@
+# $define in an imported file: shadows the outer scope for its own subtree, and
+# still lets its own $import see the value.
+---
+inner:
+  $define:
+    MOLA_TEST_DEFINE_METHOD: "from_inner_file"
+  $import: test_define_base.yaml
+outer:
+  $import: test_define_base.yaml


### PR DESCRIPTION
## Motivation

Shared MOLA pipeline files already expose their tunable settings as `${VAR|default}` hooks, but a launcher had no way to drive them from the YAML itself — the value had to come from the real environment.

The workaround was to duplicate whole blocks after an `$import` just to change one nested field. That is especially bad for values living **inside a YAML sequence**, since `$import`'s deep-merge replaces sequences wholesale, so patching one field of one list item forces a verbatim copy of the entire sequence. `mola_mapper`'s Oxford Spires launcher carries ~35 such duplicated lines (plus a long comment explaining why), purely to switch a deskew method and an initial-localization method.

## What this adds

A `$define` map key holding `NAME: VALUE` pairs, bound as `${NAME}` variables for the subtree of the map it appears in — **including the files pulled in by a sibling `$import` / `$include{}`**:

```yaml
- name: lidar_odom
  type: mola::LidarOdometry

  $define:
    MOLA_DESKEW_METHOD: "MotionCompensationMethod::IMU"
    MOLA_LO_INITIAL_LOCALIZATION_METHOD: "InitLocalization::PitchAndRollFromIMU"

  $import: lidar3d-default.yaml
```

## Semantics

- **Priority: `environment > $define > inline |default`.** The bindings go into `YAMLParseOptions::variables`, so the resolution order in `parseVars()` is unchanged. A variable exported on the command line still overrides the file, keeping the existing `MOLA_DESKEW_METHOD=... mola-cli sys.yaml` UX intact.
- **Not a `setenv`.** Scope is the YAML subtree; nothing leaks into the process environment, into `$()` sub-processes, or into a sibling module's `$import`.
- **Scope = the map it appears in and everything below**, covering both imported files and plain sibling keys. A nested `$define` shadows an outer one for its own subtree.
- Values are themselves expanded, so they can be built from `${}` / `$()`.
- The key is stripped from the output.

Because the variable pass runs later over the whole document with the *outer* options, a subtree carrying a `$define` is expanded eagerly, so the definitions reach plain sibling keys and not only the imported files. Without that, `$define` would silently do nothing for siblings — the same class of silent-no-op that the existing `$import` nesting gotcha already causes.

## Testing

- New `test_parseDefine()` in `test-yaml-parser.cpp` (+2 fixture files) covering: driving an imported file's hooks, reaching into sequences, fallback to inline defaults, env-wins-over-`$define`, sibling-key reach, subtree scoping, composed values, nested/shadowing scopes, and the non-map error path. Full suite passes.
- Verified end-to-end with `mola-yaml-parser` against the real `lidar3d-default.yaml`: both `observations_deskew_pass` filter steps and `initial_localization.method` resolve from `$define`.

## Docs

New `$define` section in `concept-slam-configuration-file.rst`, plus updates to the pass-order list, the processing-order table, the `${VAR}` resolution-order list, and the `yaml_helpers.h` API docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `$define` YAML directive to bind `${VAR}` substitutions scoped to the subtree where `$define` appears.
  * Supports `$define` with imported/included content and correct map-key handling during preprocessing.
  * Includes nested shadowing and sibling scoping behavior; `$define` is omitted from the final configuration.
  * Variable precedence is `environment > $define > |default`.
* **Documentation**
  * Updated parsing/preprocessing docs to describe `$define` semantics and processing order.
* **Tests**
  * Added unit tests and fixtures covering scoping, shadowing, imports, expansion, and invalid usage.
* **Bug Fixes**
  * Malformed `$define` (non-map content) now throws an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->