### PR TITLE
feat(metric_maps): add mola::IncrementalPointCloud (incremental k-d tree local map)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -142,6 +142,52 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
 - `SparseVoxelPointCloud`
 - `NDTMap` (Normal Distribution Transform)
 - `KeyframeMap`
+- `IncrementalPointCloud` (new 2026): sliding-window LIO local map derived from
+  `mrpt::maps::CGenericPointsMap`, backed by **one** incremental self-balancing
+  nanoflann k-d tree (`KDTreeSingleIndexIncrementalAdaptor`, or the `…MT`
+  variant with background rebuilds) instead of rebuilding a static tree on every
+  scan. Insertion goes through the inherited `CPointsMap` entry points (the
+  index picks up appended points lazily); `creationOptions.remove_points_farther_than`
+  trims a cube around the robot on each `insertObservation()`, and the slots
+  freed by the index are recycled, keeping storage bounded under churn.
+  `remove_points_farther_than` is a **cube half-side** (Chebyshev distance, as in
+  `HashedVoxelPointCloud::remove_voxels_farther_than`), NOT a radius on keyframe
+  centres like KFM's `remove_frames_farther_than`: every point inside it is kept
+  in a single tree and rendered, so it needs a far tighter budget than KFM's
+  equivalent -- around the sensor range, not several times it.
+  `async_rebuild` (the `…MT` index) moves the balancing rebuilds off the mapping
+  thread and is what keeps insertion latency flat -- on Oxford Spires it takes
+  local-map insertion from mean 28 ms / max 371 ms to mean 10 ms / max 38 ms with
+  no spike over 100 ms -- so `lidar3d-gicp.yaml` enables it by default. Its
+  worker reads the inherited coordinate buffers, so those must not be
+  reallocated while it runs: `reserve()`/`resize()`/`setSize()` are overridden to
+  wait for it first (which covers `insertObservation()`/`insertAnotherMap()`),
+  and insertion keeps spare capacity for one batch so a raw `insertPointFast()`
+  loop cannot realloc either. Don't add a growth path that bypasses those.
+  Reclaimed-but-not-yet-reused slots are blanked to NaN so that generic
+  `CPointsMap` walkers (notably `insertAnotherMap()`, used by
+  `LidarOdometry_Publish.cpp` to copy layers out for visualization) cannot
+  resurrect evicted geometry. The storage array itself never shrinks on its own:
+  it settles at its high-water mark and slots are recycled; `compact()` releases
+  it on demand.
+  Implements `mp2p_icp::NearestPointWithCovCapable` with lazily computed,
+  cached, plane-regularized per-point covariances (the "option A" of the plan;
+  voxel/NDT-style and dirty-propagation covariances remain future work). Not for
+  loop closure (a global SE(3) re-map would force a full rebuild) -- use
+  `KeyframePointCloudMap` there. Caveats: point removal is lazy, so the
+  inherited `size()` counts live + not-yet-reclaimed slots (use
+  `livePointCount()`, or `compact()` to drop them); `nn_*` indices are storage
+  slots; 2D `nn_*` queries throw.
+  Gated by the CMake-set `MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD`
+  (requires nanoflann >= 1.10.0; the class is simply not built otherwise).
+  **nanoflann is included by `src/IncrementalKDTree.cpp` alone, by absolute path
+  (`MOLA_NANOFLANN_HEADER`, set by CMake) and with its namespace renamed**,
+  because MRPT bundles its own, usually older, copy of the same header and
+  mixing both would be an ODR violation (their pooled allocators differ while
+  sharing mangled names). An `-I` cannot select ours: MRPT exports its copy's
+  directory as `-isystem`, and a directory listed both ways is deduplicated by
+  GCC in favor of the system entry. Keep that file free of MRPT headers, and
+  keep nanoflann out of the public headers.
 - All support MRPT serialization
 - `mola::OptionsCapable` (`include/mola_metric_maps/OptionsCapable.h`): mixin interface
   implemented by `NDT`, `HashedVoxelPointCloud`, `SparseVoxelPointCloud`, `SparseTreesPointCloud`,
@@ -306,6 +352,7 @@ so it keeps `::getenv` by design.
 |----------|------|---------|----------|---------|
 | `MOLA_MODULES_LIB_PATH` | path list | (unset) | `mola_launcher/src/MolaLauncherApp.cpp` | Extra directories to search for module shared libraries |
 | `MOLA_MODULES_SHARED_PATH` | path list | (unset) | `mola_launcher/src/MolaLauncherApp.cpp` | Extra directories to search for module shared (data) files |
+| `MOLA_INCREMENTAL_MAP_DEBUG_STATS` | bool | false | `mola_metric_maps/src/IncrementalPointCloud.cpp` | Trace live/storage/free-slot counts and the map bbox on every insertion |
 | `MOLA_KEYFRAME_MAP_PROFILE_COV` | bool | false | `mola_metric_maps/src/KeyframePointCloudMap.cpp` | Print profiling stats for per-KF covariance computation |
 | `MOLA_KEYFRAME_MAP_DEBUG_ACTIVE_KFS` | bool | false | `mola_metric_maps/src/KeyframePointCloudMap.cpp` | Trace which keyframes are in the active ICP set |
 | `MOLA_KEYFRAME_MAP_DEBUG_DUMP_KFS_ON_LOAD` | bool | false | `mola_metric_maps/src/KeyframePointCloudMap.cpp` | Dump per-keyframe debug info right after loading a `.mm` map |

--- a/agents.md
+++ b/agents.md
@@ -178,8 +178,14 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   inherited `size()` counts live + not-yet-reclaimed slots (use
   `livePointCount()`, or `compact()` to drop them); `nn_*` indices are storage
   slots; 2D `nn_*` queries throw.
-  Gated by the CMake-set `MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD`
-  (requires nanoflann >= 1.10.0; the class is simply not built otherwise).
+  Requires nanoflann >= 1.10.0. On distributions shipping an older one the build
+  still succeeds, with a CMake warning: the class is compiled and registered as
+  usual, but `src/IncrementalKDTree_stub.cpp` replaces the k-d tree factory with
+  one that throws an explanatory `std::runtime_error` naming the version found,
+  so a YAML asking for the class fails with that instead of MRPT's generic "no
+  such registered CMetricMap class". `MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD`
+  is defined (PUBLIC) only when the feature is functional; the header is always
+  usable either way.
   **nanoflann is included by `src/IncrementalKDTree.cpp` alone, by absolute path
   (`MOLA_NANOFLANN_HEADER`, set by CMake) and with its namespace renamed**,
   because MRPT bundles its own, usually older, copy of the same header and

--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -32,15 +32,25 @@ if(TBB_FOUND)
 endif()
 
 # mola::IncrementalPointCloud needs nanoflann's incremental (self-balancing)
-# k-d tree index, added in nanoflann 1.10.0. Older versions are still fine for
-# everything else in this library, the class is just not built.
-find_package(nanoflann 1.10 QUIET)
-if(nanoflann_FOUND)
+# k-d tree index, added in nanoflann 1.10.0. On ROS distributions shipping an
+# older nanoflann the build still succeeds: the class is compiled and registered
+# as usual, but its k-d tree factory is replaced by a stub that throws an
+# explanatory error if anything actually tries to instantiate the map.
+find_package(nanoflann QUIET)
+if(nanoflann_FOUND AND nanoflann_VERSION VERSION_GREATER_EQUAL 1.10)
   set(MOLA_HAS_INCREMENTAL_POINT_CLOUD ON)
   message(STATUS "mola_metric_maps: nanoflann ${nanoflann_VERSION} found, building mola::IncrementalPointCloud")
 else()
   set(MOLA_HAS_INCREMENTAL_POINT_CLOUD OFF)
-  message(STATUS "mola_metric_maps: nanoflann >=1.10 not found, skipping mola::IncrementalPointCloud")
+  if(nanoflann_FOUND)
+    set(MOLA_NANOFLANN_FOUND_VERSION "${nanoflann_VERSION}")
+  else()
+    set(MOLA_NANOFLANN_FOUND_VERSION "not found")
+  endif()
+  message(WARNING
+    "mola_metric_maps: nanoflann >=1.10 is required by mola::IncrementalPointCloud, "
+    "but the available version is '${MOLA_NANOFLANN_FOUND_VERSION}'. The class will be "
+    "built as a stub that throws at runtime; everything else is unaffected.")
 endif()
 
 
@@ -72,14 +82,15 @@ set(LIB_PUBLIC_HDRS
   include/mola_metric_maps/SparseVoxelPointCloud.h
 )
 
+# The map class is always built; only the k-d tree backend is conditional (see
+# the nanoflann version check above).
+list(APPEND LIB_SRCS src/IncrementalPointCloud.cpp)
+list(APPEND LIB_PUBLIC_HDRS include/mola_metric_maps/IncrementalPointCloud.h)
+
 if(MOLA_HAS_INCREMENTAL_POINT_CLOUD)
-  list(APPEND LIB_SRCS
-    src/IncrementalKDTree.cpp
-    src/IncrementalPointCloud.cpp
-  )
-  list(APPEND LIB_PUBLIC_HDRS
-    include/mola_metric_maps/IncrementalPointCloud.h
-  )
+  list(APPEND LIB_SRCS src/IncrementalKDTree.cpp)
+else()
+  list(APPEND LIB_SRCS src/IncrementalKDTree_stub.cpp)
 endif()
 
 mola_add_library(
@@ -128,6 +139,10 @@ if(MOLA_HAS_INCREMENTAL_POINT_CLOUD)
 
   set_source_files_properties(src/IncrementalKDTree.cpp
     PROPERTIES COMPILE_DEFINITIONS "MOLA_NANOFLANN_HEADER=\"${MOLA_NANOFLANN_HEADER}\"")
+else()
+  # So the stub can name the version actually found in its error message:
+  set_source_files_properties(src/IncrementalKDTree_stub.cpp
+    PROPERTIES COMPILE_DEFINITIONS "MOLA_NANOFLANN_FOUND_VERSION=\"${MOLA_NANOFLANN_FOUND_VERSION}\"")
 endif()
 
 # -----------------------

--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -31,6 +31,18 @@ if(TBB_FOUND)
   option(MOLA_METRIC_MAPS_USE_TBB "If found TBB, this option controls whether to use it or not" ON)
 endif()
 
+# mola::IncrementalPointCloud needs nanoflann's incremental (self-balancing)
+# k-d tree index, added in nanoflann 1.10.0. Older versions are still fine for
+# everything else in this library, the class is just not built.
+find_package(nanoflann 1.10 QUIET)
+if(nanoflann_FOUND)
+  set(MOLA_HAS_INCREMENTAL_POINT_CLOUD ON)
+  message(STATUS "mola_metric_maps: nanoflann ${nanoflann_VERSION} found, building mola::IncrementalPointCloud")
+else()
+  set(MOLA_HAS_INCREMENTAL_POINT_CLOUD OFF)
+  message(STATUS "mola_metric_maps: nanoflann >=1.10 not found, skipping mola::IncrementalPointCloud")
+endif()
+
 
 # 3rdparty deps:
 add_subdirectory(3rdparty)
@@ -60,6 +72,16 @@ set(LIB_PUBLIC_HDRS
   include/mola_metric_maps/SparseVoxelPointCloud.h
 )
 
+if(MOLA_HAS_INCREMENTAL_POINT_CLOUD)
+  list(APPEND LIB_SRCS
+    src/IncrementalKDTree.cpp
+    src/IncrementalPointCloud.cpp
+  )
+  list(APPEND LIB_PUBLIC_HDRS
+    include/mola_metric_maps/IncrementalPointCloud.h
+  )
+endif()
+
 mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
@@ -78,6 +100,34 @@ mola_add_library(
 if (TBB_FOUND AND MOLA_METRIC_MAPS_USE_TBB)
   target_compile_definitions(${PROJECT_NAME} PRIVATE MOLA_METRIC_MAPS_USE_TBB)
   target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb)
+endif()
+
+if(MOLA_HAS_INCREMENTAL_POINT_CLOUD)
+  target_compile_definitions(${PROJECT_NAME}
+    PUBLIC MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD)
+
+  # nanoflann is deliberately NOT linked as a target, and its header is NOT
+  # reached through the include path at all: src/IncrementalKDTree.cpp includes
+  # it by ABSOLUTE path via the macro below.
+  #
+  # The reason is that MRPT ships (and its binaries are built against) its own,
+  # usually older, bundled copy of the very same "nanoflann.hpp", exported as an
+  # -isystem directory. Adding the right directory as "-I" does not help: when a
+  # directory appears both as -I and as -isystem, GCC drops the -I entry and
+  # keeps the system one, so MRPT's copy would still win. An absolute path
+  # removes the ambiguity entirely, and keeps the header out of every other
+  # translation unit of this library.
+  get_target_property(MOLA_NANOFLANN_INCLUDE_DIRS nanoflann::nanoflann INTERFACE_INCLUDE_DIRECTORIES)
+  find_file(MOLA_NANOFLANN_HEADER nanoflann.hpp
+    PATHS ${MOLA_NANOFLANN_INCLUDE_DIRS}
+    NO_DEFAULT_PATH
+  )
+  if(NOT MOLA_NANOFLANN_HEADER)
+    message(FATAL_ERROR "nanoflann >=1.10 was found, but its nanoflann.hpp could not be located in '${MOLA_NANOFLANN_INCLUDE_DIRS}'")
+  endif()
+
+  set_source_files_properties(src/IncrementalKDTree.cpp
+    PROPERTIES COMPILE_DEFINITIONS "MOLA_NANOFLANN_HEADER=\"${MOLA_NANOFLANN_HEADER}\"")
 endif()
 
 # -----------------------

--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -30,8 +30,8 @@
  */
 
 #include <mola_metric_maps/OptionsCapable.h>
-#include <mrpt/config/CLoadableOptions.h>
 #include <mp2p_icp/NearestPointWithCovCapable.h>
+#include <mrpt/config/CLoadableOptions.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/CMatrixFixed.h>
@@ -201,8 +201,8 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
    */
   void nn_search_cov2cov(
       const NearestPointWithCovCapable& localMap, const mrpt::poses::CPose3D& localMapPose,
-      const float max_search_distance, mp2p_icp::MatchedPointWithCovList& outPairings)
-      const override;
+      const float                        max_search_distance,
+      mp2p_icp::MatchedPointWithCovList& outPairings) const override;
 
   [[nodiscard]] std::size_t point_count() const override;
 
