### PR TITLE
Give IncrementalPointCloud::nn_search_cov2cov() a canonical pairing order

### DIFF
--- a/mola_metric_maps/src/IncrementalPointCloud.cpp
+++ b/mola_metric_maps/src/IncrementalPointCloud.cpp
@@ -1023,6 +1023,22 @@ void IncrementalPointCloud::nn_search_cov2cov(
 
   if (matches.empty()) return;
 
+  // Give the pairing list a canonical order. Pass 3 below emits `outPairings`
+  // in this order, and that order reaches the solver's summation order and
+  // therefore the optimized pose, so it must not depend on which worker threads
+  // happened to take part. Each local point yields at most one match, so its
+  // slot is a unique key and the order is total.
+  //
+  // Unlike the equivalent in KeyframePointCloudMap, this sorts both the
+  // parallel and the sequential path, because neither was canonical here:
+  // `snapshotLiveIndices()` walks the k-d tree depth-first, so `localLive` is
+  // in tree-topology order rather than in slot order. That also makes the two
+  // paths agree by construction, and makes the result independent of the tree
+  // shape a rebuild happened to leave behind.
+  std::sort(
+      matches.begin(), matches.end(),
+      [](const Match& a, const Match& b) { return a.local_slot < b.local_slot; });
+
   // --- Pass 2: covariances of the matched global points -------------------
   // Deduplicated, so no two threads write to the same cache entry.
   std::vector<uint32_t> globalSlots;

--- a/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_incrementalpointcloud.cpp
@@ -389,6 +389,63 @@ void test_cov2cov()
 }
 
 // -------------------------------------------------------------------------
+// Pairings must come back in a canonical order, every run. The parallel path
+// accumulates into thread-local vectors and merges them in an unspecified
+// order, and the snapshot of live local points is in k-d tree traversal order
+// rather than in slot order, so neither path was canonical on its own. The
+// resulting permutation reaches the solver's summation order and therefore the
+// optimized pose. Ascending local_idx is asserted because it is a total order
+// on a unique key, which also pins the parallel and sequential paths together.
+void test_pairing_order_is_canonical()
+{
+  // Big enough that TBB really splits the range across workers: on a small
+  // cloud the defect this guards against does not show up at all.
+  auto surface = mrpt::maps::CSimplePointsMap::Create();
+  for (int ix = -100; ix <= 100; ix++)
+  {
+    for (int iy = -100; iy <= 100; iy++)
+    {
+      surface->insertPointFast(
+          static_cast<float>(ix * 0.1), static_cast<float>(iy * 0.1),
+          static_cast<float>(rng.drawGaussian1D(0, 0.005)));
+    }
+  }
+  surface->mark_as_modified();
+
+  mola::IncrementalPointCloud global;
+  insertPoints(global, *surface);
+
+  mola::IncrementalPointCloud local;
+  insertPoints(local, *surface);
+
+  // Tombstones make the tree's traversal order diverge from slot order, which
+  // is the case the sort has to survive:
+  local.keepOnlyPointsNear({0, 0, 0}, 8.0);
+
+  std::vector<uint32_t> reference;
+  for (int pass = 0; pass < 4; pass++)
+  {
+    mp2p_icp::MatchedPointWithCovList pairings;
+    global.nn_search_cov2cov(
+        local, mrpt::poses::CPose3D::Identity(), 0.5f /*max search distance*/, pairings);
+    ASSERT_(!pairings.empty());
+
+    std::vector<uint32_t> order;
+    order.reserve(pairings.size());
+    for (const auto& p : pairings) order.push_back(static_cast<uint32_t>(p.local_idx));
+
+    ASSERTMSG_(
+        std::is_sorted(order.begin(), order.end()),
+        "Pairings are not in canonical (ascending local_idx) order");
+
+    if (pass == 0)
+      reference = order;
+    else
+      ASSERTMSG_(order == reference, "Pairing order differs between identical calls");
+  }
+}
+
+// -------------------------------------------------------------------------
 // Compares NN query results between two maps expected to hold the same set of
 // points (used by the k-d tree baking tests below).
 void assertSameNNResults(
@@ -775,6 +832,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_bounded_memory_under_churn();
     test_serialization_and_copy();
     test_cov2cov();
+    test_pairing_order_is_canonical();
     test_kdtree_bake_roundtrip_memory();
     test_kdtree_bake_roundtrip_file();
     test_kdtree_bake_then_clear_and_reinsert();


### PR DESCRIPTION
Completes the pairing-order determinism work started in #191 (`bfe6cb2e`), which fixed `KeyframePointCloudMap` only. `mola::IncrementalPointCloud` has the same defect and was left behind, so any pipeline selecting that map class via `MOLA_LOCALMAP_CLASS` still produced a run-dependent pairing order.

### The defect

The parallel path accumulates correspondences into a `tbb::enumerable_thread_specific` and merges it by iteration, whose order is unspecified: it depends on which worker threads happened to take part. That order reaches the solver's summation order over the normal equations, and from there the optimized pose.

### Why this class needs more than the keyframe map did

In `KeyframePointCloudMap` the sequential path already emits in ascending `local_idx`, so #191 only had to pin the parallel path to it.

Here **neither path was canonical**. The live local points come from `snapshotLiveIndices()`, which is a depth-first walk of the k-d tree (`nanoflann.hpp`), so they arrive in tree-topology order rather than slot order. Tombstones and rebuilds change that shape, so with `async_rebuild` enabled the pairing order varied between runs *even single-threaded*.

The sort is therefore applied to the shared intermediate match list, before the pairings are assembled, rather than inside the `#if MOLA_METRIC_MAPS_USE_TBB` block. That pins both paths to the same order and makes the result independent of whatever tree shape a rebuild left behind. Two sibling call sites in this same file already sort that snapshot for the same reason.

Sorting the intermediate list also keeps the comparison on an 8-byte key instead of a full pairing (3x3 matrix included), and gives the assembly pass ascending access into the coordinate and covariance buffers instead of scattered access.

Each local point yields at most one match, so its slot is a unique key and the resulting order is total.

### Test

`test_pairing_order_is_canonical` asserts ascending `local_idx` and identical order across repeated calls, over a cloud that has had `keepOnlyPointsNear()` applied so tombstones really do push tree order away from slot order, and large enough (201x201) that TBB splits the range across workers -- on a small cloud the defect does not appear at all.

Verified to fail without the source change:

```
Message:  Pairings are not in canonical (ascending local_idx) order
Location: tests/test-mola_metric_maps_incrementalpointcloud.cpp:437
```

Full `mola_metric_maps` suite passes with the change, 9/9 including the incremental-map stress test.

### Note on what this does and does not fix

This makes the pairing *order* a function of the data. It does not make the pairing *set* deterministic on this map class: the background k-d tree rebuild is a separate, by-design source of variation, since the `nn_*` query paths never join that worker. Reproducible runs on this map class still need `MOLA_INCREMENTAL_MAP_ASYNC_REBUILD=false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pairings generated from point-cloud searches now follow a consistent, predictable order.
  * Results remain stable across repeated searches and different processing paths.

* **Tests**
  * Added coverage to verify canonical pairing order, including point clouds containing removed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->