### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,4 +156,4 @@ Contributions require acceptance of the Contributor License Agreement (CLA).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=MOLAorg/mola&type=Date)](https://star-history.com/#MOLAorg/mola&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=MOLAorg/mola&type=Date)](https://star-history.dera.page/#MOLAorg/mola&Date)


### PR DESCRIPTION
The README star history chart is currently broken because GitHub's stargazer API is no longer available, so the chart does not render. This switches it to a working mirror so the chart displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link and image source to use the new hosting address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->