@@ -292,8 +292,8 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
 
   // mola::OptionsCapable interface:
   [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
-  bool                                                                trySetCreationOptions(
-                                                                     const mrpt::config::CConfigFileBase& cfg, const std::string& section) override;
+  bool                                                                 trySetCreationOptions(
+                                                                      const mrpt::config::CConfigFileBase& cfg, const std::string& section) override;
 
  public:
   // Interface for use within a mrpt::maps::CMultiMetricMap:

--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -221,9 +221,11 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
    *  `likelihoodOptions` and `renderOptions` groups inherited from
    *  `mrpt::maps::CPointsMap` apply as usual.
    *
-   *  Changing any of the k-d tree parameters (`async_rebuild`, `alpha_*`)
-   *  requires an empty map; `trySetCreationOptions()` returns false instead of
-   *  silently discarding points.
+   *  Changing any of the k-d tree parameters (`async_rebuild`, `alpha_*`,
+   *  `reserve_points`) on an already-populated map is fine:
+   *  `trySetCreationOptions()` compacts and rebuilds the index with the new
+   *  values, so no point is lost, but the point indices previously returned by
+   *  the `nn_*` methods are invalidated. \sa compact()
    */
   struct TCreationOptions : public mrpt::config::CLoadableOptions
   {

--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -1,0 +1,375 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   IncrementalPointCloud.h
+ * @brief  Sliding-window point cloud with an incremental (self-balancing) k-d tree
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+#pragma once
+
+/** \def MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD
+ *  Defined by the build system when nanoflann >= 1.10.0 (the version that
+ *  introduced the incremental k-d tree index) was available, which is what
+ *  mola::IncrementalPointCloud is built upon. Everything below is compiled out
+ *  otherwise.
+ */
+#if defined(MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD)
+
+#include <mola_metric_maps/OptionsCapable.h>
+#include <mrpt/config/CLoadableOptions.h>
+#include <mp2p_icp/NearestPointWithCovCapable.h>
+#include <mrpt/maps/CGenericPointsMap.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/math/CMatrixFixed.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace mola
+{
+namespace internal
+{
+class IncrementalKDTree;
+}
+
+/** A single-global-frame, sliding-window point map for LiDAR (inertial)
+ *  odometry, backed by **one incremental, self-balancing nanoflann k-d tree**
+ *  instead of a static tree rebuilt on every scan.
+ *
+ * ## Why
+ * `mrpt::maps::CPointsMap` is a `mrpt::math::KDTreeCapable`: every insertion
+ * marks the index dirty and the **entire** tree is rebuilt on the next query,
+ * i.e. O(N log N) per scan. Here insertion is amortized O(log N) per point plus
+ * bounded (optionally backgrounded) partial rebuilds.
+ *
+ * ## Role
+ * This is the *odometry local map*, playing the same role as
+ * `mola::HashedVoxelPointCloud` / `mola::SparseTreesPointCloud`, but exact
+ * (per-point) rather than voxelized:
+ * - points are added by the usual `insertObservation()` / `insertAnotherMap()`
+ *   / `insertPoint()` entry points inherited from `CGenericPointsMap`, so all
+ *   per-point channels (`t`, `intensity`, `view_x/y/z`, ...) are supported;
+ * - points far from the robot are evicted on insertion, see
+ *   `TCreationOptions::remove_points_farther_than`;
+ * - nearest-neighbor queries go through `mrpt::maps::NearestNeighborsCapable`;
+ * - GICP-style matching goes through `mp2p_icp::NearestPointWithCovCapable`
+ *   (per-point, plane-regularized covariances).
+ *
+ * ## Not for loop closure
+ * A single global tree cannot cheaply absorb a global SE(3) re-map: every
+ * coordinate moves, forcing a full rebuild and a full covariance recompute. For
+ * loop-closing maps use `mola::KeyframePointCloudMap`, which keeps points in
+ * per-keyframe local frames.
+ *
+ * ## Point indices are storage slots
+ * Removal from the tree is lazy (tombstones reclaimed by later rebuilds), and
+ * reclaimed slots are recycled by subsequent insertions to keep memory bounded.
+ * As a consequence, the inherited `size()` reports the **storage** size (live,
+ * plus reclaimed-but-not-yet-reused, plus not-yet-reclaimed slots); use
+ * `livePointCount()` for the number of points actually in the map, or
+ * `compact()` to make the two equal. The indices reported by the `nn_*` methods
+ * are storage slots, valid for `getPointFast()` and stable until the slot is
+ * recycled. Views of the live set only (visualization, serialization,
+ * `getAsSimplePointsMap()`) are compacted on the fly.
+ *
+ * Reclaimed slots are blanked to NaN rather than left holding the evicted
+ * point's coordinates, so that generic code walking the inherited `CPointsMap`
+ * buffers (notably `insertAnotherMap()`, used to copy map layers out for
+ * publishing/visualization) does not resurrect long-evicted geometry. Slots of
+ * points that are tombstoned but not reclaimed yet do still hold their
+ * coordinates; that fraction is bounded by
+ * `TCreationOptions::alpha_deleted`.
+ *
+ * @note Thread-safety: all index access is serialized internally, so a mapping
+ *       thread and an ICP thread may use the map concurrently.
+ */
+class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
+                              public mp2p_icp::NearestPointWithCovCapable,
+                              public mola::OptionsCapable
+{
+  DEFINE_SERIALIZABLE(IncrementalPointCloud, mola)
+
+ public:
+  IncrementalPointCloud();
+  ~IncrementalPointCloud() override;
+
+  IncrementalPointCloud(const IncrementalPointCloud& o);
+  IncrementalPointCloud& operator=(const IncrementalPointCloud& o);
+
+  /** @name Data access API
+   *  @{ */
+
+  /** Number of points actually in the map, i.e. excluding the tombstoned
+   *  storage slots still counted by the inherited `size()`.
+   */
+  [[nodiscard]] std::size_t livePointCount() const;
+
+  /** Number of storage slots ready to be reused by the next insertion. */
+  [[nodiscard]] std::size_t recyclableSlotCount() const;
+
+  /** Physically drops the tombstoned storage slots (so `size()` becomes
+   *  `livePointCount()`) and rebuilds the k-d tree with the current
+   *  `creationOptions`. Point indices previously returned by the `nn_*`
+   *  methods are invalidated.
+   *
+   *  Call it after changing any structural option (`async_rebuild`, `alpha_*`,
+   *  `reserve_points`) on an already-populated map; `trySetCreationOptions()`
+   *  does it for you.
+   */
+  void compact();
+
+  /** Removes every point outside the axis-aligned cube of half side
+   *  `half_side` centered at `center`. This is what insertions do
+   *  automatically when `TCreationOptions::remove_points_farther_than` is set.
+   */
+  void keepOnlyPointsNear(const mrpt::math::TPoint3Df& center, double half_side);
+
+  /** A copy holding only the live points, in ascending slot order, with all
+   *  per-point fields preserved.
+   */
+  [[nodiscard]] mrpt::maps::CGenericPointsMap::Ptr liveCompactedCopy() const;
+
+  /** O(1): the AABB maintained by the k-d tree. It is a conservative superset
+   *  of the live points, since not-yet-reclaimed points still contribute.
+   */
+  mrpt::math::TBoundingBoxf boundingBox() const override;
+
+  /** @} */
+
+  /** @name CPointsMap storage interface
+   *  Overridden so that growing the coordinate buffers can never happen while a
+   *  background k-d tree rebuild is reading them (see `async_rebuild`).
+   *  @{ */
+  void reserve(std::size_t newLength) override;
+  void resize(std::size_t newLength) override;
+  void setSize(std::size_t newLength) override;
+  /** @} */
+
+  /** @name API of the NearestNeighborsCapable virtual interface
+   *  @{ */
+  [[nodiscard]] bool   nn_has_indices_or_ids() const override;
+  [[nodiscard]] size_t nn_index_count() const override;
+
+  void nn_prepare_for_3d_queries() const override;
+
+  [[nodiscard]] bool nn_single_search(
+      const mrpt::math::TPoint3Df& query, mrpt::math::TPoint3Df& result, float& out_dist_sqr,
+      uint64_t& resultIndexOrID) const override;
+  [[nodiscard]] bool nn_single_search(
+      const mrpt::math::TPoint2Df& query, mrpt::math::TPoint2Df& result, float& out_dist_sqr,
+      uint64_t& resultIndexOrID) const override;
+  void nn_multiple_search(
+      const mrpt::math::TPoint3Df& query, const size_t N,
+      std::vector<mrpt::math::TPoint3Df>& results, std::vector<float>& out_dists_sqr,
+      std::vector<uint64_t>& resultIndicesOrIDs) const override;
+  void nn_multiple_search(
+      const mrpt::math::TPoint2Df& query, const size_t N,
+      std::vector<mrpt::math::TPoint2Df>& results, std::vector<float>& out_dists_sqr,
+      std::vector<uint64_t>& resultIndicesOrIDs) const override;
+  void nn_radius_search(
+      const mrpt::math::TPoint3Df& query, const float search_radius_sqr,
+      std::vector<mrpt::math::TPoint3Df>& results, std::vector<float>& out_dists_sqr,
+      std::vector<uint64_t>& resultIndicesOrIDs, size_t maxPoints) const override;
+  void nn_radius_search(
+      const mrpt::math::TPoint2Df& query, const float search_radius_sqr,
+      std::vector<mrpt::math::TPoint2Df>& results, std::vector<float>& out_dists_sqr,
+      std::vector<uint64_t>& resultIndicesOrIDs, size_t maxPoints) const override;
+  /** @} */
+
+  /** @name API of the mp2p_icp::NearestPointWithCovCapable virtual interface
+   *  @{ */
+
+  /** Pairs each point of `localMap` (which must also be an
+   *  `IncrementalPointCloud`) with its nearest point in this map, weighting the
+   *  pair by the GICP matrix `(COV_global + R*COV_local*R^T)^-1`.
+   */
+  void nn_search_cov2cov(
+      const NearestPointWithCovCapable& localMap, const mrpt::poses::CPose3D& localMapPose,
+      const float max_search_distance, mp2p_icp::MatchedPointWithCovList& outPairings)
+      const override;
+
+  [[nodiscard]] std::size_t point_count() const override;
+
+  /** @} */
+
+  /** @name Public virtual methods implementation for CMetricMap
+   *  @{ */
+  std::string asString() const override;
+  bool        isEmpty() const override;
+  void        getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void        saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const override;
+  const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const override;
+  /** @} */
+
+  /** All parameters specific to this class. The standard `insertionOptions`,
+   *  `likelihoodOptions` and `renderOptions` groups inherited from
+   *  `mrpt::maps::CPointsMap` apply as usual.
+   *
+   *  Changing any of the k-d tree parameters (`async_rebuild`, `alpha_*`)
+   *  requires an empty map; `trySetCreationOptions()` returns false instead of
+   *  silently discarding points.
+   */
+  struct TCreationOptions : public mrpt::config::CLoadableOptions
+  {
+    TCreationOptions() = default;
+
+    void loadFromConfigFile(
+        const mrpt::config::CConfigFileBase& source,
+        const std::string&                   section) override;  // See base docs
+    void dumpToTextStream(std::ostream& out) const override;  // See base docs
+
+    void writeToStream(mrpt::serialization::CArchive& out) const;
+    void readFromStream(mrpt::serialization::CArchive& in);
+
+    /** If !=0, on each insertion with a known robot pose, keep only the points
+     *  inside the axis-aligned cube of this half side [m] around it. This is
+     *  the sliding-window trim of FAST-LIO-style local maps, the analogous of
+     *  `HashedVoxelPointCloud::remove_voxels_farther_than`.
+     */
+    double remove_points_farther_than = .0;
+
+    /** Perform the k-d tree balancing rebuilds on a background thread. Bounds
+     *  the mapping-thread tail latency (on a LiDAR-odometry local map this
+     *  turns ~300 ms insertion spikes into a flat ~10 ms), at the cost of
+     *  roughly twice the index memory.
+     *
+     *  @note The worker reads the inherited coordinate buffers, so they must
+     *  not be reallocated while it runs. `reserve()`, `resize()` and
+     *  `setSize()` wait for it, which covers `insertObservation()` and
+     *  `insertAnotherMap()`; a hand-written `insertPointFast()` loop bypasses
+     *  them, so either reserve the storage up front (`reserve_points`) or grow
+     *  it through `reserve()`.
+     */
+    bool async_rebuild = false;
+
+    /** Weight-balance rebuild threshold: a subtree is rebuilt when its larger
+     *  child holds more than this fraction of its points. Lower keeps queries
+     *  faster and rebuilds more frequent.
+     */
+    float alpha_balance = 0.75f;
+
+    /** Tombstone rebuild threshold: a subtree is rebuilt, physically dropping
+     *  removed points, once this fraction of it is dead.
+     */
+    float alpha_deleted = 0.5f;
+
+    /** If !=0, pre-allocate storage for this many points. Recommended together
+     *  with `async_rebuild`, since it avoids reallocating the coordinate
+     *  buffers the background worker reads.
+     */
+    uint64_t reserve_points = 0;
+
+    /** Number of neighbors used to estimate each point covariance for
+     *  `nn_search_cov2cov()`. \sa mola::KeyframePointCloudMap
+     */
+    uint32_t k_correspondences_for_cov = 20;
+
+    /** Below this number of neighbors actually found, a plane fit is deemed
+     *  unreliable and an isotropic covariance is used instead.
+     */
+    uint32_t min_correspondences_for_cov = 5;
+
+    /** Maximum distance [m] to search neighbors for the covariance estimate. */
+    double max_distance_for_cov = 1.0;
+  };
+  TCreationOptions creationOptions;
+
+  // mola::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
+  bool                                                                trySetCreationOptions(
+                                                                     const mrpt::config::CConfigFileBase& cfg, const std::string& section) override;
+
+ public:
+  // Interface for use within a mrpt::maps::CMultiMetricMap:
+  MAP_DEFINITION_START(IncrementalPointCloud)
+  mola::IncrementalPointCloud::TCreationOptions creationOpts;
+  mrpt::maps::CPointsMap::TInsertionOptions     insertionOpts;
+  mrpt::maps::CPointsMap::TLikelihoodOptions    likelihoodOpts;
+  mrpt::maps::CPointsMap::TRenderOptions        renderOpts;
+  MAP_DEFINITION_END(IncrementalPointCloud)
+
+ protected:
+  // See docs in base CMetricMap class:
+  void internal_clear() override;
+
+  bool internal_insertObservation(
+      const mrpt::obs::CObservation&                   obs,
+      const std::optional<const mrpt::poses::CPose3D>& robotPose = std::nullopt) override;
+
+ private:
+  /// Serializes all access to index_ and to the caches below.
+  mutable std::recursive_mutex mtx_;
+
+  mutable std::unique_ptr<internal::IncrementalKDTree> index_;
+
+  /// Storage slots reclaimed by the index, ready to be reused.
+  mutable std::vector<uint32_t> free_slots_;
+
+  /// Number of leading storage slots already handed to the index.
+  mutable std::size_t indexed_up_to_ = 0;
+
+  /// Size of the last appended batch, used to keep spare capacity when the
+  /// rebuilds run on a background thread (see internal_insertObservation()).
+  std::size_t last_insert_batch_ = 0;
+
+  /// Per-point, plane-regularized covariance cache, in this map's frame.
+  mutable std::vector<mrpt::math::CMatrixFloat33> cov_;
+  mutable std::vector<uint8_t>                    cov_valid_;
+
+  /// Used for getAsSimplePointsMap() only.
+  mutable mrpt::maps::CSimplePointsMap::Ptr cachedPoints_;
+
+  /** (Re)creates the index from `creationOptions` and bulk-loads **every**
+   *  storage slot into it. Only valid when no slot is tombstoned, i.e. right
+   *  after the storage was cleared, replaced wholesale, or compacted;
+   *  otherwise use compact(), which drops the dead slots first.
+   */
+  void resetIndex();
+
+  /** Indexes anything appended through the inherited `CPointsMap` API since
+   *  the last call, and rebuilds from scratch if the storage shrank. Must be
+   *  called under `mtx_` before any query or eviction.
+   */
+  void ensureIndexUpToDate() const;
+
+  /// Points the index at the current (possibly reallocated) coordinate buffers.
+  void refreshPointBuffers() const;
+
+  /// Moves storage slot `from` (coordinates and every field) onto slot `to`.
+  void relocatePoint(std::size_t from, std::size_t to);
+
+  /** Moves the just-appended points in [firstAppended, size()) into recycled
+   *  slots where possible, shrinking the storage accordingly, and hands every
+   *  resulting slot to the index.
+   */
+  void indexAppendedPointsRecycling(std::size_t firstAppended);
+
+  /// Collects the slots the index reclaimed, blanks them and marks them reusable.
+  void harvestRemovedSlots();
+
+  /// Computes and caches the covariance of one live point, if not cached yet.
+  void computeCovariance(uint32_t slot) const;
+
+  /** Fills the covariance cache for the given slots, in parallel when TBB is
+   *  available. The caller must pass each slot at most once, so that threads
+   *  never write to the same cache entry.
+   */
+  void ensureCovariancesFor(const std::vector<uint32_t>& slots) const;
+};
+
+}  // namespace mola
+
+#endif  // MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD

--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -20,11 +20,14 @@
 
 /** \def MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD
  *  Defined by the build system when nanoflann >= 1.10.0 (the version that
- *  introduced the incremental k-d tree index) was available, which is what
- *  mola::IncrementalPointCloud is built upon. Everything below is compiled out
- *  otherwise.
+ *  introduced the incremental k-d tree index) was available, i.e. when
+ *  mola::IncrementalPointCloud is actually functional.
+ *
+ *  The class is declared, compiled and registered in the class factory either
+ *  way, so this header is always usable; without a suitable nanoflann,
+ *  *constructing* the map throws an explanatory std::runtime_error instead of
+ *  failing earlier with a confusing "no such registered CMetricMap class".
  */
-#if defined(MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD)
 
 #include <mola_metric_maps/OptionsCapable.h>
 #include <mrpt/config/CLoadableOptions.h>
@@ -371,5 +374,3 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
 };
 
 }  // namespace mola
