### PR TITLE
Give nn_search_cov2cov() a canonical pairing order

### DIFF
--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -1091,6 +1091,9 @@ void KeyframePointCloudMap::nn_search_cov2cov(
                      : -2.0f;  // sentinel: never reached when filter is disabled
 
 #if defined(MOLA_METRIC_MAPS_USE_TBB)
+  // Pairings are appended, so only the ones added below get reordered:
+  const size_t firstNewPairing = outPairings.size();
+
   tbb::enumerable_thread_specific<mp2p_icp::MatchedPointWithCovList> tls;
 
   tbb::parallel_for(
@@ -1170,6 +1173,15 @@ void KeyframePointCloudMap::nn_search_cov2cov(
         outPairings.end(), std::make_move_iterator(localVec.begin()),
         std::make_move_iterator(localVec.end()));
   }
+
+  // Thread-local vectors are visited in an unspecified order, so restore the
+  // order the sequential path produces. Each local point yields at most one
+  // pairing, so its index is a unique key. The pairing list order reaches the
+  // solver's summation order, and from there the optimized pose.
+  std::sort(
+      outPairings.begin() + firstNewPairing, outPairings.end(),
+      [](const mp2p_icp::point_with_cov_pair_t& a, const mp2p_icp::point_with_cov_pair_t& b)
+      { return a.local_idx < b.local_idx; });
 #endif
 
   // Recover original:
@@ -1300,6 +1312,9 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
   }
 
 #if defined(MOLA_METRIC_MAPS_USE_TBB)
+  // Pairings are appended, so only the ones added below get reordered:
+  const size_t firstNewPairing = outPairings.size();
+
   tbb::enumerable_thread_specific<mp2p_icp::MatchedPointWithCovList> tls;
 
   tbb::parallel_for(
@@ -1421,6 +1436,15 @@ void KeyframePointCloudMap::nn_search_cov2cov_approximate(
         outPairings.end(), std::make_move_iterator(localVec.begin()),
         std::make_move_iterator(localVec.end()));
   }
+
+  // Thread-local vectors are visited in an unspecified order, so restore the
+  // order the sequential path produces. Each local point yields at most one
+  // pairing, so its index is a unique key. The pairing list order reaches the
+  // solver's summation order, and from there the optimized pose.
+  std::sort(
+      outPairings.begin() + firstNewPairing, outPairings.end(),
+      [](const mp2p_icp::point_with_cov_pair_t& a, const mp2p_icp::point_with_cov_pair_t& b)
+      { return a.local_idx < b.local_idx; });
 #endif
 
   if (debugMatchStats)

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -331,6 +331,71 @@ void test_pairing_indices_consistent()
   }
 }
 
