### PR TITLE
fix(mola_yaml): outer $define wins over a more deeply imported file's own $define

### DIFF
--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -600,8 +600,7 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
       continue;
     }
 
-    scopedOpts.variables[varName] =
-        trimWSNL(mola::parse_yaml(value.as<std::string>(), valueOpts));
+    scopedOpts.variables[varName] = trimWSNL(mola::parse_yaml(value.as<std::string>(), valueOpts));
   }
 
   m.erase(itDefine);

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -550,6 +550,18 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
  * The values may themselves contain `${}` / `$()` expressions; they are resolved
  * against the OUTER scope, so the result never depends on the order in which the
  * map entries happen to be visited.
+ *
+ * OUTER-WINS ACROSS NESTING: a name already present in `opts.variables` -
+ * whether set by an ancestor `$define` (however many `$import` levels up) or
+ * supplied by the caller before parsing started - is left untouched; this
+ * block's own entry for that name is skipped. This mirrors, one level up,
+ * "environment > $define > inline default" for a single `${VAR|default}`
+ * token: the scope closer to the document root / the caller has final say,
+ * not the file it happens to import. Without this, a reusable imported
+ * fragment that `$define`s one of its own hooks (to change ONLY its inline
+ * default) would silently and permanently shadow that same hook for every
+ * file that imports it, with no way for an importer to override it short of
+ * restating the whole target key as a literal sibling value.
  */
 [[nodiscard]] std::optional<mola::YAMLParseOptions> consumeDefineBlock(
     yaml::map_t& m, const mola::YAMLParseOptions& opts)
@@ -579,7 +591,16 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
     {
       THROW_EXCEPTION("`$define` entries must be scalar `NAME: VALUE` pairs.");
     }
-    scopedOpts.variables[key.as<std::string>()] =
+    const std::string varName = key.as<std::string>();
+
+    // Already set by an outer scope: that definition wins (see OUTER-WINS
+    // note above), so this file's own entry for the same name is a no-op.
+    if (opts.variables.count(varName) != 0)
+    {
+      continue;
+    }
+
+    scopedOpts.variables[varName] =
         trimWSNL(mola::parse_yaml(value.as<std::string>(), valueOpts));
   }
 
@@ -629,6 +650,11 @@ void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opt
     // The resolution order in parseVars() is unchanged, so the effective
     // priority is: real environment > `$define` > inline `|default`. A variable
     // exported on the command line therefore still overrides the YAML file.
+    // Across NESTED `$define` scopes for the SAME name (e.g. an imported file
+    // `$define`s one of its own hooks), the OUTER one wins: consumeDefineBlock
+    // skips re-defining a name already present in the incoming `opts`, so the
+    // scope closest to the document root - not the file it imports - has
+    // final say (see its doc comment).
     const auto  defineOpts = consumeDefineBlock(n.asMap(), opts);
     const auto& scopedOpts = defineOpts.has_value() ? *defineOpts : opts;
 

--- a/mola_yaml/tests/test-yaml-parser.cpp
+++ b/mola_yaml/tests/test-yaml-parser.cpp
@@ -729,7 +729,9 @@ void test_parseDefine()
     ASSERT_EQUAL_(y["params"]["v"].as<std::string>(), "composed-suffix");
   }
 
-  // --- nested scopes: an inner $define shadows the outer one ---
+  // --- nested scopes: an OUTER $define wins over a more deeply imported
+  //     file's own $define for the SAME name; a name the outer scope never
+  //     touches still gets set by the inner file's own $define ---
   {
     const std::string input =
         "$define:\n"
@@ -737,10 +739,40 @@ void test_parseDefine()
         "top:\n"
         "  $import: test_define_nested.yaml\n";
     const auto y = mola::parse_yaml(yaml::FromText(input), opts);
-    // test_define_nested.yaml re-defines the variable for its `inner` subtree
-    // only; `outer` inherits the top-level definition.
-    ASSERT_EQUAL_(y["top"]["inner"]["method"].as<std::string>(), "from_inner_file");
+    // test_define_nested.yaml's `inner` subtree tries to re-define the SAME
+    // variable; the outer (root) definition wins for both `inner` and `outer`:
+    ASSERT_EQUAL_(y["top"]["inner"]["method"].as<std::string>(), "from_outer");
     ASSERT_EQUAL_(y["top"]["outer"]["method"].as<std::string>(), "from_outer");
+    // A name the outer scope never touches still gets set by the more deeply
+    // imported file's own $define:
+    ASSERT_EQUAL_(y["top"]["inner"]["gain"].as<std::string>(), "from_inner_file_gain");
+    // ... and, absent any $define for it anywhere, falls back to the inline
+    // default, same as always:
+    ASSERT_EQUAL_(y["top"]["outer"]["gain"].as<std::string>(), "1.0");
+  }
+
+  // --- outer-wins holds across a genuine multi-level $import CHAIN too, not
+  //     just nested same-document scopes: a reusable fragment that $define's
+  //     one of its own hooks (test_define_chain_middle.yaml, itself imported
+  //     via a plain, un-$define'd $import here) must not permanently shadow
+  //     that hook from every file that imports it ---
+  {
+    const std::string input =
+        "$define:\n"
+        "  MOLA_TEST_DEFINE_METHOD: from_outer_chain\n"
+        "$import: test_define_chain_middle.yaml\n";
+    const auto y = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["method"].as<std::string>(), "from_outer_chain");
+    // Untouched by either layer's $define: still the inline default.
+    ASSERT_EQUAL_(y["gain"].as<std::string>(), "1.0");
+  }
+
+  // --- without an outer override, the middle file's own $define still
+  //     applies (it is not merely inert) ---
+  {
+    const std::string input = "$import: test_define_chain_middle.yaml\n";
+    const auto        y     = mola::parse_yaml(yaml::FromText(input), opts);
+    ASSERT_EQUAL_(y["method"].as<std::string>(), "from_middle_file");
   }
 
   // --- a non-map $define value is an error ---

