### PR TITLE
Let a module expose child loggers for console capture

### DIFF
--- a/mola_kernel/include/mola_kernel/interfaces/ExecutableBase.h
+++ b/mola_kernel/include/mola_kernel/interfaces/ExecutableBase.h
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace mola
@@ -115,6 +116,27 @@ class ExecutableBase : public mrpt::system::COutputLogger,  // for logging
 
   void        setModuleInstanceName(const std::string& s);
   std::string getModuleInstanceName() const;
+
+  /** A short name identifying a child logger, as returned by
+   * child_loggers(). \sa child_loggers() */
+  using ChildLoggerName = std::string;
+
+  /** Additional loggers owned by this module that are not this
+   * ExecutableBase itself, e.g. a library engine run on a background
+   * thread with its own mrpt::system::COutputLogger. Overriding this
+   * lets generic log consumers (like a GUI console window) capture their
+   * output the same way they already do for the module itself, without
+   * the module having to relay each message through its own logger.
+   * Each entry pairs a short name identifying the sub-logger with a
+   * pointer to it; the pointer must stay valid for as long as it may be
+   * returned here.
+   * \sa findService()
+   */
+  virtual std::vector<std::pair<ChildLoggerName, mrpt::system::COutputLogger*>> child_loggers()
+      const
+  {
+    return {};
+  }
   /** @} */
 
   /** @name Module parameter handling

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -324,6 +324,10 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   // ---------------------------------------------------------------------------
   double                lastTimeCheckForConsoleModules_ = 0;
   std::set<std::string> consoleHookedModules_;  // instance names already hooked
+  // child_loggers() entries already hooked, keyed by logger identity (a
+  // module may create/destroy these, e.g. a background-thread engine, so
+  // they cannot be tracked by instance name alone).
+  std::set<const mrpt::system::COutputLogger*> consoleHookedChildLoggers_;
 
   void console_check_new_modules();
 };

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -469,30 +469,71 @@ void MolaVizImGui::console_check_new_modules()
     module->setVerbosityLevelForCallbacks(captureLevel);
 
     const std::string name = module->getModuleInstanceName();
-    if (consoleHookedModules_.count(name)) continue;
-    consoleHookedModules_.insert(name);
-    sink->note_source(name);
+    if (!consoleHookedModules_.count(name))
+    {
+      consoleHookedModules_.insert(name);
+      sink->note_source(name);
 
-    // shared_ptr capture keeps the sink alive as long as the module's logger
-    // holds this callback; 'name' (not loggerName) is captured for a stable id.
-    module->logRegisterCallback(
-        [sink, name](
-            std::string_view msg, mrpt::system::VerbosityLevel       level,
-            std::string_view /*loggerName*/, mrpt::Clock::time_point timestamp)
-        {
-          std::vector<std::string> lines;
-          mrpt::system::tokenize(std::string(msg), "\r\n", lines);
-          if (lines.empty()) lines.push_back(std::string(msg));
-
-          for (const auto& line : lines)
+      // shared_ptr capture keeps the sink alive as long as the module's
+      // logger holds this callback; 'name' (not loggerName) is captured for
+      // a stable id.
+      module->logRegisterCallback(
+          [sink, name](
+              std::string_view msg, mrpt::system::VerbosityLevel       level,
+              std::string_view /*loggerName*/, mrpt::Clock::time_point timestamp)
           {
-            ConsoleLogEntry e;
-            e.timestamp = timestamp;
-            e.level     = level;
-            e.source    = name;
-            e.text      = line;
-            sink->push(e);
-          }
-        });
+            std::vector<std::string> lines;
+            mrpt::system::tokenize(std::string(msg), "\r\n", lines);
+            if (lines.empty()) lines.push_back(std::string(msg));
+
+            for (const auto& line : lines)
+            {
+              ConsoleLogEntry e;
+              e.timestamp = timestamp;
+              e.level     = level;
+              e.source    = name;
+              e.text      = line;
+              sink->push(e);
+            }
+          });
+    }
+
+    // Sub-loggers the module owns but does not log through itself (e.g. a
+    // library engine run on its own background thread). Hooked the same
+    // way, tagged with their own source name, so their output shows up in
+    // the console window without the module having to relay each message.
+    for (const auto& [childName, childLogger] : module->child_loggers())
+    {
+      if (!childLogger) continue;
+
+      // Re-applied every tick, same reasoning as for the module above.
+      childLogger->setVerbosityLevelForCallbacks(captureLevel);
+
+      if (consoleHookedChildLoggers_.count(childLogger)) continue;
+      consoleHookedChildLoggers_.insert(childLogger);
+
+      const std::string fullName = name + "/" + childName;
+      sink->note_source(fullName);
+
+      childLogger->logRegisterCallback(
+          [sink, fullName](
+              std::string_view msg, mrpt::system::VerbosityLevel       level,
+              std::string_view /*loggerName*/, mrpt::Clock::time_point timestamp)
+          {
+            std::vector<std::string> lines;
+            mrpt::system::tokenize(std::string(msg), "\r\n", lines);
+            if (lines.empty()) lines.push_back(std::string(msg));
+
+            for (const auto& line : lines)
+            {
+              ConsoleLogEntry e;
+              e.timestamp = timestamp;
+              e.level     = level;
+              e.source    = fullName;
+              e.text      = line;
+              sink->push(e);
+            }
+          });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `ExecutableBase` gains `child_loggers()`, an optional hook returning additional `mrpt::system::COutputLogger` instances a module owns but does not log through itself (e.g. a library engine run on its own background thread).
- `mola_viz_imgui`'s console window discovers and hooks these the same way it already does for the module itself, tagged with a `module/child` source name.

## Why
`mola_mapper`'s background loop-closure engine (`mola_sm_loop_closure`'s `FrameToFrameLoopClosure`) has its own, independent `COutputLogger`. Its console output was invisible to the imgui Console window, since that window only discovers `findService<ExecutableBase>()` modules. Relaying the messages through the owning module's own logger was rejected: it would re-apply the module's own verbosity gating and defeat independently-configurable sub-engine verbosity (e.g. `MOLA_VERBOSITY_LOOP_CLOSURE`). This hook lets each child logger keep its own gating while still getting captured.

A consumer of this (mola_mapper's `Mapper::child_loggers()` override) has already landed on `mola_mapper`'s `develop`.

## Test plan
- [x] `colcon build --packages-select mola_kernel mola_viz_imgui mola_mapper`
- [x] `colcon test --packages-select mola_mapper` (26/26 passing)
- [ ] Manual: run a loop-closure-enabled launch and confirm `loop_closure` engine messages appear in the imgui Console window under a `Mapper/loop_closure` source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modules can now expose additional named output loggers.
  * The in-app console now captures messages from child loggers using clear module and logger source names.
  * Logger verbosity settings are applied consistently to both modules and their child loggers.

* **Bug Fixes**
  * Prevented duplicate console hooks for modules and dynamically created child loggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->