+// ── 9b. Pairings come back in a canonical order, every run ────────────────
+// The parallel path accumulates into thread-local vectors and merges them, and
+// the merge order is unspecified. The resulting permutation reaches the
+// solver's summation order and therefore the optimized pose, so it must not
+// depend on which workers happened to run. Ascending local_idx is the order the
+// sequential path produces, so asserting it also pins the parallel path to the
+// sequential result.
+void test_pairing_order_is_canonical()
+{
+  constexpr float kDz      = 0.02f;
+  constexpr float kMaxDist = 1.0f;
+
+  // Big enough that TBB really splits the range across workers: on a small
+  // cloud the defect this guards against does not show up at all.
+  constexpr size_t kNx = 200, kNy = 200;
+
+  const auto global_pts = makeGridPts(0.f, 0.f, 0.f, 1.f, kNx, kNy);
+  const auto local_pts  = makeGridPts(kDz, 0.f, 0.f, 1.f, kNx, kNy);
+
+  for (const bool approximate : {false, true})
+  {
+    auto global_m = makeMapFromCloud(makeCloudWithViews(global_pts));
+    global_m.creationOptions.use_view_direction_filter = false;
+    global_m.creationOptions.approximate_cov           = approximate;
+    global_m.icp_get_prepared_as_global(mrpt::poses::CPose3D::Identity());
+
+    std::vector<std::pair<uint32_t, uint32_t>> reference;
+
+    for (int rep = 0; rep < 5; ++rep)
+    {
+      auto local_m = makeMapFromCloud(makeCloudWithViews(local_pts));
+
+      mp2p_icp::MatchedPointWithCovList pairings;
+      global_m.nn_search_cov2cov(local_m, mrpt::poses::CPose3D::Identity(), kMaxDist, pairings);
+
+      ASSERT_(!pairings.empty());
+
+      // Each local point yields at most one pairing, so the key is unique and
+      // the order is strict:
+      for (size_t i = 1; i < pairings.size(); ++i)
+      {
+        ASSERTMSG_(
+            pairings[i - 1].local_idx < pairings[i].local_idx,
+            "Pairings are not in canonical (ascending local_idx) order");
+      }
+
+      std::vector<std::pair<uint32_t, uint32_t>> idx;
+      idx.reserve(pairings.size());
+      for (const auto& p : pairings)
+      {
+        idx.emplace_back(p.local_idx, p.global_idx);
+      }
+
+      if (rep == 0)
+      {
+        reference = std::move(idx);
+      }
+      else
+      {
+        ASSERTMSG_(idx == reference, "The pairing list changed between identical runs");
+      }
+    }
+  }
+}
+
 // ── 10. Points beyond max_search_distance are never paired ────────────────
 void test_distance_threshold_respected()
 {
@@ -1465,6 +1530,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     std::cout << "test_pairing_indices_consistent ...\n";
     test_pairing_indices_consistent();
+
+    std::cout << "test_pairing_order_is_canonical ...\n";
+    test_pairing_order_is_canonical();
 
     std::cout << "test_distance_threshold_respected ...\n";
     test_distance_threshold_respected();


### PR DESCRIPTION
## The problem

The parallel path in `nn_search_cov2cov()` (and `nn_search_cov2cov_approximate()`) accumulates correspondences into a `tbb::enumerable_thread_specific` and merges it by iteration. That iteration order is unspecified — it depends on which worker threads happened to take part.

The permutation is not cosmetic: it reaches the solver, which accumulates the normal equations over the pairing list **in order**, so the floating-point summation order (and hence the optimized pose, at ULP level) becomes a function of thread scheduling rather than of the input.

## Evidence

`oxford-spires` `keble-college-03`, offline CLI, host under load. Two fingerprints over the pairing list at the first ICP call, both over raw IEEE-754 bit patterns:

| | runs | distinct values |
|---|---|---|
| order-independent hash (XOR of contents) | 12 | **1** |
| order-dependent hash (FNV-1a in list order) | 8 | **8** |

So the *set* of correspondences was already a pure function of the input; only the *order* was not. With this change the order hash collapses to a single value across 12 runs, and so does `H(0,0)` at that call.

## Why sort by `local_idx`

That is exactly what the sequential path produces: each local point yields at most one pairing, and it appends them in index order. So the parallel and sequential outputs agree by construction rather than by coincidence, and the key is unique, so the order is total.

## Scope, honestly

On this sequence the end-to-end trajectory was already stable without this change (after a separate fix in `mola_state_estimation`), so this is not a "fixes a visible bug" PR — it closes a measured nondeterminism that reaches the solver and can propagate, rather than one currently observed to. The XOR-vs-FNV measurement above is what makes it concrete rather than theoretical.

## Test

`test_pairing_order_is_canonical` covers both the exact and approximate variants, on a cloud large enough (200x200) that TBB really splits the range. Without the change it fails with:

```
Pairings are not in canonical (ascending local_idx) order
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored consistent pairing order during exact and approximate covariance matching.
  * Improved deterministic solver behavior by ensuring newly generated pairings are ordered by their local index.

* **Tests**
  * Added coverage verifying canonical pairing order and repeatable results across matching runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->