### PR TITLE
Add mola::TransformTreeSource: expose the /tf tree to other MOLA modules

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -340,6 +340,23 @@ Test coverage exists for: `mola_yaml`, `mola_metric_maps`, `mola_pose_list`, `mo
 All MOLA systems are described in YAML. See `mola_demos/` for examples.
 Variable expansion and file includes are supported by `mola_yaml`.
 
+### Exposing a /tf tree: `mola::TransformTreeSource`
+
+`mola_kernel/interfaces/TransformTreeSource.h` lets a module publish its tree
+of coordinate frames (ROS `/tf`) to other MOLA modules without dragging ROS
+types into `mola_kernel`: `transform_tree(root)` returns the subtree below
+`root` with poses already resolved against it, as plain `mrpt::poses::CPose3D`.
+
+- Implemented by `Rosbag1Dataset`, `Rosbag2Dataset` and `BridgeROS2`, all of
+  which already own a `tf2::BufferCore`. **The filtering is done in the
+  source**, since it is what owns the buffer: a consumer never receives, nor
+  walks, the frames of unrelated subtrees.
+- No locking is needed around the walk: `tf2::BufferCore` guards its own
+  internals, so it may run while another thread feeds `/tf`.
+- Consumers detect it with `findService<mola::TransformTreeSource>()`, guarded
+  by `__has_include` (see `MOLA_HAS_TRANSFORM_TREE_SOURCE`) so downstream
+  packages keep building against an older `mola_kernel`.
+
 ### GUI Widget Creation (v2.6+)
 Use `GuiWidgetDescription` for backend-agnostic widget creation in `VizInterface`.
 Do not use direct MRPT GUI calls in modules — use the `VizInterface` abstraction.

--- a/agents.md
+++ b/agents.md
@@ -353,9 +353,7 @@ types into `mola_kernel`: `transform_tree(root)` returns the subtree below
   walks, the frames of unrelated subtrees.
 - No locking is needed around the walk: `tf2::BufferCore` guards its own
   internals, so it may run while another thread feeds `/tf`.
-- Consumers detect it with `findService<mola::TransformTreeSource>()`, guarded
-  by `__has_include` (see `MOLA_HAS_TRANSFORM_TREE_SOURCE`) so downstream
-  packages keep building against an older `mola_kernel`.
+- Consumers detect it with `findService<mola::TransformTreeSource>()`.
 
 ### GUI Widget Creation (v2.6+)
 Use `GuiWidgetDescription` for backend-agnostic widget creation in `VizInterface`.

--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -27,6 +27,12 @@
 #include <mola_kernel/interfaces/RawDataConsumer.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
 #include <mola_kernel/interfaces/Relocalization.h>
+#if __has_include(<mola_kernel/interfaces/TransformTreeSource.h>)
+#include <mola_kernel/interfaces/TransformTreeSource.h>
+/** Feature macro: mola_kernel provides mola::TransformTreeSource, so this
+ *  bridge exposes the live /tf tree to other MOLA modules. */
+#define MOLA_HAS_TRANSFORM_TREE_SOURCE 1
+#endif
 
 // MRPT:
 #include <mrpt/maps/COccupancyGridMap2D.h>
@@ -105,13 +111,27 @@ namespace mola
  *
  * \ingroup mola_bridge_ros2_grp
  */
-class BridgeROS2 : public RawDataSourceBase, public mola::RawDataConsumer
+class BridgeROS2 : public RawDataSourceBase,
+                   public mola::RawDataConsumer
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+    ,
+                   public mola::TransformTreeSource
+#endif
 {
   DEFINE_MRPT_OBJECT(BridgeROS2, mola)
 
  public:
   BridgeROS2();
   ~BridgeROS2() override;
+
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+  // Virtual interface of TransformTreeSource (see docs in base class)
+  std::optional<TransformTree> transform_tree(
+      const std::string&                            root,
+      const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const override;
+
+  std::string transform_tree_default_root() const override { return params_.base_link_frame; }
+#endif
 
   // disabled copy & move ctors:
   BridgeROS2(const BridgeROS2&)            = delete;

--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -27,12 +27,7 @@
 #include <mola_kernel/interfaces/RawDataConsumer.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
 #include <mola_kernel/interfaces/Relocalization.h>
-#if __has_include(<mola_kernel/interfaces/TransformTreeSource.h>)
 #include <mola_kernel/interfaces/TransformTreeSource.h>
-/** Feature macro: mola_kernel provides mola::TransformTreeSource, so this
- *  bridge exposes the live /tf tree to other MOLA modules. */
-#define MOLA_HAS_TRANSFORM_TREE_SOURCE 1
-#endif
 
 // MRPT:
 #include <mrpt/maps/COccupancyGridMap2D.h>
@@ -112,11 +107,8 @@ namespace mola
  * \ingroup mola_bridge_ros2_grp
  */
 class BridgeROS2 : public RawDataSourceBase,
-                   public mola::RawDataConsumer
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
-    ,
+                   public mola::RawDataConsumer,
                    public mola::TransformTreeSource
-#endif
 {
   DEFINE_MRPT_OBJECT(BridgeROS2, mola)
 
@@ -124,14 +116,12 @@ class BridgeROS2 : public RawDataSourceBase,
   BridgeROS2();
   ~BridgeROS2() override;
 
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
   // Virtual interface of TransformTreeSource (see docs in base class)
   std::optional<TransformTree> transform_tree(
       const std::string&                            root,
       const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const override;
 
   std::string transform_tree_default_root() const override { return params_.base_link_frame; }
-#endif
 
   // disabled copy & move ctors:
   BridgeROS2(const BridgeROS2&)            = delete;

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -71,6 +71,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
 #include <rclcpp/node.hpp>
+#include <set>
 #include <std_msgs/msg/float32.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -669,8 +670,9 @@ std::optional<mola::TransformTree> BridgeROS2::transform_tree(
   }
 
   // Build the parent -> children adjacency of the whole buffer first, so the
-  // subtree below 'root' can then be visited breadth-first (which gives the
-  // "parents before children" order the interface promises).
+  // subtree below 'root' can then be walked depth-first. Each node is emitted
+  // before its own children are queued, which is what gives the "parents
+  // before children" order the interface promises.
   std::vector<std::string> allFrames;
   tf_buffer_->_getFrameStrings(allFrames);
 
@@ -693,6 +695,10 @@ std::optional<mola::TransformTree> BridgeROS2::transform_tree(
   tree.timestamp = timestamp.value_or(mrpt::Clock::now());
   tree.nodes.push_back({root, {}, mrpt::poses::CPose3D::Identity()});
 
+  // 'visited' guards against a cyclic parent chain: tf2 reassigns a frame's
+  // parent on every setTransform(), so malformed input can produce one, and
+  // the walk would otherwise never terminate.
+  std::set<std::string>    visited = {root};
   std::vector<std::string> pending = {root};
   while (!pending.empty())
   {
@@ -731,6 +737,11 @@ std::optional<mola::TransformTree> BridgeROS2::transform_tree(
       {
         // A frame with no usable transform at this time is skipped, together
         // with its own subtree (it has no resolvable pose to draw it at).
+        continue;
+      }
+
+      if (!visited.insert(child).second)
+      {
         continue;
       }
 

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -657,7 +657,6 @@ void BridgeROS2::callbackOnPointCloud2(
 }
 #endif
 
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
 std::optional<mola::TransformTree> BridgeROS2::transform_tree(
     const std::string& root, const std::optional<mrpt::Clock::time_point>& timestamp) const
 {
@@ -752,7 +751,6 @@ std::optional<mola::TransformTree> BridgeROS2::transform_tree(
 
   return tree;
 }
-#endif
 
 bool BridgeROS2::waitForTransform(
     mrpt::poses::CPose3D& des, const std::string& frame, const std::string& referenceFrame)

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -656,6 +656,93 @@ void BridgeROS2::callbackOnPointCloud2(
 }
 #endif
 
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+std::optional<mola::TransformTree> BridgeROS2::transform_tree(
+    const std::string& root, const std::optional<mrpt::Clock::time_point>& timestamp) const
+{
+  // No external locking is needed here: tf2::BufferCore guards its own
+  // internals, so this walk may run concurrently with the TransformListener
+  // thread feeding /tf.
+  if (!tf_buffer_ || !tf_buffer_->_frameExists(root))
+  {
+    return {};
+  }
+
+  // Build the parent -> children adjacency of the whole buffer first, so the
+  // subtree below 'root' can then be visited breadth-first (which gives the
+  // "parents before children" order the interface promises).
+  std::vector<std::string> allFrames;
+  tf_buffer_->_getFrameStrings(allFrames);
+
+  const tf2::TimePoint queryTime =
+      timestamp ? tf2::TimePoint(timestamp->time_since_epoch()) : tf2::TimePoint();
+
+  std::map<std::string, std::vector<std::string>> children;
+  for (const auto& f : allFrames)
+  {
+    std::string parent;
+    if (tf_buffer_->_getParent(f, queryTime, parent) ||
+        tf_buffer_->_getParent(f, tf2::TimePoint(), parent))
+    {
+      children[parent].push_back(f);
+    }
+  }
+
+  mola::TransformTree tree;
+  tree.root      = root;
+  tree.timestamp = timestamp.value_or(mrpt::Clock::now());
+  tree.nodes.push_back({root, {}, mrpt::poses::CPose3D::Identity()});
+
+  std::vector<std::string> pending = {root};
+  while (!pending.empty())
+  {
+    const std::string frame = pending.back();
+    pending.pop_back();
+
+    const auto itChildren = children.find(frame);
+    if (itChildren == children.end())
+    {
+      continue;
+    }
+
+    for (const auto& child : itChildren->second)
+    {
+      mrpt::poses::CPose3D childInRoot;
+      try
+      {
+        // Prefer the requested time, but fall back to the latest available
+        // transform: a consumer asking about "now" can easily be slightly
+        // ahead of what the listener has received so far.
+        geometry_msgs::msg::TransformStamped tfMsg;
+        try
+        {
+          tfMsg = tf_buffer_->lookupTransform(root, child, queryTime);
+        }
+        catch (const tf2::TransformException&)
+        {
+          tfMsg = tf_buffer_->lookupTransform(root, child, tf2::TimePoint());
+        }
+
+        tf2::Transform t;
+        tf2::fromMsg(tfMsg.transform, t);
+        childInRoot = mrpt::ros2bridge::fromROS(t);
+      }
+      catch (const tf2::TransformException&)
+      {
+        // A frame with no usable transform at this time is skipped, together
+        // with its own subtree (it has no resolvable pose to draw it at).
+        continue;
+      }
+
+      tree.nodes.push_back({child, frame, childInRoot});
+      pending.push_back(child);
+    }
+  }
+
+  return tree;
+}
+#endif
+
 bool BridgeROS2::waitForTransform(
     mrpt::poses::CPose3D& des, const std::string& frame, const std::string& referenceFrame)
 {

--- a/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
+++ b/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
@@ -21,6 +21,12 @@
 #include <mola_kernel/interfaces/Dataset_UI.h>
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
+#if __has_include(<mola_kernel/interfaces/TransformTreeSource.h>)
+#include <mola_kernel/interfaces/TransformTreeSource.h>
+/** Feature macro: mola_kernel provides mola::TransformTreeSource, so this
+ *  dataset exposes its /tf tree to other MOLA modules. */
+#define MOLA_HAS_TRANSFORM_TREE_SOURCE 1
+#endif
 #include <mrpt/obs/CSensoryFrame.h>
 #include <mrpt/serialization/CArchive.h>
 
@@ -57,7 +63,13 @@ namespace mola
  *  robot frame.
  *
  * \ingroup mola_input_rosbag2_grp */
-class Rosbag2Dataset : public RawDataSourceBase, public OfflineDatasetSource, public Dataset_UI
+class Rosbag2Dataset : public RawDataSourceBase,
+                       public OfflineDatasetSource,
+                       public Dataset_UI
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+    ,
+                       public TransformTreeSource
+#endif
 {
   DEFINE_MRPT_OBJECT(Rosbag2Dataset, mola)
 
@@ -104,6 +116,15 @@ class Rosbag2Dataset : public RawDataSourceBase, public OfflineDatasetSource, pu
     auto lck       = mrpt::lockHelper(dataset_ui_mtx_);
     teleport_here_ = timestep;
   }
+
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+  // Virtual interface of TransformTreeSource (see docs in base class)
+  std::optional<TransformTree> transform_tree(
+      const std::string&                            root,
+      const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const override;
+
+  std::string transform_tree_default_root() const override { return base_link_frame_id_; }
+#endif
 
  protected:
   // See docs in base class

--- a/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
+++ b/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
@@ -21,12 +21,7 @@
 #include <mola_kernel/interfaces/Dataset_UI.h>
 #include <mola_kernel/interfaces/OfflineDatasetSource.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
-#if __has_include(<mola_kernel/interfaces/TransformTreeSource.h>)
 #include <mola_kernel/interfaces/TransformTreeSource.h>
-/** Feature macro: mola_kernel provides mola::TransformTreeSource, so this
- *  dataset exposes its /tf tree to other MOLA modules. */
-#define MOLA_HAS_TRANSFORM_TREE_SOURCE 1
-#endif
 #include <mrpt/obs/CSensoryFrame.h>
 #include <mrpt/serialization/CArchive.h>
 
@@ -65,11 +60,8 @@ namespace mola
  * \ingroup mola_input_rosbag2_grp */
 class Rosbag2Dataset : public RawDataSourceBase,
                        public OfflineDatasetSource,
-                       public Dataset_UI
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
-    ,
+                       public Dataset_UI,
                        public TransformTreeSource
-#endif
 {
   DEFINE_MRPT_OBJECT(Rosbag2Dataset, mola)
 
@@ -117,14 +109,12 @@ class Rosbag2Dataset : public RawDataSourceBase,
     teleport_here_ = timestep;
   }
 
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
   // Virtual interface of TransformTreeSource (see docs in base class)
   std::optional<TransformTree> transform_tree(
       const std::string&                            root,
       const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const override;
 
   std::string transform_tree_default_root() const override { return base_link_frame_id_; }
-#endif
 
  protected:
   // See docs in base class

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -958,7 +958,6 @@ mrpt::obs::CSensoryFrame::Ptr Rosbag2Dataset::datasetGetObservations(size_t time
   return read_ahead_.at(timestep)->obs;
 }
 
-#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
 std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
     const std::string& root, const std::optional<mrpt::Clock::time_point>& timestamp) const
 {
@@ -1052,7 +1051,6 @@ std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
 
   return tree;
 }
-#endif
 
 // TODO: Remove once this package is well available
 #if MRPT_ROS2_BRIDGE_VERSION < 0x030400

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -957,6 +957,92 @@ mrpt::obs::CSensoryFrame::Ptr Rosbag2Dataset::datasetGetObservations(size_t time
   return read_ahead_.at(timestep)->obs;
 }
 
+#if defined(MOLA_HAS_TRANSFORM_TREE_SOURCE)
+std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
+    const std::string& root, const std::optional<mrpt::Clock::time_point>& timestamp) const
+{
+  // No external locking is needed here: tf2::BufferCore guards its own
+  // internals, so this walk may run concurrently with the thread feeding /tf.
+  if (!tfBuffer_ || !tfBuffer_->_frameExists(root))
+  {
+    return {};
+  }
+
+  // Build the parent -> children adjacency of the whole buffer first, so the
+  // subtree below 'root' can then be visited breadth-first (which gives the
+  // "parents before children" order the interface promises).
+  std::vector<std::string> allFrames;
+  tfBuffer_->_getFrameStrings(allFrames);
+
+  const tf2::TimePoint queryTime =
+      timestamp ? tf2::TimePoint(timestamp->time_since_epoch()) : tf2::TimePoint();
+
+  std::map<std::string, std::vector<std::string>> children;
+  for (const auto& f : allFrames)
+  {
+    std::string parent;
+    if (tfBuffer_->_getParent(f, queryTime, parent) ||
+        tfBuffer_->_getParent(f, tf2::TimePoint(), parent))
+    {
+      children[parent].push_back(f);
+    }
+  }
+
+  mola::TransformTree tree;
+  tree.root      = root;
+  tree.timestamp = timestamp.value_or(mrpt::Clock::now());
+  tree.nodes.push_back({root, {}, mrpt::poses::CPose3D::Identity()});
+
+  std::vector<std::string> pending = {root};
+  while (!pending.empty())
+  {
+    const std::string frame = pending.back();
+    pending.pop_back();
+
+    const auto itChildren = children.find(frame);
+    if (itChildren == children.end())
+    {
+      continue;
+    }
+
+    for (const auto& child : itChildren->second)
+    {
+      mrpt::poses::CPose3D childInRoot;
+      try
+      {
+        // Prefer the requested time, but fall back to the latest available
+        // transform: /tf is streamed as the bag plays, so a consumer asking
+        // about "now" can easily be slightly ahead of the buffered data.
+        geometry_msgs::msg::TransformStamped tfMsg;
+        try
+        {
+          tfMsg = tfBuffer_->lookupTransform(root, child, queryTime);
+        }
+        catch (const tf2::TransformException&)
+        {
+          tfMsg = tfBuffer_->lookupTransform(root, child, tf2::TimePoint());
+        }
+
+        tf2::Transform t;
+        tf2::fromMsg(tfMsg.transform, t);
+        childInRoot = mrpt::ros2bridge::fromROS(t);
+      }
+      catch (const tf2::TransformException&)
+      {
+        // A frame with no usable transform at this time is skipped, together
+        // with its own subtree (it has no resolvable pose to draw it at).
+        continue;
+      }
+
+      tree.nodes.push_back({child, frame, childInRoot});
+      pending.push_back(child);
+    }
+  }
+
+  return tree;
+}
+#endif
+
 // TODO: Remove once this package is well available
 #if MRPT_ROS2_BRIDGE_VERSION < 0x030400
 bool Rosbag2Dataset::findOutSensorPose(

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -46,6 +46,7 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
 
+#include <set>
 #include <tf2/buffer_core.hpp>
 #include <tf2/convert.hpp>
 #include <tf2/exceptions.hpp>
@@ -969,8 +970,9 @@ std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
   }
 
   // Build the parent -> children adjacency of the whole buffer first, so the
-  // subtree below 'root' can then be visited breadth-first (which gives the
-  // "parents before children" order the interface promises).
+  // subtree below 'root' can then be walked depth-first. Each node is emitted
+  // before its own children are queued, which is what gives the "parents
+  // before children" order the interface promises.
   std::vector<std::string> allFrames;
   tfBuffer_->_getFrameStrings(allFrames);
 
@@ -993,6 +995,10 @@ std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
   tree.timestamp = timestamp.value_or(mrpt::Clock::now());
   tree.nodes.push_back({root, {}, mrpt::poses::CPose3D::Identity()});
 
+  // 'visited' guards against a cyclic parent chain: tf2 reassigns a frame's
+  // parent on every setTransform(), so malformed input can produce one, and
+  // the walk would otherwise never terminate.
+  std::set<std::string>    visited = {root};
   std::vector<std::string> pending = {root};
   while (!pending.empty())
   {
@@ -1031,6 +1037,11 @@ std::optional<mola::TransformTree> Rosbag2Dataset::transform_tree(
       {
         // A frame with no usable transform at this time is skipped, together
         // with its own subtree (it has no resolvable pose to draw it at).
+        continue;
+      }
+
+      if (!visited.insert(child).second)
+      {
         continue;
       }
 

--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIB_SRCS
   src/interfaces/NavStateFilter.cpp
   src/interfaces/RawDataSourceBase.cpp
   src/interfaces/SharedKeyframeMap.cpp
+  src/interfaces/TransformTreeSource.cpp
   src/interfaces/VizInterface.cpp
   src/utils/Synchronizer.cpp
   src/MinimalModuleContainer.cpp
@@ -56,6 +57,7 @@ set(LIB_PUBLIC_HDRS
   include/mola_kernel/interfaces/RawDataSourceBase.h
   include/mola_kernel/interfaces/Relocalization.h
   include/mola_kernel/interfaces/SharedKeyframeMap.h
+  include/mola_kernel/interfaces/TransformTreeSource.h
   include/mola_kernel/interfaces/VizInterface.h
   include/mola_kernel/MinimalModuleContainer.h
   include/mola_kernel/pretty_print_exception.h

--- a/mola_kernel/include/mola_kernel/interfaces/TransformTreeSource.h
+++ b/mola_kernel/include/mola_kernel/interfaces/TransformTreeSource.h
@@ -1,0 +1,108 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   TransformTreeSource.h
+ * @brief  Virtual interface for modules exposing a tree of coordinate frames.
+ * @author Jose Luis Blanco Claraco
+ * @date   2026
+ */
+#pragma once
+
+#include <mrpt/core/Clock.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mola
+{
+/** One coordinate frame within a TransformTree. */
+struct TransformTreeNode
+{
+  TransformTreeNode() = default;
+
+  /** This frame's name, e.g. "LF_FOOT". */
+  std::string frame;
+
+  /** Name of this frame's parent. Empty for the tree root only. */
+  std::string parent;
+
+  /** Pose of this frame with respect to the tree root. */
+  mrpt::poses::CPose3D pose_in_root;
+};
+
+/** A snapshot of all coordinate frames hanging below a given root frame,
+ *  with their poses already resolved with respect to that root. */
+struct TransformTree
+{
+  TransformTree() = default;
+
+  /** The frame all poses in `nodes` are relative to. */
+  std::string root;
+
+  /** The time the poses were looked up at. */
+  mrpt::Clock::time_point timestamp;
+
+  /** The root itself is included, as the first entry, with an identity pose
+   *  and an empty `parent`. Parents always appear before their children. */
+  std::vector<TransformTreeNode> nodes;
+};
+
+/** Mixin interface for modules that track a tree of coordinate frames (ROS
+ *  "/tf" and "/tf_static", or an equivalent), and can expose snapshots of it
+ *  to other MOLA modules: dataset readers, live sensor bridges, etc.
+ *
+ *  Consumers detect it the same way they detect a `NavStateFilter`
+ *  (`ExecutableBase::findService<TransformTreeSource>()`). Note that this
+ *  interface is deliberately free of any ROS/tf2 type, so `mola_kernel` stays
+ *  independent of ROS.
+ *
+ *  Implementations are required to be thread-safe.
+ *
+ *  \ingroup mola_kernel_interfaces_grp
+ */
+class TransformTreeSource
+{
+ public:
+  TransformTreeSource()                                      = default;
+  TransformTreeSource(const TransformTreeSource&)            = default;
+  TransformTreeSource& operator=(const TransformTreeSource&) = default;
+  TransformTreeSource(TransformTreeSource&&)                 = default;
+  TransformTreeSource& operator=(TransformTreeSource&&)      = default;
+  virtual ~TransformTreeSource();
+
+  /** Returns all frames reachable *below* `root` (that is, the subtree it is
+   *  the root of), with their poses resolved with respect to it.
+   *
+   *  Filtering happens here, in the source, since it is what owns the
+   *  underlying transform buffer: a consumer interested in a robot's joints
+   *  never has to receive, nor walk, the frames of unrelated subtrees.
+   *
+   *  \param root      The frame to use as the subtree root, e.g. "base_link".
+   *  \param timestamp The time to look the transforms up at. If not provided,
+   *                   or if no data is buffered for it, the latest available
+   *                   transform of each frame is used instead.
+   *  \return The subtree, or `std::nullopt` if `root` is not a known frame.
+   */
+  virtual std::optional<TransformTree> transform_tree(
+      const std::string&                            root,
+      const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const = 0;
+
+  /** Returns the frame this source considers the robot's body frame (its
+   *  `base_link_frame_id` parameter, or equivalent), so consumers can default
+   *  to it instead of hardcoding a name. Empty if the source has none. */
+  virtual std::string transform_tree_default_root() const { return {}; }
+};
+
+}  // namespace mola

--- a/mola_kernel/src/interfaces/TransformTreeSource.cpp
+++ b/mola_kernel/src/interfaces/TransformTreeSource.cpp
@@ -1,0 +1,15 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+#include <mola_kernel/interfaces/TransformTreeSource.h>
+
+mola::TransformTreeSource::~TransformTreeSource() = default;


### PR DESCRIPTION
Adds a `mola_kernel` interface letting a data source publish its tree of coordinate frames, so consumers can use it — the first one being an opt-in "draw the robot's joints as it moves" view in `mola_lidar_odometry` ([PR there](https://github.com/MOLAorg/mola_lidar_odometry/pull/125)).

### The interface

`mola_kernel/interfaces/TransformTreeSource.h`:

```cpp
virtual std::optional<TransformTree> transform_tree(
    const std::string& root,
    const std::optional<mrpt::Clock::time_point>& timestamp = std::nullopt) const = 0;