-
-#endif  // MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD

--- a/mola_metric_maps/package.xml
+++ b/mola_metric_maps/package.xml
@@ -22,6 +22,7 @@
   <depend>mp2p_icp</depend>  <!-- actually, just the mp2p_icp_map library -->
 
   <depend>tbb</depend>
+  <depend>nanoflann</depend>  <!-- optional: >=1.10 enables mola::IncrementalPointCloud -->
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_metric_maps/src/IncrementalKDTree.cpp
+++ b/mola_metric_maps/src/IncrementalKDTree.cpp
@@ -1,0 +1,231 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   IncrementalKDTree.cpp
+ * @brief  Opaque wrapper over nanoflann's incremental (self-balancing) k-d tree
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+
+// ---------------------------------------------------------------------------
+//  This translation unit is the ONLY place in the library where nanoflann is
+//  included, and it deliberately includes no MRPT header.
+//
+//  MRPT bundles its own copy of nanoflann and its shared libraries are compiled
+//  against it. That copy is usually older than the one providing the
+//  incremental index used here, and the two versions differ in non-template
+//  entities (e.g. the pooled allocator) that would end up sharing a mangled
+//  name at link time. Mixing them is an ODR violation with real
+//  memory-corruption potential, so the namespace is renamed for our private
+//  copy, which makes every symbol distinct.
+//
+//  For the same reason the header is included by ABSOLUTE path (MOLA_NANOFLANN_HEADER,
+//  set by CMake): MRPT exports its own copy through an -isystem directory, and a
+//  directory given both as -I and -isystem is deduplicated by GCC in favor of the
+//  system one, so no include-path ordering can reliably select ours.
+//
+//  Consequences to preserve when editing this file:
+//   - do not include any MRPT (or other nanoflann-using) header here;
+//   - do not expose any nanoflann type through IncrementalKDTree.h.
+// ---------------------------------------------------------------------------
+#if !defined(MOLA_NANOFLANN_HEADER)
+#define MOLA_NANOFLANN_HEADER <nanoflann.hpp>
+#endif
+
+#define nanoflann mola_nanoflann
+#include MOLA_NANOFLANN_HEADER
+#undef nanoflann
+
+#if !defined(NANOFLANN_VERSION) || NANOFLANN_VERSION < 0x010A00
+#error "mola::IncrementalPointCloud requires nanoflann >= 1.10.0 (incremental index)"
+#endif
+
+#include "IncrementalKDTree.h"
+
+#include <algorithm>
+#include <type_traits>
+
+namespace
+{
+/** nanoflann dataset adaptor over three externally-owned coordinate arrays. */
+struct PointBuffers
+{
+  const float* coords[3] = {nullptr, nullptr, nullptr};
+  std::size_t  count     = 0;
+
+  [[nodiscard]] inline std::size_t kdtree_get_point_count() const { return count; }
+
+  [[nodiscard]] inline float kdtree_get_pt(const std::size_t idx, const std::size_t dim) const
+  {
+    return coords[dim][idx];
+  }
+
+  template <class BBOX>
+  bool kdtree_get_bbox(BBOX&) const
+  {
+    return false;
+  }
+};
+
+using metric_t = mola_nanoflann::L2_Simple_Adaptor<float, PointBuffers>;
+
+using sync_index_t =
+    mola_nanoflann::KDTreeSingleIndexIncrementalAdaptor<metric_t, PointBuffers, 3, uint32_t>;
+
+using async_index_t =
+    mola_nanoflann::KDTreeSingleIndexIncrementalAdaptorMT<metric_t, PointBuffers, 3, uint32_t>;
+
+template <class INDEX>
+class IncrementalKDTreeImpl : public mola::internal::IncrementalKDTree
+{
+ public:
+  explicit IncrementalKDTreeImpl(const Params& p) : params_(p.alpha_balance, p.alpha_deleted)
+  {
+    createIndex();
+  }
+
+  void setPointBuffers(
+      const float* xs, const float* ys, const float* zs, std::size_t count) override
+  {
+    // Written only when something actually changed: the MT worker reads these
+    // while it rebuilds, and the owner calls this on every query/insertion.
+    // The owner guarantees the pointers cannot change while a rebuild is in
+    // flight (it blocks before any reallocation); `count` is not consulted by
+    // the rebuild path, which walks an explicit index list.
+    if (data_.coords[0] != xs || data_.coords[1] != ys || data_.coords[2] != zs)
+    {
+      data_.coords[0] = xs;
+      data_.coords[1] = ys;
+      data_.coords[2] = zs;
+    }
+    if (data_.count != count) data_.count = count;
+  }
+
+  void reserve(std::size_t n) override { index_->reserve(n); }
+
+  void clear() override
+  {
+    index_.reset();  // joins the background worker, if any
+    createIndex();
+  }
+
+  void addPoint(uint32_t index) override { index_->addPoint(index); }
+
+  void addPoints(uint32_t firstIndex, uint32_t lastIndex) override
+  {
+    index_->addPoints(firstIndex, lastIndex);
+  }
+
+  void removePoint(uint32_t index) override { index_->removePoint(index); }
+
+  void keepOnlyPointsInsideBox(const float minCorner[3], const float maxCorner[3]) override
+  {
+    typename INDEX::BoundingBox keep;
+    mola_nanoflann::resize(keep, 3);
+    for (int d = 0; d < 3; d++)
+    {
+      keep[d].low  = minCorner[d];
+      keep[d].high = maxCorner[d];
+    }
+    index_->removeOutsideBox(keep);
+  }
+
+  std::vector<uint32_t> acquireRemovedPoints() override { return index_->acquireRemovedPoints(); }
+
+  void waitForPendingRebuilds() override
+  {
+    if constexpr (std::is_same_v<INDEX, async_index_t>)
+    {
+      index_->sync();
+    }
+  }
+
+  std::size_t size() const override { return index_->size(); }
+  std::size_t physicalSize() const override { return index_->physicalSize(); }
+
+  void snapshotLiveIndices(std::vector<uint32_t>& out) const override
+  {
+    index_->snapshotLiveIndices(out);
+  }
+
+  bool boundingBox(float minCorner[3], float maxCorner[3]) const override
+  {
+    if (index_->empty()) return false;
+
+    const auto bb = index_->boundingBox();
+    for (int d = 0; d < 3; d++)
+    {
+      minCorner[d] = bb[d].low;
+      maxCorner[d] = bb[d].high;
+    }
+    return true;
+  }
+
+  std::size_t knnSearch(
+      const float query[3], std::size_t k, uint32_t* outIndices, float* outDistsSqr) const override
+  {
+    return index_->knnSearch(query, k, outIndices, outDistsSqr);
+  }
+
+  std::size_t knnSearchWithinRadius(
+      const float query[3], std::size_t k, float maxDistSqr, uint32_t* outIndices,
+      float* outDistsSqr) const override
+  {
+    return index_->rknnSearch(query, k, outIndices, outDistsSqr, maxDistSqr);
+  }
+
+  void radiusSearch(const float query[3], float radiusSqr, std::vector<Neighbor>& out) const override
+  {
+    std::vector<mola_nanoflann::ResultItem<uint32_t, float>> matches;
+    index_->radiusSearch(query, radiusSqr, matches);
+
+    out.reserve(out.size() + matches.size());
+    for (const auto& m : matches)
+    {
+      out.push_back({m.first, m.second});
+    }
+  }
+
+ private:
+  void createIndex()
+  {
+    index_ = std::make_unique<INDEX>(3, data_, params_);
+    // Always on: the owner relies on it to recycle point slots and keep its
+    // storage bounded under churn.
+    index_->setCollectRemovedPoints(true);
+  }
+
+  /// Referenced (by const&) from the index, hence declared before it.
+  PointBuffers data_;
+
+  mola_nanoflann::KDTreeIncrementalIndexParams params_;
+
+  std::unique_ptr<INDEX> index_;
+};
+
+}  // namespace
+
+namespace mola::internal
+{
+IncrementalKDTree::~IncrementalKDTree() = default;
+
+std::unique_ptr<IncrementalKDTree> IncrementalKDTree::Create(const Params& p)
+{
+  if (p.async_rebuild)
+  {
+    return std::make_unique<IncrementalKDTreeImpl<async_index_t>>(p);
+  }
+  return std::make_unique<IncrementalKDTreeImpl<sync_index_t>>(p);
+}
+
+}  // namespace mola::internal

--- a/mola_metric_maps/src/IncrementalKDTree.cpp
+++ b/mola_metric_maps/src/IncrementalKDTree.cpp
@@ -184,7 +184,8 @@ class IncrementalKDTreeImpl : public mola::internal::IncrementalKDTree
     return index_->rknnSearch(query, k, outIndices, outDistsSqr, maxDistSqr);
   }
 
