### PR TITLE
fix(mola_metric_maps): don't require nanoflann>=1.5.1 for KeyframePointCloudMap covariances

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -231,6 +231,15 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   voxel-decimate step) is the most expensive part of `regroupKeyframes()` and is
   parallelized across clusters with TBB (`tbb::parallel_for`, gated by
   `MOLA_METRIC_MAPS_USE_TBB`, falling back to a serial loop when TBB is absent).
+- `KeyframePointCloudMap::TCreationOptions::max_distance_for_cov` bounds the per-point
+  covariance neighborhood, which maps onto nanoflann's radius-limited kNN (RKNN) via the
+  optional max-distance argument of MRPT's `kdTreeNClosestPoint3DIdx()`. That overload
+  throws at runtime on nanoflann < 1.5.1 (still the case on Ubuntu jammy / Humble), so
+  `computeCovariancesAndDensity()` guards it with `MOLA_MM_HAS_RKNN_SEARCH`
+  (`NANOFLANN_VERSION >= 0x151`) and otherwise runs a plain kNN truncated at the same
+  radius, which yields exactly the same neighbor set since results come back sorted.
+  The `NANOFLANN_VERSION` that decides is the one MRPT's own templates were built
+  against, picked up transitively from the MRPT headers: do not include nanoflann there.
 - `KeyframePointCloudMap::TCreationOptions::approximate_cov` (default `false`): for
   `nn_search_cov2cov()` (used by `mp2p_icp::Matcher_Cov2Cov`, i.e. GICP-style pipelines).
   When `true`, `icp_get_prepared_as_global()` skips assembling the merged, multi-keyframe

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -41,8 +41,10 @@
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 #include <mrpt/version.h>  // For MRPT_VERSION
 
+#include <algorithm>  // std::lower_bound
 #include <cmath>
 #include <cstdint>
+#include <iterator>  // std::distance
 #include <numeric>  // std::accumulate
 #include <sstream>
 #include <unordered_set>
@@ -54,6 +56,20 @@
 
 #include <atomic>
 #include <type_traits>
+
+// Radius-limited kNN (RKNN), which MRPT exposes as the optional
+// maximum-search-distance argument of kdTreeNClosestPoint3DIdx(), needs
+// nanoflann >= 1.5.1; older versions throw at runtime from that overload.
+// NANOFLANN_VERSION comes in transitively from the MRPT points-map headers
+// above, i.e. it describes exactly the copy MRPT's own templates were built
+// against, which is the one that decides here. (Do NOT include nanoflann
+// directly: see the note at the top of IncrementalKDTree.cpp.)
+//
+// The version varies across ROS distributions, so this cannot be assumed:
+// Ubuntu jammy still ships 1.4.2.
+#if defined(NANOFLANN_VERSION) && NANOFLANN_VERSION >= 0x151
+#define MOLA_MM_HAS_RKNN_SEARCH 1
+#endif
 
 #if defined(MOLA_MM_HAS_ROTATE_VIEW_HEADER)
 // Feature detection for mp2p_icp::rotateViewDirectionFields(): the function
@@ -2797,9 +2813,26 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
         std::vector<size_t> k_indices;
         std::vector<float>  k_sq_distances;
 
+#if defined(MOLA_MM_HAS_RKNN_SEARCH)
         pointcloud_->kdTreeNClosestPoint3DIdx(
             xs[i], ys[i], zs[i], K_CORRESPONDENCES, k_indices, k_sq_distances,
             MAX_DIST_SQR_FOR_COV);
+#else
+    // Equivalent to the RKNN search above: a plain kNN returns its
+    // neighbors sorted by ascending squared distance, so cutting the
+    // result at the first entry that reaches the limit leaves exactly the
+    // ones an RKNN search would have accepted (it keeps distances strictly
+    // below the limit too). The only cost is visiting all K neighbors
+    // before dropping the far ones.
+    pointcloud_->kdTreeNClosestPoint3DIdx(
+        xs[i], ys[i], zs[i], K_CORRESPONDENCES, k_indices, k_sq_distances);
+
+    const auto within_radius = static_cast<size_t>(std::distance(
+        k_sq_distances.begin(),
+        std::lower_bound(k_sq_distances.begin(), k_sq_distances.end(), MAX_DIST_SQR_FOR_COV)));
+    k_indices.resize(within_radius);
+    k_sq_distances.resize(within_radius);
+#endif
 
         // Too few neighbors actually found: a plane/line fit from this few
         // samples is unreliable, so fall back to an isotropic covariance