```

`TransformTree` is plain data: a flat, parents-before-children list of `{frame, parent, pose_in_root}`, with `pose_in_root` an `mrpt::poses::CPose3D`. **No ROS/tf2 type crosses the interface**, so `mola_kernel` stays ROS-independent.

Two design points worth calling out:

- **Filtering happens in the source, not the consumer.** The source is what owns the `tf2::BufferCore`, so it can walk only the requested subtree. A consumer interested in a robot's joints never receives, nor walks, the frames of unrelated subtrees. (On the GrandTour dataset used for testing, the buffer holds 81 frames.)
- **No locking is added around the walk.** `tf2::BufferCore` guards its own internals (`frame_mutex_`, taken by `lookupTransform`, `_getParent` and `_getFrameStrings` alike) — which is also precisely what already lets `BridgeROS2`'s `TransformListener` feed the buffer from its own thread while the main thread reads it.

### Implementations in this repo

`Rosbag2Dataset` and `BridgeROS2`. (`Rosbag1Dataset` lives in its own repo: [mola_input_rosbag1#PR](https://github.com/MOLAorg/mola_input_rosbag1/pulls).)

### Testing

End-to-end through `mola_lidar_odometry` on the GrandTour `2024-10-01-11-29-55` mission (ANYmal-D quadruped, ROS 1 bags): the tree grows from 37 frames (static-only, at startup) to all 81 once the 100 Hz joint transforms are buffered, and renders correctly with links and names. Full workspace builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving timestamped transform-tree snapshots from ROS 2 bridges and rosbag datasets.
  * Transform trees can be requested from a selected root frame, with `base_link` as the default root.
  * Added handling for missing, invalid, or unavailable transforms, including fallback to the latest available data.

* **Documentation**
  * Documented the transform-tree interface, filtering behavior, thread-safety, and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->