-  void radiusSearch(const float query[3], float radiusSqr, std::vector<Neighbor>& out) const override
+  void radiusSearch(
+      const float query[3], float radiusSqr, std::vector<Neighbor>& out) const override
   {
     std::vector<mola_nanoflann::ResultItem<uint32_t, float>> matches;
     index_->radiusSearch(query, radiusSqr, matches);

--- a/mola_metric_maps/src/IncrementalKDTree.h
+++ b/mola_metric_maps/src/IncrementalKDTree.h
@@ -88,9 +88,9 @@ class IncrementalKDTree
   /// Drops the whole tree (and any pending background rebuild).
   virtual void clear() = 0;
 
-  virtual void addPoint(uint32_t index)                          = 0;
+  virtual void addPoint(uint32_t index)                           = 0;
   virtual void addPoints(uint32_t firstIndex, uint32_t lastIndex) = 0;
-  virtual void removePoint(uint32_t index)                       = 0;
+  virtual void removePoint(uint32_t index)                        = 0;
 
   /** Removes every point outside the given axis-aligned box: the sliding
    *  window map-trimming primitive.

--- a/mola_metric_maps/src/IncrementalKDTree.h
+++ b/mola_metric_maps/src/IncrementalKDTree.h
@@ -1,0 +1,153 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   IncrementalKDTree.h
+ * @brief  Opaque wrapper over nanoflann's incremental (self-balancing) k-d tree
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace mola::internal
+{
+/** Abstract facade over the nanoflann incremental k-d tree index
+ *  (`KDTreeSingleIndexIncrementalAdaptor` and its multi-threaded variant),
+ *  used by mola::IncrementalPointCloud.
+ *
+ *  This header intentionally exposes no nanoflann type: the whole library is
+ *  included by a single implementation file that pulls in no MRPT header.
+ *  MRPT bundles (and its binaries are compiled against) its own copy of
+ *  nanoflann, which is typically older than the one providing the incremental
+ *  index. Both copies declare the same non-template entities, so letting them
+ *  be visible to the same translation unit -- or exporting either of them
+ *  through a public header -- would be an ODR violation with real
+ *  memory-corruption potential. See IncrementalKDTree.cpp.
+ *
+ *  Point coordinates are *not* owned here: the index only stores point indices
+ *  ("slots") into externally-owned x/y/z buffers, see setPointBuffers().
+ */
+class IncrementalKDTree
+{
+ public:
+  struct Params
+  {
+    /// Run the balancing rebuilds on a background thread.
+    bool async_rebuild = false;
+
+    /// Weight-balance and tombstone-fraction rebuild thresholds.
+    float alpha_balance = 0.75f;
+    float alpha_deleted = 0.5f;
+  };
+
+  struct Neighbor
+  {
+    uint32_t index    = 0;
+    float    dist_sqr = 0;
+  };
+
+  [[nodiscard]] static std::unique_ptr<IncrementalKDTree> Create(const Params& p);
+
+  virtual ~IncrementalKDTree();
+
+  IncrementalKDTree(const IncrementalKDTree&)            = delete;
+  IncrementalKDTree& operator=(const IncrementalKDTree&) = delete;
+
+  /** @name Dataset binding
+   *  @{ */
+
+  /** Rebinds the coordinate buffers the index reads point coordinates from.
+   *  Must be called again after anything that may have reallocated them
+   *  (i.e. after growing the owner point cloud).
+   */
+  virtual void setPointBuffers(
+      const float* xs, const float* ys, const float* zs, std::size_t count) = 0;
+
+  /** @} */
+
+  /** @name Modifiers
+   *  @{ */
+
+  /// Pre-sizes internal structures for an expected point count.
+  virtual void reserve(std::size_t n) = 0;
+
+  /// Drops the whole tree (and any pending background rebuild).
+  virtual void clear() = 0;
+
+  virtual void addPoint(uint32_t index)                          = 0;
+  virtual void addPoints(uint32_t firstIndex, uint32_t lastIndex) = 0;
+  virtual void removePoint(uint32_t index)                       = 0;
+
+  /** Removes every point outside the given axis-aligned box: the sliding
+   *  window map-trimming primitive.
+   */
+  virtual void keepOnlyPointsInsideBox(const float minCorner[3], const float maxCorner[3]) = 0;
+
+  /** Point slots that became physically free since the last call, so the
+   *  owner can recycle them. Removal is lazy (tombstones), so slots only show
+   *  up here once an actual rebuild reclaimed them.
+   */
+  [[nodiscard]] virtual std::vector<uint32_t> acquireRemovedPoints() = 0;
+
+  /// Blocks until any in-flight background rebuild has been integrated.
+  virtual void waitForPendingRebuilds() = 0;
+
+  /** @} */
+
+  /** @name Observers
+   *  @{ */
+
+  /// Number of live (non-removed) points.
+  [[nodiscard]] virtual std::size_t size() const = 0;
+
+  /// Number of nodes physically stored (live + not-yet-reclaimed tombstones).
+  [[nodiscard]] virtual std::size_t physicalSize() const = 0;
+
+  /// Appends the live point slots into `out`.
+  virtual void snapshotLiveIndices(std::vector<uint32_t>& out) const = 0;
+
+  /** O(1) AABB of the points in the index (a conservative superset of the live
+   *  set, since not-yet-reclaimed tombstones still contribute).
+   *  \return false if the index is empty, in which case the outputs are unset.
+   */
+  [[nodiscard]] virtual bool boundingBox(float minCorner[3], float maxCorner[3]) const = 0;
+
+  /** @} */
+
+  /** @name Queries
+   *  @{ */
+
+  /// \return the number of neighbors actually found (<= k).
+  [[nodiscard]] virtual std::size_t knnSearch(
+      const float query[3], std::size_t k, uint32_t* outIndices, float* outDistsSqr) const = 0;
+
+  /// As knnSearch(), but discarding neighbors farther than `maxDistSqr`.
+  [[nodiscard]] virtual std::size_t knnSearchWithinRadius(
+      const float query[3], std::size_t k, float maxDistSqr, uint32_t* outIndices,
+      float* outDistsSqr) const = 0;
+
+  /// Appends every neighbor closer than `radiusSqr` (squared distance).
+  virtual void radiusSearch(
+      const float query[3], float radiusSqr, std::vector<Neighbor>& out) const = 0;
+
+  /** @} */
+
+ protected:
+  IncrementalKDTree() = default;
+};
+
+}  // namespace mola::internal

--- a/mola_metric_maps/src/IncrementalKDTree_stub.cpp
+++ b/mola_metric_maps/src/IncrementalKDTree_stub.cpp
@@ -1,0 +1,51 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   IncrementalKDTree_stub.cpp
+ * @brief  Fallback for builds whose nanoflann lacks the incremental k-d tree
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+
+// Built instead of IncrementalKDTree.cpp when the available nanoflann predates
+// the incremental (self-balancing) index, added in 1.10.0. mola::IncrementalPointCloud
+// is still declared, compiled and registered in the class factory, so that YAML
+// configurations naming it fail with an explanatory message instead of MRPT's
+// generic "no such registered CMetricMap class", which reads like a typo or a
+// missing plugin.
+
+#include <stdexcept>
+#include <string>
+
+#include "IncrementalKDTree.h"
+
+#if !defined(MOLA_NANOFLANN_FOUND_VERSION)
+#define MOLA_NANOFLANN_FOUND_VERSION "not found"
+#endif
+
+namespace mola::internal
+{
+IncrementalKDTree::~IncrementalKDTree() = default;
+
+std::unique_ptr<IncrementalKDTree> IncrementalKDTree::Create(
+    [[maybe_unused]] const Params& p)
+{
+  throw std::runtime_error(
+      "mola::IncrementalPointCloud is not available in this build: it requires "
+      "nanoflann >= 1.10.0 (the release that introduced the incremental k-d tree "
+      "index), but this workspace was built against nanoflann '" MOLA_NANOFLANN_FOUND_VERSION
+      "'. Install a newer nanoflann and rebuild mola_metric_maps, or use "
+      "mola::KeyframePointCloudMap instead.");
+}
+
+}  // namespace mola::internal

--- a/mola_metric_maps/src/IncrementalKDTree_stub.cpp
+++ b/mola_metric_maps/src/IncrementalKDTree_stub.cpp
@@ -37,8 +37,7 @@ namespace mola::internal
 {
 IncrementalKDTree::~IncrementalKDTree() = default;
 
-std::unique_ptr<IncrementalKDTree> IncrementalKDTree::Create(
-    [[maybe_unused]] const Params& p)
+std::unique_ptr<IncrementalKDTree> IncrementalKDTree::Create([[maybe_unused]] const Params& p)
 {
   throw std::runtime_error(
       "mola::IncrementalPointCloud is not available in this build: it requires "

--- a/mola_metric_maps/src/IncrementalPointCloud.cpp
+++ b/mola_metric_maps/src/IncrementalPointCloud.cpp
@@ -447,9 +447,8 @@ bool IncrementalPointCloud::internal_insertObservation(
         "[IncrementalPointCloud] insert_ms=%.1f live=%zu storage=%zu free_slots=%zu "
         "bbox=[%.1f %.1f %.1f]-[%.1f %.1f %.1f]\n",
         ms, index_->size(), m_x.size(), free_slots_.size(), static_cast<double>(bb.min.x),
-        static_cast<double>(bb.min.y), static_cast<double>(bb.min.z),
-        static_cast<double>(bb.max.x), static_cast<double>(bb.max.y),
-        static_cast<double>(bb.max.z));
+        static_cast<double>(bb.min.y), static_cast<double>(bb.min.z), static_cast<double>(bb.max.x),
+        static_cast<double>(bb.max.y), static_cast<double>(bb.max.z));
   }
 
   return ok;
@@ -505,7 +504,7 @@ void IncrementalPointCloud::compact()
     // Copies points and all per-point fields back onto ourselves, dropping the
     // tombstoned slots on the way (it clears us first, which already resets
     // the index):
-    const auto live = liveCompactedCopy();
+    const auto  live = liveCompactedCopy();
     CPointsMap::operator=(*live);
   }
 