### PR DESCRIPTION
## Problem

`mola::KeyframePointCloudMap` is currently **unusable on Humble**: every insertion throws on the first scan.

`TCreationOptions::max_distance_for_cov` (default `1.0`, so this is always on) makes `computeCovariancesAndDensity()` pass MRPT's optional max-search-distance argument to `kdTreeNClosestPoint3DIdx()`, which selects nanoflann's radius-limited kNN (RKNN). MRPT compiles that path out below nanoflann 1.5.1, leaving a bare throw:

```
==== MRPT exception ====
Message:  RKNN search requires nanoflann>=1.5.1
Location: mrpt/math/KDTreeCapable.h:829
  [3] mola::KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity()
  [4] mola::KeyframePointCloudMap::internal_insertObservation(...)
```

Ubuntu jammy ships nanoflann **1.4.2**, so this fires on Humble and nowhere else (noble and later are on ≥ 1.5).

Observed today:

- **This package's own tests**, on the buildfarm — [`Hdev__mola__ubuntu_jammy_amd64` #489](https://build.ros2.org/job/Hdev__mola__ubuntu_jammy_amd64/489/), building `develop` at `fef02c75`:
  ```
  The following tests FAILED:
     12 - run_test-mola_metric_maps_keyframemap (Failed)
     14 - run_test-mola_metric_maps_options_ini_io (Failed)
  ```
- **Downstream**: `mola_lidar_odometry` loses its local map on the first LiDAR frame, latches into its fatal-error state ("Discarding incoming observations") and produces an empty trajectory, failing 6 dataset tests in its GitHub CI (humble job only).

### Why it appeared now

Bisecting the same buildfarm job: #455 and #465 pass, #489 fails. Before `mrpt_ros` 2.15.20, `ros-humble-mrpt-libbase` installed MRPT's **vendored nanoflann 1.9.0** and `libnanoflann-dev` was not in the dependency closure at all, so RKNN compiled fine. 2.15.20 disabled `MRPT_INSTALL_EMBEDDED_nanoflann` and added `<depend>nanoflann</depend>`, a rosdep key that resolves to `libnanoflann-dev` on Ubuntu. On jammy that took the effective nanoflann **backwards, 1.9.0 → 1.4.2**.

So this is not really a MOLA regression, but MOLA should not depend on that detail of how MRPT happens to be packaged on a given distro.

## Fix

Guard the RKNN call with `MOLA_MM_HAS_RKNN_SEARCH` (`NANOFLANN_VERSION >= 0x151`) and fall back to a plain kNN truncated at the same radius.

The two are exactly equivalent: a kNN result comes back sorted by ascending squared distance, so cutting it at the first entry that reaches the limit leaves precisely the neighbors an RKNN search would have accepted (including its strictly-below-the-limit boundary). The only cost is visiting all K neighbors before dropping the far ones — negligible at the default K=20.

`NANOFLANN_VERSION` is taken from the transitive include via the MRPT points-map headers, which is deliberately the copy MRPT's own templates were built against, i.e. the one that actually decides. nanoflann is **not** included directly here, per the ODR note at the top of `IncrementalKDTree.cpp`.

This is the same treatment `mola::IncrementalPointCloud` already gets for its own nanoflann floor, except that here the feature degrades to an exact equivalent rather than to a stub.

## Verification

Both paths built against the same nanoflann (1.9.0) and run over a fixed 4000-point pseudo-random cloud with `max_distance_for_cov` tight enough to genuinely truncate the k=20 neighborhood — 22 points fall below `min_correspondences_for_cov` and take the isotropic fallback, so the radius cutoff and its boundary are exercised.

The resulting `cov_inv` values from `nn_search_cov2cov()` are **identical to the last printed digit** for all 4000 pairings, once the TBB-dependent pairing order is canonicalized (that order is nondeterministic run to run even for a single build).

The full 14-test package suite passes with either path compiled.

## Notes

Once released, this unblocks Humble regardless of what MRPT packaging does. Separately worth fixing on the MRPT side so Humble gets a modern nanoflann back rather than just degrading gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved covariance calculations for keyframe point clouds by restricting neighborhood searches to the configured distance threshold.
  * Results now consistently exclude points outside the selected radius.
  * Added compatibility handling so bounded neighborhood searches work consistently across supported search-library versions.
  * Improved the reliability and consistency of point-cloud analysis when calculating local covariance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->