--- a/mola_yaml/tests/test_define_chain_middle.yaml
+++ b/mola_yaml/tests/test_define_chain_middle.yaml
@@ -1,0 +1,9 @@
+# A reusable fragment that $define's one of the base file's hooks itself, to
+# retune ITS OWN inline default -- mirroring a real "mola_mapper's shared
+# loop-closure pipeline retunes one of mola_sm_loop_closure's hooks" file. A
+# file further up an $import chain must still be able to override
+# MOLA_TEST_DEFINE_METHOD (see the "outer-wins" tests in test-yaml-parser.cpp).
+---
+$define:
+  MOLA_TEST_DEFINE_METHOD: from_middle_file
+$import: test_define_base.yaml

--- a/mola_yaml/tests/test_define_nested.yaml
+++ b/mola_yaml/tests/test_define_nested.yaml
@@ -1,9 +1,11 @@
-# $define in an imported file: shadows the outer scope for its own subtree, and
-# still lets its own $import see the value.
+# $define in an imported file: for a name the OUTER scope already defines, the
+# outer definition wins (does NOT get shadowed here); for a name the outer
+# scope never touches, this file's own $define still applies normally.
 ---
 inner:
   $define:
-    MOLA_TEST_DEFINE_METHOD: "from_inner_file"
+    MOLA_TEST_DEFINE_METHOD: "from_inner_file"    # outer also defines this: outer wins
+    MOLA_TEST_DEFINE_GAIN: "from_inner_file_gain" # outer does not touch this: this wins
   $import: test_define_base.yaml
 outer:
   $import: test_define_base.yaml


### PR DESCRIPTION
## Summary
- Nested `$define` blocks for the same variable name did not compose the way `$import` sibling overrides do: the more deeply imported file's own `$define` silently won, discarding an outer file's override for that same name — the opposite of the documented `environment > $define > inline default` priority, one level up.
- `consumeDefineBlock()` now skips a `$define` entry whose name is already present in the inherited scope, so the scope closest to the document root (or the caller's initial variables) has final say.
- Found while retuning `mola_mapper`'s loop-closure pipeline YAMLs, which chain two `$import` levels (a per-dataset override importing a shared fragment importing `mola_sm_loop_closure`'s base pipeline), each retuning a hook via `$define`.

## Behavior change
- Before: `outer.yaml $define X=1` imports `middle.yaml $define X=5` imports `base ${X|default}` → resolved to `5` (middle wins).
- After: same chain → resolves to `1` (outer wins), matching the intuitive/documented "the file doing the importing has final say" model.
- Unaffected: disjoint variable names across nesting levels, a `$define` overriding a plain sibling-key value, and real environment variables (still win over everything).

## Test plan
- [x] Rewrote `tests/test_define_nested.yaml` + its `test_parseDefine()` case to assert the new (opposite) outer-wins contract, while still covering a name only the inner file defines (still applies normally).
- [x] Added `tests/test_define_chain_middle.yaml` + a dedicated regression test for the exact multi-level `$import` chain shape that surfaced this (mirrors the real `mola_mapper` files).
- [x] `colcon test --packages-select mola_yaml`: 100% passed (2/2).
- [x] Verified end-to-end via `mola-yaml-parser` on a minimal repro before/after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated YAML `$define` scoping across nested imports so outer/document-root definitions take precedence when the same variable name is already set.
  * Kept inner `$define` values effective only for variables not defined in the outer scope.
  * Ensured the same “outer-wins” behavior across multi-level `$import` chains.
* **Tests**
  * Updated and expanded define/import precedence assertions for nested and chained scenarios.
  * Added a new YAML fixture to cover a `$define` override coming from a middle imported file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->