--- a/mola_metric_maps/src/IncrementalPointCloud.cpp
+++ b/mola_metric_maps/src/IncrementalPointCloud.cpp
@@ -1,0 +1,1090 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   IncrementalPointCloud.cpp
+ * @brief  Sliding-window point cloud with an incremental (self-balancing) k-d tree
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+
+#include <mola_metric_maps/IncrementalPointCloud.h>
+#include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
+#include <mrpt/core/bits_math.h>  // mrpt::square()
+#include <mrpt/core/exceptions.h>
+#include <mrpt/core/format.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/core/lock_helper.h>
+#include <mrpt/obs/CObservation.h>
+#include <mrpt/opengl/CSetOfObjects.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+
+#include "IncrementalKDTree.h"
+
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+#include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
+#endif
+
+using namespace mola;
+
+namespace
+{
+/// Trace live/storage/free-slot counts and the map bbox on every insertion.
+const bool ENV_DEBUG_STATS = mrpt::get_env<bool>("MOLA_INCREMENTAL_MAP_DEBUG_STATS", false);
+}  // namespace
+
+//  =========== Begin of Map definition ============
+MAP_DEFINITION_REGISTER(
+    "mola::IncrementalPointCloud,IncrementalPointCloud", mola::IncrementalPointCloud)
+
+IncrementalPointCloud::TMapDefinition::TMapDefinition() = default;
+
+void IncrementalPointCloud::TMapDefinition::loadFromConfigFile_map_specific(
+    const mrpt::config::CConfigFileBase& s, const std::string& sectionPrefix)
+{
+  using namespace std::string_literals;
+
+  if (s.sectionExists(sectionPrefix + "_creationOpts"s))
+  {
+    creationOpts.loadFromConfigFile(s, sectionPrefix + "_creationOpts"s);
+  }
+
+  if (s.sectionExists(sectionPrefix + "_insertOpts"s))
+  {
+    insertionOpts.loadFromConfigFile(s, sectionPrefix + "_insertOpts"s);
+  }
+
+  if (s.sectionExists(sectionPrefix + "_likelihoodOpts"s))
+  {
+    likelihoodOpts.loadFromConfigFile(s, sectionPrefix + "_likelihoodOpts"s);
+  }
+
+  if (s.sectionExists(sectionPrefix + "_renderOpts"s))
+  {
+    renderOpts.loadFromConfigFile(s, sectionPrefix + "_renderOpts"s);
+  }
+}
+
+void IncrementalPointCloud::TMapDefinition::dumpToTextStream_map_specific(std::ostream& out) const
+{
+  creationOpts.dumpToTextStream(out);
+  insertionOpts.dumpToTextStream(out);
+  likelihoodOpts.dumpToTextStream(out);
+  renderOpts.dumpToTextStream(out);
+}
+
+mrpt::maps::CMetricMap::Ptr IncrementalPointCloud::internal_CreateFromMapDefinition(
+    const mrpt::maps::TMetricMapInitializer& _def)
+{
+  const IncrementalPointCloud::TMapDefinition* def =
+      dynamic_cast<const IncrementalPointCloud::TMapDefinition*>(&_def);
+  ASSERT_(def);
+
+  auto obj = IncrementalPointCloud::Create();
+
+  obj->creationOptions   = def->creationOpts;
+  obj->insertionOptions  = def->insertionOpts;
+  obj->likelihoodOptions = def->likelihoodOpts;
+  obj->renderOptions     = def->renderOpts;
+
+  // Apply the (possibly changed) k-d tree parameters:
+  obj->resetIndex();
+
+  return obj;
+}
+//  =========== End of Map definition Block =========
+
+IMPLEMENTS_SERIALIZABLE(IncrementalPointCloud, CGenericPointsMap, mola)
+
+// =====================================
+// Construction / copy
+// =====================================
+
+IncrementalPointCloud::IncrementalPointCloud() { resetIndex(); }
+
+IncrementalPointCloud::~IncrementalPointCloud() = default;
+
+IncrementalPointCloud::IncrementalPointCloud(const IncrementalPointCloud& o) : CGenericPointsMap()
+{
+  *this = o;
+}
+
+IncrementalPointCloud& IncrementalPointCloud::operator=(const IncrementalPointCloud& o)
+{
+  if (this == &o) return *this;
+
+  std::scoped_lock lck(mtx_, o.mtx_);
+
+  // Copy the live points only: tombstoned storage slots must not be resurrected
+  // by the index rebuild below.
+  const auto compacted = o.liveCompactedCopy();
+
+  // Copies point coordinates and all per-point fields (and clears us first):
+  CPointsMap::operator=(*compacted);
+
+  creationOptions   = o.creationOptions;
+  insertionOptions  = o.insertionOptions;
+  likelihoodOptions = o.likelihoodOptions;
+  renderOptions     = o.renderOptions;
+  genericMapParams  = o.genericMapParams;
+
+  resetIndex();
+
+  return *this;
+}
+
+// =====================================
+// Index maintenance
+// =====================================
+
+void IncrementalPointCloud::resetIndex()
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  internal::IncrementalKDTree::Params p;
+  p.async_rebuild = creationOptions.async_rebuild;
+  p.alpha_balance = creationOptions.alpha_balance;
+  p.alpha_deleted = creationOptions.alpha_deleted;
+
+  index_ = internal::IncrementalKDTree::Create(p);
+
+  free_slots_.clear();
+  indexed_up_to_ = 0;
+
+  const std::size_t n = m_x.size();
+  cov_.assign(n, mrpt::math::CMatrixFloat33());
+  cov_valid_.assign(n, 0);
+
+  if (creationOptions.reserve_points != 0)
+  {
+    const auto n_reserve = static_cast<std::size_t>(creationOptions.reserve_points);
+    index_->reserve(n_reserve);
+    // Also the coordinate buffers: with a background rebuild worker reading
+    // them, avoiding reallocations is what makes insertion cheap (see
+    // internal_insertObservation()).
+    this->reserve(n_reserve);
+  }
+
+  refreshPointBuffers();
+
+  if (n != 0)
+  {
+    index_->addPoints(0, static_cast<uint32_t>(n - 1));
+    indexed_up_to_ = n;
+  }
+}
+
+void IncrementalPointCloud::refreshPointBuffers() const
+{
+  index_->setPointBuffers(m_x.data(), m_y.data(), m_z.data(), m_x.size());
+}
+
+void IncrementalPointCloud::reserve(std::size_t newLength)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  // A background rebuild reads the coordinate buffers, so it must be finished
+  // before they can move. Reserving enough storage up front (`reserve_points`)
+  // is what keeps this from ever triggering in steady state, where slot
+  // recycling stops the storage from growing at all.
+  if (index_ && creationOptions.async_rebuild && newLength > m_x.capacity())
+  {
+    index_->waitForPendingRebuilds();
+  }
+
+  CGenericPointsMap::reserve(newLength);
+
+  if (index_) refreshPointBuffers();
+}
+
+void IncrementalPointCloud::resize(std::size_t newLength)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  if (index_ && creationOptions.async_rebuild && newLength > m_x.capacity())
+  {
+    index_->waitForPendingRebuilds();
+  }
+
+  CGenericPointsMap::resize(newLength);
+
+  if (index_) refreshPointBuffers();
+}
+
+void IncrementalPointCloud::setSize(std::size_t newLength)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  if (index_ && creationOptions.async_rebuild && newLength > m_x.capacity())
+  {
+    index_->waitForPendingRebuilds();
+  }
+
+  CGenericPointsMap::setSize(newLength);
+
+  // Unlike resize(), this erases the previous contents, so every slot index the
+  // tree holds became meaningless:
+  if (index_) resetIndex();
+}
+
+void IncrementalPointCloud::ensureIndexUpToDate() const
+{
+  const std::size_t n = m_x.size();
+
+  if (n < indexed_up_to_)
+  {
+    // The storage was replaced or truncated behind our back: the slot
+    // bookkeeping is no longer valid, so start over.
+    const_cast<IncrementalPointCloud*>(this)->resetIndex();
+    return;
+  }
+
+  if (n == indexed_up_to_)
+  {
+    refreshPointBuffers();
+    return;
+  }
+
+  // Points appended through the inherited CPointsMap API: index the new tail.
+  cov_.resize(n);
+  cov_valid_.resize(n, 0);
+  for (std::size_t i = indexed_up_to_; i < n; i++)
+  {
+    cov_valid_[i] = 0;
+  }
+
+  refreshPointBuffers();
+  index_->addPoints(static_cast<uint32_t>(indexed_up_to_), static_cast<uint32_t>(n - 1));
+  indexed_up_to_ = n;
+}
+
+void IncrementalPointCloud::relocatePoint(std::size_t from, std::size_t to)
+{
+  m_x[to] = m_x[from];
+  m_y[to] = m_y[from];
+  m_z[to] = m_z[from];
+
+  for (auto& [name, v] : m_float_fields) v[to] = v[from];
+  for (auto& [name, v] : m_double_fields) v[to] = v[from];
+  for (auto& [name, v] : m_uint16_fields) v[to] = v[from];
+  for (auto& [name, v] : m_uint8_fields) v[to] = v[from];
+}
+
+void IncrementalPointCloud::indexAppendedPointsRecycling(std::size_t firstAppended)
+{
+  const std::size_t n = m_x.size();
+
+  if (firstAppended != indexed_up_to_ || n < firstAppended)
+  {
+    // Contents were replaced rather than appended: rebuild everything.
+    resetIndex();
+    return;
+  }
+
+  if (n == firstAppended) return;  // nothing was appended
+
+  last_insert_batch_ = n - firstAppended;
+
+  cov_.resize(n);
+  cov_valid_.resize(n, 0);
+
+  refreshPointBuffers();
+
+  // Move the appended points, starting from the last one, into previously
+  // freed slots. This keeps the storage bounded by the size of the sliding
+  // window instead of growing with the total number of inserted points.
+  std::size_t moved = 0;
+  while (moved < n - firstAppended && !free_slots_.empty())
+  {
+    const uint32_t slot = free_slots_.back();
+    free_slots_.pop_back();
+
+    relocatePoint(n - 1 - moved, slot);
+    cov_valid_[slot] = 0;
+    index_->addPoint(slot);
+
+    moved++;
+  }
+
+  if (moved != 0)
+  {
+    // Drop the relocated tail. Shrinking never reallocates, but the point
+    // count seen by the index must be updated.
+    resize(n - moved);
+    cov_.resize(m_x.size());
+    cov_valid_.resize(m_x.size());
+    refreshPointBuffers();
+  }
+
+  const std::size_t newN = m_x.size();
+  if (newN > firstAppended)
+  {
+    index_->addPoints(static_cast<uint32_t>(firstAppended), static_cast<uint32_t>(newN - 1));
+  }
+  indexed_up_to_ = newN;
+}
+
+void IncrementalPointCloud::harvestRemovedSlots()
+{
+  // A freed slot keeps the coordinates of the evicted point until some later
+  // insertion overwrites it, and a big eviction can free far more slots than
+  // the next few scans consume. Those stale coordinates are invisible to the
+  // index (and hence to ICP), but NOT to code that walks the inherited
+  // CPointsMap storage directly -- most visibly `insertAnotherMap()`, which is
+  // how mola_lidar_odometry copies map layers out for publishing, and which
+  // would therefore render long-evicted geometry.
+  //
+  // Blanking them as NaN is what makes a free slot hold no point at all:
+  // `insertAnotherMap()` and the other MRPT copy paths skip non-finite points,
+  // and a recycled slot is fully overwritten anyway.
+  constexpr float kNoPoint = std::numeric_limits<float>::quiet_NaN();
+
+  for (const uint32_t slot : index_->acquireRemovedPoints())
+  {
+    if (slot < cov_valid_.size()) cov_valid_[slot] = 0;
+    if (slot < m_x.size())
+    {
+      m_x[slot] = kNoPoint;
+      m_y[slot] = kNoPoint;
+      m_z[slot] = kNoPoint;
+    }
+    free_slots_.push_back(slot);
+  }
+}
+
+void IncrementalPointCloud::keepOnlyPointsNear(
+    const mrpt::math::TPoint3Df& center, double half_side)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  ensureIndexUpToDate();
+
+  const auto  h     = static_cast<float>(half_side);
+  const float mn[3] = {center.x - h, center.y - h, center.z - h};
+  const float mx[3] = {center.x + h, center.y + h, center.z + h};
+
+  index_->keepOnlyPointsInsideBox(mn, mx);
+  harvestRemovedSlots();
+
+  mark_as_modified();
+}
+
+// =====================================
+// Insertion
+// =====================================
+
+bool IncrementalPointCloud::internal_insertObservation(
+    const mrpt::obs::CObservation& obs, const std::optional<const mrpt::poses::CPose3D>& robotPose)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  const auto tStart = std::chrono::steady_clock::now();
+
+  ensureIndexUpToDate();
+
+  // Evict first, so this very insertion can already recycle the freed slots:
+  if (creationOptions.remove_points_farther_than > 0 && robotPose.has_value())
+  {
+    keepOnlyPointsNear(
+        robotPose->translation().cast<float>(), creationOptions.remove_points_farther_than);
+  }
+
+  // A background rebuild reads the coordinate buffers, but blocking on it here
+  // would defeat the point of running it in the background. Instead the buffers
+  // are only ever allowed to move from reserve()/resize()/setSize(), which wait
+  // for the worker themselves.
+  //
+  // `insertAnotherMap()` (the path taken by mp2p_icp_filters::FilterMerge)
+  // reserves up front, so it is covered. A hand-written `insertPoint()` loop is
+  // not, since push_back can reallocate without going through reserve(), so
+  // keep enough spare capacity for a batch of the size we have been seeing.
+  if (creationOptions.async_rebuild)
+  {
+    const std::size_t margin = std::max<std::size_t>(2 * last_insert_batch_, 8192);
+    if (m_x.capacity() - m_x.size() < margin) this->reserve(m_x.size() + margin);
+  }
+
+  const std::size_t before = m_x.size();
+
+  // Let the base class do the observation-type-specific work (it also honors
+  // the standard insertionOptions, e.g. minDistBetweenLaserPoints):
+  const bool ok = CPointsMap::internal_insertObservation(obs, robotPose);
+
+  if (insertionOptions.addToExistingPointsMap)
+  {
+    indexAppendedPointsRecycling(before);
+  }
+  else
+  {
+    // The base class replaced the map contents instead of appending, so every
+    // slot index changed meaning: rebuild.
+    resetIndex();
+  }
+
+  if (ENV_DEBUG_STATS)
+  {
+    const double ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - tStart)
+            .count();
+    const auto bb = boundingBox();
+    printf(
+        "[IncrementalPointCloud] insert_ms=%.1f live=%zu storage=%zu free_slots=%zu "
+        "bbox=[%.1f %.1f %.1f]-[%.1f %.1f %.1f]\n",
+        ms, index_->size(), m_x.size(), free_slots_.size(), static_cast<double>(bb.min.x),
+        static_cast<double>(bb.min.y), static_cast<double>(bb.min.z),
+        static_cast<double>(bb.max.x), static_cast<double>(bb.max.y),
+        static_cast<double>(bb.max.z));
+  }
+
+  return ok;
+}
+
+void IncrementalPointCloud::internal_clear()
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  m_x.clear();
+  m_y.clear();
+  m_z.clear();
+  m_x.shrink_to_fit();
+  m_y.shrink_to_fit();
+  m_z.shrink_to_fit();
+
+  m_float_fields.clear();
+  m_double_fields.clear();
+  m_uint16_fields.clear();
+  m_uint8_fields.clear();
+
+  cachedPoints_.reset();
+
+  resetIndex();
+
+  mark_as_modified();
+}
+
+// =====================================
+// Data access
+// =====================================
+
+std::size_t IncrementalPointCloud::livePointCount() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+  return index_->size();
+}
+
+std::size_t IncrementalPointCloud::recyclableSlotCount() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  return free_slots_.size();
+}
+
+void IncrementalPointCloud::compact()
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  if (index_->size() != m_x.size())
+  {
+    // Copies points and all per-point fields back onto ourselves, dropping the
+    // tombstoned slots on the way (it clears us first, which already resets
+    // the index):
+    const auto live = liveCompactedCopy();
+    CPointsMap::operator=(*live);
+  }
+
+  resetIndex();
+}
+
+mrpt::maps::CGenericPointsMap::Ptr IncrementalPointCloud::liveCompactedCopy() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  std::vector<uint32_t> live;
+  index_->snapshotLiveIndices(live);
+  std::sort(live.begin(), live.end());
+
+  auto out = mrpt::maps::CGenericPointsMap::Create();
+  out->reserve(live.size());
+  out->registerPointFieldsFrom(*this);
+
+  const auto ctx = out->prepareForInsertPointsFrom(*this);
+  for (const uint32_t slot : live)
+  {
+    out->insertPointFrom(slot, ctx);
+  }
+
+  return out;
+}
+
+mrpt::math::TBoundingBoxf IncrementalPointCloud::boundingBox() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  float mn[3];
+  float mx[3];
+  if (!index_->boundingBox(mn, mx))
+  {
+    return mrpt::math::TBoundingBoxf(
+        mrpt::math::TPoint3Df(0, 0, 0), mrpt::math::TPoint3Df(0, 0, 0));
+  }
+
+  return mrpt::math::TBoundingBoxf(
+      mrpt::math::TPoint3Df(mn[0], mn[1], mn[2]), mrpt::math::TPoint3Df(mx[0], mx[1], mx[2]));
+}
+
+bool IncrementalPointCloud::isEmpty() const { return livePointCount() == 0; }
+
+std::string IncrementalPointCloud::asString() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  return mrpt::format(
+      "IncrementalPointCloud, points=%zu (storage=%zu, free slots=%zu) bbox=%s", index_->size(),
+      m_x.size(), free_slots_.size(), boundingBox().asString().c_str());
+}
+
+// =====================================
+// NearestNeighborsCapable
+// =====================================
+
+bool IncrementalPointCloud::nn_has_indices_or_ids() const
+{
+  return true;  // storage slot indices, usable with getPointFast()
+}
+
+size_t IncrementalPointCloud::nn_index_count() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  return m_x.size();
+}
+
+void IncrementalPointCloud::nn_prepare_for_3d_queries() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+}
+
+bool IncrementalPointCloud::nn_single_search(
+    const mrpt::math::TPoint3Df& query, mrpt::math::TPoint3Df& result, float& out_dist_sqr,
+    uint64_t& resultIndexOrID) const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  const float q[3] = {query.x, query.y, query.z};
+
+  uint32_t idx  = 0;
+  float    dist = 0;
+  if (index_->knnSearch(q, 1, &idx, &dist) == 0) return false;
+
+  result          = {m_x[idx], m_y[idx], m_z[idx]};
+  out_dist_sqr    = dist;
+  resultIndexOrID = idx;
+  return true;
+}
+
+void IncrementalPointCloud::nn_multiple_search(
+    const mrpt::math::TPoint3Df& query, const size_t N, std::vector<mrpt::math::TPoint3Df>& results,
+    std::vector<float>& out_dists_sqr, std::vector<uint64_t>& resultIndicesOrIDs) const
+{
+  results.clear();
+  out_dists_sqr.clear();
+  resultIndicesOrIDs.clear();
+  if (N == 0) return;
+
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  const float q[3] = {query.x, query.y, query.z};
+
+  std::vector<uint32_t> idxs(N);
+  std::vector<float>    dists(N);
+
+  const std::size_t found = index_->knnSearch(q, N, idxs.data(), dists.data());
+
+  results.reserve(found);
+  out_dists_sqr.reserve(found);
+  resultIndicesOrIDs.reserve(found);
+  for (std::size_t i = 0; i < found; i++)
+  {
+    const uint32_t idx = idxs[i];
+    results.push_back({m_x[idx], m_y[idx], m_z[idx]});
+    out_dists_sqr.push_back(dists[i]);
+    resultIndicesOrIDs.push_back(idx);
+  }
+}
+
+void IncrementalPointCloud::nn_radius_search(
+    const mrpt::math::TPoint3Df& query, const float search_radius_sqr,
+    std::vector<mrpt::math::TPoint3Df>& results, std::vector<float>& out_dists_sqr,
+    std::vector<uint64_t>& resultIndicesOrIDs, size_t maxPoints) const
+{
+  results.clear();
+  out_dists_sqr.clear();
+  resultIndicesOrIDs.clear();
+  if (search_radius_sqr <= 0) return;
+
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  const float q[3] = {query.x, query.y, query.z};
+
+  const auto lambdaAddResult = [&](uint32_t idx, float distSqr)
+  {
+    results.push_back({m_x[idx], m_y[idx], m_z[idx]});
+    out_dists_sqr.push_back(distSqr);
+    resultIndicesOrIDs.push_back(idx);
+  };
+
+  if (maxPoints != 0)
+  {
+    std::vector<uint32_t> idxs(maxPoints);
+    std::vector<float>    dists(maxPoints);
+
+    const std::size_t found =
+        index_->knnSearchWithinRadius(q, maxPoints, search_radius_sqr, idxs.data(), dists.data());
+
+    for (std::size_t i = 0; i < found; i++) lambdaAddResult(idxs[i], dists[i]);
+  }
+  else
+  {
+    std::vector<internal::IncrementalKDTree::Neighbor> matches;
+    index_->radiusSearch(q, search_radius_sqr, matches);
+
+    for (const auto& m : matches) lambdaAddResult(m.index, m.dist_sqr);
+  }
+}
+
+bool IncrementalPointCloud::nn_single_search(
+    [[maybe_unused]] const mrpt::math::TPoint2Df& query,
+    [[maybe_unused]] mrpt::math::TPoint2Df& result, [[maybe_unused]] float& out_dist_sqr,
+    [[maybe_unused]] uint64_t& resultIndexOrID) const
+{
+  THROW_EXCEPTION("Cannot run a 2D search on an IncrementalPointCloud");
+}
+
+void IncrementalPointCloud::nn_multiple_search(
+    [[maybe_unused]] const mrpt::math::TPoint2Df& query, [[maybe_unused]] const size_t N,
+    [[maybe_unused]] std::vector<mrpt::math::TPoint2Df>& results,
+    [[maybe_unused]] std::vector<float>&                 out_dists_sqr,
+    [[maybe_unused]] std::vector<uint64_t>&              resultIndicesOrIDs) const
+{
+  THROW_EXCEPTION("Cannot run a 2D search on an IncrementalPointCloud");
+}
+
+void IncrementalPointCloud::nn_radius_search(
+    [[maybe_unused]] const mrpt::math::TPoint2Df&        query,
+    [[maybe_unused]] const float                         search_radius_sqr,
+    [[maybe_unused]] std::vector<mrpt::math::TPoint2Df>& results,
+    [[maybe_unused]] std::vector<float>&                 out_dists_sqr,
+    [[maybe_unused]] std::vector<uint64_t>&              resultIndicesOrIDs,
+    [[maybe_unused]] size_t                              maxPoints) const
+{
+  THROW_EXCEPTION("Cannot run a 2D search on an IncrementalPointCloud");
+}
+
+// =====================================
+// Per-point covariances (cov2cov)
+// =====================================
+
+void IncrementalPointCloud::computeCovariance(uint32_t slot) const
+{
+  if (cov_valid_[slot] != 0) return;
+
+  cov_[slot]       = mrpt::math::CMatrixFloat33::Identity();
+  cov_valid_[slot] = 1;
+
+  const std::size_t liveCount = index_->size();
+  if (liveCount < 3) return;
+
+  const std::size_t K = std::min<std::size_t>(creationOptions.k_correspondences_for_cov, liveCount);
+  const std::size_t minK = std::min<std::size_t>(creationOptions.min_correspondences_for_cov, K);
+
+  const auto maxDistSqr = static_cast<float>(
+      creationOptions.max_distance_for_cov * creationOptions.max_distance_for_cov);
+
+  const float q[3] = {m_x[slot], m_y[slot], m_z[slot]};
+
+  std::vector<uint32_t> idxs(K);
+  std::vector<float>    dists(K);
+
+  const std::size_t found =
+      index_->knnSearchWithinRadius(q, K, maxDistSqr, idxs.data(), dists.data());
+
+  // Too few neighbors actually found: a plane fit from this few samples is
+  // unreliable, so keep the isotropic covariance set above instead of an
+  // over-confident, possibly degenerate regularized one.
+  if (found < minK) return;
+
+  Eigen::Matrix<double, 3, -1> neighbors(3, static_cast<Eigen::Index>(found));
+  for (std::size_t j = 0; j < found; j++)
+  {
+    const uint32_t nIdx                        = idxs[j];
+    neighbors(0, static_cast<Eigen::Index>(j)) = static_cast<double>(m_x[nIdx]);
+    neighbors(1, static_cast<Eigen::Index>(j)) = static_cast<double>(m_y[nIdx]);
+    neighbors(2, static_cast<Eigen::Index>(j)) = static_cast<double>(m_z[nIdx]);
+  }
+  neighbors.colwise() -= Eigen::Vector3d(m_x[slot], m_y[slot], m_z[slot]);
+
+  const Eigen::Matrix3d cov = neighbors * neighbors.transpose() / static_cast<double>(found);
+
+  // Plane regularization of the singular values (see DLIO'2023, or Segal's
+  // GICP paper): SVD sorts them in decreasing order, so the last one is the
+  // plane normal direction.
+  const Eigen::JacobiSVD<Eigen::Matrix3d> svd(cov, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+  const Eigen::Vector3d values(1.0, 1.0, 1e-3);
+  cov_[slot] = svd.matrixU() * values.asDiagonal() * svd.matrixV().transpose();
+}
+
+void IncrementalPointCloud::ensureCovariancesFor(const std::vector<uint32_t>& slots) const
+{
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  tbb::parallel_for(
+      static_cast<std::size_t>(0), slots.size(),
+      [&](std::size_t i) { computeCovariance(slots[i]); });
+#else
+  for (const uint32_t slot : slots) computeCovariance(slot);
+#endif
+}
+
+std::size_t IncrementalPointCloud::point_count() const { return livePointCount(); }
+
+void IncrementalPointCloud::nn_search_cov2cov(
+    const NearestPointWithCovCapable& localMap, const mrpt::poses::CPose3D& localMapPose,
+    const float max_search_distance, mp2p_icp::MatchedPointWithCovList& outPairings) const
+{
+  const auto* localPc = dynamic_cast<const IncrementalPointCloud*>(&localMap);
+  ASSERTMSG_(
+      localPc,
+      "Implementation expects the local map to be also of type mola::IncrementalPointCloud");
+
+  // std::scoped_lock takes both without risking a lock-order deadlock, but it
+  // must not be given the same mutex twice:
+  std::unique_lock<std::recursive_mutex> lckGlobal(mtx_, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> lckLocal(localPc->mtx_, std::defer_lock);
+  if (localPc == this)
+  {
+    lckGlobal.lock();
+  }
+  else
+  {
+    std::lock(lckGlobal, lckLocal);
+  }
+
+  ensureIndexUpToDate();
+  localPc->ensureIndexUpToDate();
+
+  // The local points, in the local map own frame:
+  std::vector<uint32_t> localLive;
+  localPc->index_->snapshotLiveIndices(localLive);
+  if (localLive.empty()) return;
+
+  // Local covariances are needed for every local point, and each slot appears
+  // exactly once in the snapshot:
+  localPc->ensureCovariancesFor(localLive);
+
+  const float max_sqr_dist = mrpt::square(max_search_distance);
+
+  const auto& l_xs = localPc->m_x;
+  const auto& l_ys = localPc->m_y;
+  const auto& l_zs = localPc->m_z;
+
+  // --- Pass 1: nearest-neighbor search (no covariance access) --------------
+  struct Match
+  {
+    uint32_t local_slot  = 0;
+    uint32_t global_slot = 0;
+  };
+  std::vector<Match> matches;
+  matches.reserve(localLive.size());
+
+  const auto lambdaMatchOne = [&](uint32_t ls, std::vector<Match>& out)
+  {
+    const auto gq = localMapPose.composePoint(mrpt::math::TPoint3D(l_xs[ls], l_ys[ls], l_zs[ls]));
+
+    const float q[3] = {
+        static_cast<float>(gq.x), static_cast<float>(gq.y), static_cast<float>(gq.z)};
+
+    uint32_t gIdx = 0;
+    float    d    = 0;
+    if (index_->knnSearchWithinRadius(q, 1, max_sqr_dist, &gIdx, &d) == 0) return;
+
+    out.push_back({ls, gIdx});
+  };
+
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+  tbb::enumerable_thread_specific<std::vector<Match>> tls;
+
+  tbb::parallel_for(
+      static_cast<std::size_t>(0), localLive.size(),
+      [&](std::size_t i) { lambdaMatchOne(localLive[i], tls.local()); });
+
+  for (auto& perThread : tls)
+  {
+    matches.insert(matches.end(), perThread.begin(), perThread.end());
+  }
+#else
+  for (const uint32_t ls : localLive) lambdaMatchOne(ls, matches);
+#endif
+
+  if (matches.empty()) return;
+
+  // --- Pass 2: covariances of the matched global points -------------------
+  // Deduplicated, so no two threads write to the same cache entry.
+  std::vector<uint32_t> globalSlots;
+  globalSlots.reserve(matches.size());
+  for (const auto& m : matches) globalSlots.push_back(m.global_slot);
+  std::sort(globalSlots.begin(), globalSlots.end());
+  globalSlots.erase(std::unique(globalSlots.begin(), globalSlots.end()), globalSlots.end());
+
+  ensureCovariancesFor(globalSlots);
+
+  // --- Pass 3: assemble the pairings --------------------------------------
+  const Eigen::Matrix3f R = localMapPose.getRotationMatrix().cast_float().asEigen();
+
+  outPairings.reserve(outPairings.size() + matches.size());
+  for (const auto& m : matches)
+  {
+    auto& p = outPairings.emplace_back();
+
+    p.local_idx  = m.local_slot;
+    p.global_idx = m.global_slot;
+    p.local      = {l_xs[m.local_slot], l_ys[m.local_slot], l_zs[m.local_slot]};
+    p.global     = {m_x[m.global_slot], m_y[m.global_slot], m_z[m.global_slot]};
+
+    // GICP \cite segal2009gicp : (COV_global + R*COV_local*R^T)^-1
+    const Eigen::Matrix3f covLocalGlobalFrame =
+        R * localPc->cov_[m.local_slot].asEigen() * R.transpose();
+
+    const Eigen::Matrix3f w = cov_[m.global_slot].asEigen() + covLocalGlobalFrame;
+
+    p.cov_inv.asEigen() = w.inverse();
+  }
+}
+
+// =====================================
+// Visualization / export
+// =====================================
+
+void IncrementalPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+{
+  MRPT_START
+  if (!genericMapParams.enableSaveAs3DObject) return;
+
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  if (index_->size() == m_x.size())
+  {
+    // No tombstoned points: the base class can render our own storage directly.
+    CGenericPointsMap::getVisualizationInto(outObj);
+    return;
+  }
+
+  const auto compacted        = liveCompactedCopy();
+  compacted->renderOptions    = renderOptions;
+  compacted->genericMapParams = genericMapParams;
+  compacted->getVisualizationInto(outObj);
+
+  MRPT_END
+}
+
+void IncrementalPointCloud::saveMetricMapRepresentationToFile(
+    const std::string& filNamePrefix) const
+{
+  using namespace std::string_literals;
+  liveCompactedCopy()->save3D_to_text_file(filNamePrefix + ".txt"s);
+}
+
+const mrpt::maps::CSimplePointsMap* IncrementalPointCloud::getAsSimplePointsMap() const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+  ensureIndexUpToDate();
+
+  if (!cachedPoints_) cachedPoints_ = mrpt::maps::CSimplePointsMap::Create();
+
+  cachedPoints_->clear();
+
+  std::vector<uint32_t> live;
+  index_->snapshotLiveIndices(live);
+  std::sort(live.begin(), live.end());
+
+  cachedPoints_->reserve(live.size());
+  for (const uint32_t slot : live)
+  {
+    cachedPoints_->insertPointFast(m_x[slot], m_y[slot], m_z[slot]);
+  }
+  cachedPoints_->mark_as_modified();
+
+  return cachedPoints_.get();
+}
+
+// =====================================
+// Serialization
+// =====================================
+
+uint8_t IncrementalPointCloud::serializeGetVersion() const { return 0; }
+
+void IncrementalPointCloud::serializeTo(mrpt::serialization::CArchive& out) const
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  // Only the live points, compacted, delegating the per-point field encoding
+  // to the base class:
+  out << *liveCompactedCopy();
+
+  creationOptions.writeToStream(out);
+  insertionOptions.writeToStream(out);
+  likelihoodOptions.writeToStream(out);
+  renderOptions.writeToStream(out);
+}
+
+void IncrementalPointCloud::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  switch (version)
+  {
+    case 0:
+    {
+      auto tmp = mrpt::maps::CGenericPointsMap::Create();
+      in >> *tmp;
+
+      // Copies points and all per-point fields (clearing us first):
+      CPointsMap::operator=(*tmp);
+
+      creationOptions.readFromStream(in);
+      insertionOptions.readFromStream(in);
+      likelihoodOptions.readFromStream(in);
+      renderOptions.readFromStream(in);
+    }
+    break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  };
+
+  resetIndex();
+}
+
+// =====================================
+// Options
+// =====================================
+
+std::map<std::string, mrpt::config::CLoadableOptions*> IncrementalPointCloud::optionsByName()
+{
+  return {
+      {"creationOptions", &creationOptions},
+      {"insertionOptions", &insertionOptions},
+      {"likelihoodOptions", &likelihoodOptions},
+      {"renderOptions", &renderOptions},
+  };
+}
+
+bool IncrementalPointCloud::trySetCreationOptions(
+    const mrpt::config::CConfigFileBase& cfg, const std::string& section)
+{
+  auto lck = mrpt::lockHelper(mtx_);
+
+  TCreationOptions newOpts = creationOptions;
+  newOpts.loadFromConfigFile(cfg, section);
+
+  const bool treeParamsChanged = newOpts.async_rebuild != creationOptions.async_rebuild ||
+                                 newOpts.alpha_balance != creationOptions.alpha_balance ||
+                                 newOpts.alpha_deleted != creationOptions.alpha_deleted ||
+                                 newOpts.reserve_points != creationOptions.reserve_points;
+
+  const bool covParamsChanged =
+      newOpts.k_correspondences_for_cov != creationOptions.k_correspondences_for_cov ||
+      newOpts.min_correspondences_for_cov != creationOptions.min_correspondences_for_cov ||
+      newOpts.max_distance_for_cov != creationOptions.max_distance_for_cov;
+
+  creationOptions = newOpts;
+
+  if (treeParamsChanged)
+  {
+    // The tree is rebuilt with the new parameters; no map content is lost.
+    compact();
+  }
+  else if (covParamsChanged)
+  {
+    std::fill(cov_valid_.begin(), cov_valid_.end(), 0);
+  }
+
+  return true;
+}
+
+void IncrementalPointCloud::TCreationOptions::loadFromConfigFile(
+    const mrpt::config::CConfigFileBase& c, const std::string& s)
+{
+  MRPT_LOAD_CONFIG_VAR(remove_points_farther_than, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(async_rebuild, bool, c, s);
+  MRPT_LOAD_CONFIG_VAR(alpha_balance, float, c, s);
+  MRPT_LOAD_CONFIG_VAR(alpha_deleted, float, c, s);
+  MRPT_LOAD_CONFIG_VAR(reserve_points, uint64_t, c, s);
+  MRPT_LOAD_CONFIG_VAR(k_correspondences_for_cov, uint64_t, c, s);
+  MRPT_LOAD_CONFIG_VAR(min_correspondences_for_cov, uint64_t, c, s);
+  MRPT_LOAD_CONFIG_VAR(max_distance_for_cov, double, c, s);
+}
+
+void IncrementalPointCloud::TCreationOptions::dumpToTextStream(std::ostream& out) const
+{
+  out << "\n------ [IncrementalPointCloud::TCreationOptions] ------- \n\n";
+
+  LOADABLEOPTS_DUMP_VAR(remove_points_farther_than, double);
+  LOADABLEOPTS_DUMP_VAR(async_rebuild, bool);
+  LOADABLEOPTS_DUMP_VAR(alpha_balance, float);
+  LOADABLEOPTS_DUMP_VAR(alpha_deleted, float);
+  LOADABLEOPTS_DUMP_VAR(reserve_points, int);
+  LOADABLEOPTS_DUMP_VAR(k_correspondences_for_cov, int);
+  LOADABLEOPTS_DUMP_VAR(min_correspondences_for_cov, int);
+  LOADABLEOPTS_DUMP_VAR(max_distance_for_cov, double);
+}
+
+void IncrementalPointCloud::TCreationOptions::writeToStream(
+    mrpt::serialization::CArchive& out) const
+{
+  const int8_t version = 0;
+  out << version;
+  out << remove_points_farther_than << async_rebuild << alpha_balance << alpha_deleted
+      << reserve_points << k_correspondences_for_cov << min_correspondences_for_cov
+      << max_distance_for_cov;
+}
+
+void IncrementalPointCloud::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
+{
+  int8_t version;
+  in >> version;
+  switch (version)
+  {
+    case 0:
+    {
+      in >> remove_points_farther_than >> async_rebuild >> alpha_balance >> alpha_deleted >>
+          reserve_points >> k_correspondences_for_cov >> min_correspondences_for_cov >>
+          max_distance_for_cov;
+    }
+    break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  }
+}

--- a/mola_metric_maps/src/register.cpp
+++ b/mola_metric_maps/src/register.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <mola_metric_maps/HashedVoxelPointCloud.h>
+#include <mola_metric_maps/IncrementalPointCloud.h>
 #include <mola_metric_maps/KeyframePointCloudMap.h>
 #include <mola_metric_maps/NDT.h>
 #include <mola_metric_maps/OccGrid.h>
@@ -39,6 +40,9 @@ MRPT_INITIALIZER(do_register_mola_metric_maps)  // NOLINT(misc-use-anonymous-nam
 
   // and register RTTI info:
   registerClass(CLASS_ID(mola::HashedVoxelPointCloud));
+#if defined(MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD)
+  registerClass(CLASS_ID(mola::IncrementalPointCloud));
+#endif
   registerClass(CLASS_ID(mola::KeyframePointCloudMap));
   registerClass(CLASS_ID(mola::NDT));
   registerClass(CLASS_ID(mola::OccGrid));

--- a/mola_metric_maps/src/register.cpp
+++ b/mola_metric_maps/src/register.cpp
@@ -40,9 +40,9 @@ MRPT_INITIALIZER(do_register_mola_metric_maps)  // NOLINT(misc-use-anonymous-nam
 
   // and register RTTI info:
   registerClass(CLASS_ID(mola::HashedVoxelPointCloud));
-#if defined(MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD)
+  // Registered even when built without a suitable nanoflann: instantiating it
+  // then throws an explanatory error, which beats "no such registered class".
   registerClass(CLASS_ID(mola::IncrementalPointCloud));
-#endif
   registerClass(CLASS_ID(mola::KeyframePointCloudMap));
   registerClass(CLASS_ID(mola::NDT));
   registerClass(CLASS_ID(mola::OccGrid));

--- a/mola_metric_maps/tests/CMakeLists.txt
+++ b/mola_metric_maps/tests/CMakeLists.txt
@@ -48,3 +48,12 @@ mola_add_test(
   mola_metric_maps
 )
 
+if(MOLA_HAS_INCREMENTAL_POINT_CLOUD)
+  mola_add_test(
+    TARGET  test-mola_metric_maps_incrementalpointcloud
+    SOURCES test-mola_metric_maps_incrementalpointcloud.cpp
+    LINK_LIBRARIES
+    mola_metric_maps
+  )
+endif()
+

--- a/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
@@ -113,9 +113,9 @@ void test_queries_against_brute_force(bool async)
     // 1) single NN
     {
       mrpt::math::TPoint3Df p;
-      float                 d    = 0;
-      uint64_t              id   = 0;
-      const bool            ok   = map.nn_single_search(q, p, d, id);
+      float                 d  = 0;
+      uint64_t              id = 0;
+      const bool            ok = map.nn_single_search(q, p, d, id);
       mrpt::math::TPoint3Df gt_p;
       float                 gt_d  = 0;
       uint64_t              gt_id = 0;
@@ -232,8 +232,8 @@ void test_bounded_memory_under_churn()
     mola::IncrementalPointCloud rawCopy;
     rawCopy.insertAnotherMap(&map, mrpt::poses::CPose3D::Identity());
 
-    std::cout << "[churn] raw insertAnotherMap copy=" << rawCopy.size()
-              << " (live was " << map.livePointCount() << ")\n";
+    std::cout << "[churn] raw insertAnotherMap copy=" << rawCopy.size() << " (live was "
+              << map.livePointCount() << ")\n";
 
     ASSERT_GE_(rawCopy.size(), map.livePointCount());
     // Anything much beyond the live set would be stale geometry showing up in
@@ -353,8 +353,7 @@ void test_cov2cov()
     float z = 0;
     surface->getPointFast(i, x, y, z);
     const auto pl = localPoseInv.composePoint(mrpt::math::TPoint3D(x, y, z));
-    local.insertPoint(
-        static_cast<float>(pl.x), static_cast<float>(pl.y), static_cast<float>(pl.z));
+    local.insertPoint(static_cast<float>(pl.x), static_cast<float>(pl.y), static_cast<float>(pl.z));
   }
 
   ASSERT_EQUAL_(global.point_count(), surface->size());

--- a/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
@@ -1,0 +1,409 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-mola_metric_maps_incrementalpointcloud.cpp
+ * @brief  Test the incremental (self-balancing k-d tree) point cloud map
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 25, 2026
+ */
+
+#include <mola_metric_maps/IncrementalPointCloud.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/random/RandomGenerators.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+mrpt::random::CRandomGenerator rng;
+
+/// Points uniformly spread in a cube of the given half side around `center`.
+mrpt::maps::CSimplePointsMap::Ptr randomCloud(
+    size_t n, const mrpt::math::TPoint3Df& center, double halfSide)
+{
+  auto pts = mrpt::maps::CSimplePointsMap::Create();
+  pts->reserve(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    pts->insertPointFast(
+        static_cast<float>(center.x + rng.drawUniform(-halfSide, halfSide)),
+        static_cast<float>(center.y + rng.drawUniform(-halfSide, halfSide)),
+        static_cast<float>(center.z + rng.drawUniform(-halfSide, halfSide)));
+  }
+  pts->mark_as_modified();
+  return pts;
+}
+
+/// An independent (MRPT static k-d tree) view of the live points, used as oracle.
+mrpt::maps::CSimplePointsMap::Ptr bruteForceReference(const mola::IncrementalPointCloud& map)
+{
+  const auto live = map.liveCompactedCopy();
+
+  auto ref = mrpt::maps::CSimplePointsMap::Create();
+  ref->reserve(live->size());
+  for (size_t i = 0; i < live->size(); i++)
+  {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    live->getPointFast(i, x, y, z);
+    ref->insertPointFast(x, y, z);
+  }
+  ref->mark_as_modified();
+  return ref;
+}
+
+void insertPoints(mola::IncrementalPointCloud& map, const mrpt::maps::CSimplePointsMap& pts)
+{
+  for (size_t i = 0; i < pts.size(); i++)
+  {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    pts.getPointFast(i, x, y, z);
+    map.insertPoint(x, y, z);
+  }
+}
+
+// -------------------------------------------------------------------------
+void test_queries_against_brute_force(bool async)
+{
+  mola::IncrementalPointCloud map;
+  map.creationOptions.async_rebuild = async;
+  map.compact();  // apply the structural option above
+  ASSERT_(map.isEmpty());
+
+  // A first batch, then a trim, then a second batch: the index must be correct
+  // across recycled slots and tombstones.
+  insertPoints(map, *randomCloud(2000, {0, 0, 0}, 20.0));
+  ASSERT_EQUAL_(map.livePointCount(), 2000UL);
+  ASSERT_(!map.isEmpty());
+
+  map.keepOnlyPointsNear({5.0f, 0.0f, 0.0f}, 10.0);
+  ASSERT_(map.livePointCount() < 2000);
+
+  insertPoints(map, *randomCloud(2000, {5, 0, 0}, 12.0));
+
+  const auto ref = bruteForceReference(map);
+  ASSERT_EQUAL_(map.livePointCount(), ref->size());
+
+  for (size_t trial = 0; trial < 200; trial++)
+  {
+    const mrpt::math::TPoint3Df q = {
+        static_cast<float>(rng.drawUniform(-20.0, 20.0)),
+        static_cast<float>(rng.drawUniform(-20.0, 20.0)),
+        static_cast<float>(rng.drawUniform(-20.0, 20.0))};
+
+    // 1) single NN
+    {
+      mrpt::math::TPoint3Df p;
+      float                 d    = 0;
+      uint64_t              id   = 0;
+      const bool            ok   = map.nn_single_search(q, p, d, id);
+      mrpt::math::TPoint3Df gt_p;
+      float                 gt_d  = 0;
+      uint64_t              gt_id = 0;
+      const bool            gt_ok = ref->nn_single_search(q, gt_p, gt_d, gt_id);
+
+      ASSERT_EQUAL_(ok, gt_ok);
+      if (!ok) continue;
+
+      ASSERT_NEAR_(d, gt_d, 1e-4f);
+
+      // The returned index must address the live point in our own storage:
+      float sx = 0;
+      float sy = 0;
+      float sz = 0;
+      map.getPointFast(id, sx, sy, sz);
+      ASSERT_NEAR_(sx, p.x, 1e-6f);
+      ASSERT_NEAR_(sy, p.y, 1e-6f);
+      ASSERT_NEAR_(sz, p.z, 1e-6f);
+    }
+
+    // 2) k-NN
+    {
+      constexpr size_t                   knn = 5;
+      std::vector<mrpt::math::TPoint3Df> res;
+      std::vector<float>                 dists;
+      std::vector<uint64_t>              ids;
+      map.nn_multiple_search(q, knn, res, dists, ids);
+
+      std::vector<mrpt::math::TPoint3Df> gt_res;
+      std::vector<float>                 gt_dists;
+      std::vector<uint64_t>              gt_ids;
+      ref->nn_multiple_search(q, knn, gt_res, gt_dists, gt_ids);
+
+      ASSERT_EQUAL_(res.size(), gt_res.size());
+      for (size_t k = 0; k < res.size(); k++)
+      {
+        ASSERT_NEAR_(dists[k], gt_dists[k], 1e-4f);
+      }
+    }
+
+    // 3) radius search (unlimited count): same set of neighbors
+    {
+      constexpr float                    radiusSqr = 4.0f;
+      std::vector<mrpt::math::TPoint3Df> res;
+      std::vector<float>                 dists;
+      std::vector<uint64_t>              ids;
+      map.nn_radius_search(q, radiusSqr, res, dists, ids, 0 /*maxPoints*/);
+
+      std::vector<mrpt::math::TPoint3Df> gt_res;
+      std::vector<float>                 gt_dists;
+      std::vector<uint64_t>              gt_ids;
+      ref->nn_radius_search(q, radiusSqr, gt_res, gt_dists, gt_ids, 0 /*maxPoints*/);
+
+      ASSERT_EQUAL_(res.size(), gt_res.size());
+
+      std::sort(dists.begin(), dists.end());
+      std::sort(gt_dists.begin(), gt_dists.end());
+      for (size_t k = 0; k < dists.size(); k++)
+      {
+        ASSERT_NEAR_(dists[k], gt_dists[k], 1e-4f);
+      }
+    }
+  }
+}
+
+// -------------------------------------------------------------------------
+void test_bounded_memory_under_churn()
+{
+  mola::IncrementalPointCloud map;
+  map.creationOptions.remove_points_farther_than = 15.0;
+
+  constexpr size_t nFrames     = 120;
+  constexpr size_t ptsPerFrame = 500;
+
+  auto obs        = mrpt::obs::CObservationPointCloud::Create();
+  obs->sensorPose = mrpt::poses::CPose3D::Identity();
+
+  for (size_t f = 0; f < nFrames; f++)
+  {
+    // The sensor sweeps along +x, one meter per frame:
+    const auto robotPose =
+        mrpt::poses::CPose3D::FromXYZYawPitchRoll(static_cast<double>(f), 0, 0, 0, 0, 0);
+
+    obs->pointcloud = randomCloud(ptsPerFrame, {0, 0, 0}, 5.0);
+
+    map.insertObservation(*obs, robotPose);
+  }
+
+  const size_t totalInserted = nFrames * ptsPerFrame;
+
+  std::cout << "[churn] storage=" << map.size() << " live=" << map.livePointCount()
+            << " free slots=" << map.recyclableSlotCount() << " total inserted=" << totalInserted
+            << "\n";
+
+  ASSERT_(map.livePointCount() > 0);
+  ASSERT_(map.livePointCount() <= map.size());
+
+  // Slot recycling must keep the storage bounded by the sliding window instead
+  // of growing with the total number of inserted points.
+  ASSERT_LT_(map.size(), totalInserted / 2);
+
+  // Every *live* point is still inside the keep cube around the last robot
+  // pose (note map.boundingBox() is only a conservative superset, since the
+  // not-yet-reclaimed tombstones also contribute to it).
+  const auto bb = map.liveCompactedCopy()->boundingBox();
+  ASSERT_GT_(bb.min.x, static_cast<float>(nFrames - 1) - 15.1f);
+  ASSERT_LT_(bb.max.x, static_cast<float>(nFrames - 1) + 15.1f);
+
+  // A generic copy through the inherited CPointsMap storage (this is how
+  // mola_lidar_odometry copies map layers out for publishing) must NOT
+  // resurrect evicted points: reclaimed slots are blanked, so it can only pick
+  // up live points plus the bounded set of not-yet-reclaimed tombstones.
+  {
+    mola::IncrementalPointCloud rawCopy;
+    rawCopy.insertAnotherMap(&map, mrpt::poses::CPose3D::Identity());
+
+    std::cout << "[churn] raw insertAnotherMap copy=" << rawCopy.size()
+              << " (live was " << map.livePointCount() << ")\n";
+
+    ASSERT_GE_(rawCopy.size(), map.livePointCount());
+    // Anything much beyond the live set would be stale geometry showing up in
+    // the published/visualized map:
+    ASSERT_LT_(rawCopy.size(), map.livePointCount() * 6 / 5);
+
+    // Points tombstoned but not reclaimed yet do keep their coordinates, so
+    // the copy may reach slightly past the keep cube. What it must never
+    // contain is geometry from the beginning of the run: that would mean
+    // reclaimed slots are still holding their evicted point.
+    const auto rawBb = rawCopy.boundingBox();
+    ASSERT_GT_(rawBb.min.x, static_cast<float>(nFrames) * 0.5f);
+  }
+
+  // ... and compacting must drop exactly the tombstoned slots:
+  map.compact();
+  ASSERT_EQUAL_(map.size(), map.livePointCount());
+  ASSERT_EQUAL_(map.recyclableSlotCount(), 0UL);
+}
+
+// -------------------------------------------------------------------------
+void test_serialization_and_copy()
+{
+  mola::IncrementalPointCloud map;
+  map.creationOptions.remove_points_farther_than = 7.0;
+  map.creationOptions.k_correspondences_for_cov  = 12;
+
+  insertPoints(map, *randomCloud(3000, {0, 0, 0}, 20.0));
+  map.keepOnlyPointsNear({0, 0, 0}, 8.0);
+
+  const size_t nLive = map.livePointCount();
+  ASSERT_(nLive > 0);
+  ASSERT_(nLive < 3000);
+
+  const auto lambdaSameContents = [&](const mola::IncrementalPointCloud& other)
+  {
+    ASSERT_EQUAL_(other.livePointCount(), nLive);
+    // A deserialized/copied map is compacted, so there is nothing tombstoned:
+    ASSERT_EQUAL_(other.size(), nLive);
+    ASSERT_EQUAL_(other.creationOptions.k_correspondences_for_cov, 12U);
+    ASSERT_NEAR_(other.creationOptions.remove_points_farther_than, 7.0, 1e-9);
+
+    for (size_t trial = 0; trial < 100; trial++)
+    {
+      const mrpt::math::TPoint3Df q = {
+          static_cast<float>(rng.drawUniform(-10.0, 10.0)),
+          static_cast<float>(rng.drawUniform(-10.0, 10.0)),
+          static_cast<float>(rng.drawUniform(-10.0, 10.0))};
+
+      mrpt::math::TPoint3Df p1;
+      mrpt::math::TPoint3Df p2;
+      float                 d1 = 0;
+      float                 d2 = 0;
+      uint64_t              i1 = 0;
+      uint64_t              i2 = 0;
+
+      ASSERT_(map.nn_single_search(q, p1, d1, i1));
+      ASSERT_(other.nn_single_search(q, p2, d2, i2));
+      ASSERT_NEAR_(d1, d2, 1e-5f);
+      ASSERT_NEAR_(p1.x, p2.x, 1e-5f);
+      ASSERT_NEAR_(p1.y, p2.y, 1e-5f);
+      ASSERT_NEAR_(p1.z, p2.z, 1e-5f);
+    }
+  };
+
+  // Copy:
+  {
+    const mola::IncrementalPointCloud copy = map;
+    lambdaSameContents(copy);
+  }
+
+  // Serialization round trip:
+  {
+    mrpt::io::CMemoryStream buf;
+    auto                    arch = mrpt::serialization::archiveFrom(buf);
+    arch << map;
+
+    buf.Seek(0);
+    mola::IncrementalPointCloud restored;
+    arch >> restored;
+
+    lambdaSameContents(restored);
+  }
+}
+
+// -------------------------------------------------------------------------
+void test_cov2cov()
+{
+  // A locally-planar surface, so the plane-regularized covariances are well
+  // defined:
+  auto surface = mrpt::maps::CSimplePointsMap::Create();
+  for (int ix = -30; ix <= 30; ix++)
+  {
+    for (int iy = -30; iy <= 30; iy++)
+    {
+      surface->insertPointFast(
+          static_cast<float>(ix * 0.2), static_cast<float>(iy * 0.2),
+          static_cast<float>(rng.drawGaussian1D(0, 0.005)));
+    }
+  }
+  surface->mark_as_modified();
+
+  mola::IncrementalPointCloud global;
+  insertPoints(global, *surface);
+
+  // The local map holds the very same points, but expressed in a frame such
+  // that composing them with `localPose` lands exactly on the global ones.
+  const auto localPose =
+      mrpt::poses::CPose3D::FromXYZYawPitchRoll(1.0, -0.5, 0.2, 0.15, 0.02, -0.03);
+  const auto localPoseInv = mrpt::poses::CPose3D::Identity() - localPose;
+
+  mola::IncrementalPointCloud local;
+  for (size_t i = 0; i < surface->size(); i++)
+  {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    surface->getPointFast(i, x, y, z);
+    const auto pl = localPoseInv.composePoint(mrpt::math::TPoint3D(x, y, z));
+    local.insertPoint(
+        static_cast<float>(pl.x), static_cast<float>(pl.y), static_cast<float>(pl.z));
+  }
+
+  ASSERT_EQUAL_(global.point_count(), surface->size());
+  ASSERT_EQUAL_(local.point_count(), surface->size());
+
+  mp2p_icp::MatchedPointWithCovList pairings;
+  global.nn_search_cov2cov(local, localPose, 0.5f /*max search distance*/, pairings);
+
+  ASSERT_EQUAL_(pairings.size(), surface->size());
+
+  for (const auto& p : pairings)
+  {
+    // Each local point, once composed, must land on its own global twin:
+    const auto lg = localPose.composePoint(mrpt::math::TPoint3D(p.local.x, p.local.y, p.local.z));
+    ASSERT_NEAR_(lg.x, p.global.x, 1e-4);
+    ASSERT_NEAR_(lg.y, p.global.y, 1e-4);
+    ASSERT_NEAR_(lg.z, p.global.z, 1e-4);
+
+    // The GICP weight must be a usable, finite matrix:
+    for (int r = 0; r < 3; r++)
+    {
+      for (int c = 0; c < 3; c++)
+      {
+        ASSERT_(std::isfinite(p.cov_inv(r, c)));
+      }
+      ASSERT_GT_(p.cov_inv(r, r), .0f);
+    }
+  }
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+  try
+  {
+    rng.randomize(1234U);
+
+    test_queries_against_brute_force(false /*sync index*/);
+    test_queries_against_brute_force(true /*background rebuilds*/);
+    test_bounded_memory_under_churn();
+    test_serialization_and_copy();
+    test_cov2cov();
+
+    std::cout << "All tests passed.\n";
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << "\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
## What

Adds `mola::IncrementalPointCloud`: a single-global-frame, sliding-window local map for LiDAR (inertial) odometry, backed by **one incremental, self-balancing nanoflann k-d tree** instead of a static tree rebuilt on every scan.

`mrpt::maps::CPointsMap` is a `KDTreeCapable`, so every insertion marks the index dirty and the whole tree is rebuilt on the next query — O(N log N) per scan. Here insertion is amortized O(log N) per point plus bounded (optionally backgrounded) partial rebuilds.

## Design

- Derives from `mrpt::maps::CGenericPointsMap`, so points arrive through the usual `insertObservation()` / `insertAnotherMap()` / `insertPoint()` entry points with all per-point channels (`t`, `intensity`, `view_x/y/z`, …) preserved. The index picks up appended points lazily, which makes it robust to any MRPT insertion route.
- Eviction on insertion via `creationOptions.remove_points_farther_than` (a **cube half-side**, Chebyshev distance, same convention as `HashedVoxelPointCloud::remove_voxels_farther_than`). Slots the index reclaims are recycled, so storage stays bounded under churn.
- GICP matching through `mp2p_icp::NearestPointWithCovCapable`, with lazily computed, cached, plane-regularized per-point covariances.
- **Odometry only.** A single global tree cannot cheaply absorb a loop-closure re-map (all coordinates move ⇒ full rebuild + full covariance recompute); `KeyframePointCloudMap` remains the choice there.

## nanoflann isolation (please read before touching `IncrementalKDTree.cpp`)

The incremental index needs nanoflann ≥ 1.10.0. On distributions shipping an older one the build still succeeds, with a CMake warning: the class is compiled and registered as usual, but its k-d tree factory is replaced by a stub that throws an explanatory `std::runtime_error` naming the version found, so a YAML asking for the class fails with that rather than MRPT's generic "no such registered CMetricMap class". `MOLA_METRIC_MAPS_HAS_INCREMENTAL_POINT_CLOUD` advertises whether the feature is functional; the header is always usable.

Verified against the nanoflann 1.9.0 shipped by ROS Humble: configures with the warning, builds clean, the class registers, and construction throws the expected message.

MRPT bundles (and its binaries are built against) its own, usually older, copy of `nanoflann.hpp`. The two versions differ in non-template entities that share mangled names — e.g. `PooledAllocator` changed its `WORDSIZE`, its allocation strategy and renamed `malloc` → `allocateBytes` — so letting both reach one program is an ODR violation with real heap-corruption potential.

Include-path ordering cannot resolve this: MRPT exports its copy's directory as `-isystem`, and GCC deduplicates a directory listed both as `-I` and `-isystem` in favour of the system entry, silently dropping ours. So:

- nanoflann is included by `src/IncrementalKDTree.cpp` **alone**, by **absolute path** (`MOLA_NANOFLANN_HEADER`, set by CMake) and with its **namespace renamed**;
- that TU includes no MRPT header, and no nanoflann type is exposed through a public header;
- a version guard fails the build loudly if an older header is ever picked up anyway.

## Caveats, deliberately kept

- Removal is lazy, so the inherited `size()` counts live plus not-yet-reused slots. `livePointCount()` gives the live count, `compact()` makes the two equal. The storage array settles at its high-water mark and does not shrink on its own.
- Reclaimed slots are blanked to NaN so that generic `CPointsMap` walkers — notably `insertAnotherMap()`, which is how map layers are copied out for publishing/visualization — cannot resurrect evicted geometry.
- With `async_rebuild`, the worker reads the coordinate buffers, so `reserve()`/`resize()`/`setSize()` are overridden to wait for it before those can move, and insertion keeps spare capacity for one batch so a raw `insertPointFast()` loop cannot reallocate either. Any new growth path must respect this.
- Only per-point lazy covariances are implemented. Voxel/NDT-style and dirty-propagation variants are left as future work rather than shipped untested.
- 2D `nn_*` queries throw, as in the sibling voxel maps.

## Testing

New `test-mola_metric_maps_incrementalpointcloud`, covering both index variants:

- KNN / k-NN / radius queries against a brute-force oracle after an insert → evict → insert stream;
- bounded memory under churn (9,319 storage slots for 60,000 inserted points) and that a raw `insertAnotherMap()` copy cannot contain geometry from the start of the run;
- `cov2cov` pairings and GICP weights on a planar patch;
- serialization round-trip and copy.

All 16 tests in the package pass. End-to-end on Oxford Spires via `mola_lidar_odometry` (see MOLAorg/mola_lidar_odometry#111).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `IncrementalPointCloud` metric-map type for efficient sliding-window point storage with bounded memory, compaction, spatial trimming, and covariance-aware matching (3D nearest-neighbor, k-NN, and radius queries).
  * Includes visualization/export and serialization support.
* **Documentation**
  * Documented usage, options, and limitations (including 2D query behavior) and added `MOLA_INCREMENTAL_MAP_DEBUG_STATS` for insertion-time tracing.
* **Build & Compatibility**
  * Added nanoflann version gating: full functionality requires nanoflann ≥ 1.10; otherwise the incremental backend fails at runtime.
* **Tests**
  * Added unit tests covering search correctness, bounded-storage/compaction, async rebuild variants, serialization round-trips, and covariance matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->