### PR TITLE
NDT: report every candidate cell plane, not only the closest one

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -225,6 +225,12 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   GCC in favor of the system entry. Keep that file free of MRPT headers, and
   keep nanoflann out of the public headers.
 - All support MRPT serialization
+- `NDT` implements `mp2p_icp::NearestPlaneCapable` twice over: `nn_search_pt2pl()`
+  returns the single closest cell plane, and `nn_visit_pt2pl_candidates()` reports
+  every cell plane in the same search window, for matchers that combine candidates
+  rather than select one (`mp2p_icp::Matcher_NDT_Blend`). Both walk the voxels
+  through the shared `visitPt2PlSearchCells()` helper, so they can never disagree
+  about which cells a query examines.
 - `mola::OptionsCapable` (`include/mola_metric_maps/OptionsCapable.h`): mixin interface
   implemented by `NDT`, `HashedVoxelPointCloud`, `SparseVoxelPointCloud`, `SparseTreesPointCloud`,
   and `KeyframePointCloudMap` (i.e. all map classes defined in this library; basic `mrpt::maps`

--- a/agents.md
+++ b/agents.md
@@ -230,7 +230,12 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
   every cell plane in the same search window, for matchers that combine candidates
   rather than select one (`mp2p_icp::Matcher_NDT_Blend`). Both walk the voxels
   through the shared `visitPt2PlSearchCells()` helper, so they can never disagree
-  about which cells a query examines.
+  about which cells a query examines. `nn_visit_pt2pl_candidates()`'s declaration
+  and definition are guarded by `#if defined(MP2P_ICP_HAS_NN_VISIT_PT2PL_CANDIDATES)`
+  (a self-describing macro `mp2p_icp` defines in `NearestPlaneCapable.h` once the
+  method exists there): the ROS binary repos still ship an older mp2p_icp without
+  it, and `NearestPlaneCapable`'s default implementation (best-candidate only)
+  keeps `NDT` usable there.
 - `mola::OptionsCapable` (`include/mola_metric_maps/OptionsCapable.h`): mixin interface
   implemented by `NDT`, `HashedVoxelPointCloud`, `SparseVoxelPointCloud`, `SparseTreesPointCloud`,
   and `KeyframePointCloudMap` (i.e. all map classes defined in this library; basic `mrpt::maps`

--- a/mola_metric_maps/include/mola_metric_maps/NDT.h
+++ b/mola_metric_maps/include/mola_metric_maps/NDT.h
@@ -356,6 +356,40 @@ class NDT : public mrpt::maps::CMetricMap,
    *  @{ */
   NearestPlaneResult nn_search_pt2pl(
       const mrpt::math::TPoint3Df& point, const float max_search_distance) const override;
+
+  void nn_visit_pt2pl_candidates(
+      const mrpt::math::TPoint3Df& point, float max_search_distance,
+      const plane_candidate_visitor_t& visitor) const override;
+
+  /** Visits every existing voxel that a nearest-plane query at `point` has to
+   *  examine. Shared by the two searches above so that they always walk the
+   *  same voxels, in the same order.
+   */
+  template <typename Functor>
+  void visitPt2PlSearchCells(
+      const mrpt::math::TPoint3Df& point, const float max_search_distance, Functor f) const
+  {
+    const int margin = static_cast<int>(std::ceil(max_search_distance * voxel_size_inv_));
+
+    const global_index3d_t idxs0 = coordToGlobalIdx(point) - global_index3d_t(margin, margin, margin);
+    const global_index3d_t idxs1 = coordToGlobalIdx(point) + global_index3d_t(margin, margin, margin);
+
+    for (int32_t cx = idxs0.cx; cx <= idxs1.cx; cx++)
+    {
+      for (int32_t cy = idxs0.cy; cy <= idxs1.cy; cy++)
+      {
+        for (int32_t cz = idxs0.cz; cz <= idxs1.cz; cz++)
+        {
+          const VoxelData* v = voxelByGlobalIdxs({cx, cy, cz});
+          if (!v)
+          {
+            continue;
+          }
+          f(*v);
+        }
+      }
+    }
+  }
   /** @} */
 
   /** @name Public virtual methods implementation for CMetricMap

--- a/mola_metric_maps/include/mola_metric_maps/NDT.h
+++ b/mola_metric_maps/include/mola_metric_maps/NDT.h
@@ -357,9 +357,11 @@ class NDT : public mrpt::maps::CMetricMap,
   NearestPlaneResult nn_search_pt2pl(
       const mrpt::math::TPoint3Df& point, const float max_search_distance) const override;
 
+#if defined(MP2P_ICP_HAS_NN_VISIT_PT2PL_CANDIDATES)
   void nn_visit_pt2pl_candidates(
       const mrpt::math::TPoint3Df& point, float max_search_distance,
       const plane_candidate_visitor_t& visitor) const override;
+#endif
 
   /** Visits every existing voxel that a nearest-plane query at `point` has to
    *  examine. Shared by the two searches above so that they always walk the

--- a/mola_metric_maps/include/mola_metric_maps/NDT.h
+++ b/mola_metric_maps/include/mola_metric_maps/NDT.h
@@ -371,8 +371,10 @@ class NDT : public mrpt::maps::CMetricMap,
   {
     const int margin = static_cast<int>(std::ceil(max_search_distance * voxel_size_inv_));
 
-    const global_index3d_t idxs0 = coordToGlobalIdx(point) - global_index3d_t(margin, margin, margin);
-    const global_index3d_t idxs1 = coordToGlobalIdx(point) + global_index3d_t(margin, margin, margin);
+    const global_index3d_t idxs0 =
+        coordToGlobalIdx(point) - global_index3d_t(margin, margin, margin);
+    const global_index3d_t idxs1 =
+        coordToGlobalIdx(point) + global_index3d_t(margin, margin, margin);
 
     for (int32_t cx = idxs0.cx; cx <= idxs1.cx; cx++)
     {

--- a/mola_metric_maps/src/NDT.cpp
+++ b/mola_metric_maps/src/NDT.cpp
@@ -1199,6 +1199,7 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult NDT::nn_search_pt2pl(
   return ret;
 }
 
+#if defined(MP2P_ICP_HAS_NN_VISIT_PT2PL_CANDIDATES)
 void NDT::nn_visit_pt2pl_candidates(
     const mrpt::math::TPoint3Df& query, const float max_search_distance,
     const plane_candidate_visitor_t& visitor) const
@@ -1232,6 +1233,7 @@ void NDT::nn_visit_pt2pl_candidates(
         visitor(c);
       });
 }
+#endif
 
 bool NDT::nn_single_search(
     const mrpt::math::TPoint3Df& query, mrpt::math::TPoint3Df& result, float& out_dist_sqr,

--- a/mola_metric_maps/src/NDT.cpp
+++ b/mola_metric_maps/src/NDT.cpp
@@ -1165,61 +1165,72 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult NDT::nn_search_pt2pl(
 {
   NearestPlaneCapable::NearestPlaneResult ret;
 
-  const int nn_search_margin = static_cast<int>(std::ceil(max_search_distance * voxel_size_inv_));
-
-  const global_index3d_t idxs0 =
-      coordToGlobalIdx(query) -
-      global_index3d_t(nn_search_margin, nn_search_margin, nn_search_margin);
-  const global_index3d_t idxs1 =
-      coordToGlobalIdx(query) +
-      global_index3d_t(nn_search_margin, nn_search_margin, nn_search_margin);
-
-  auto lambdaCheckCell = [&](const global_index3d_t& p)
-  {
-    auto* v = voxelByGlobalIdxs(p);
-    if (!v)
-    {
-      return;
-    }
-    const auto& ndt = v->ndt();
-    if (!ndt)
-    {
-      return;
-    }
-    if (!ndt_is_plane(*ndt))
-    {
-      return;
-    }
-
-    const auto&                normal        = ndt->eigVectors[0];
-    const mrpt::math::TPoint3D planeCentroid = ndt->meanCov.mean.asTPoint();
-    const auto                 thePlane      = mrpt::math::TPlane(planeCentroid, normal);
-    const double               ptPlaneDist   = std::abs(thePlane.distance(query));
-
-    // Better than the current one? replace:
-    if (!ret.pairing || ptPlaneDist < ret.distance)
-    {
-      auto& pa              = ret.pairing.emplace();
-      pa.pt_local           = query;
-      pa.pl_global.centroid = planeCentroid;
-      pa.pl_global.plane    = thePlane;
-
-      ret.distance = static_cast<float>(ptPlaneDist);
-    }
-  };
-
-  for (int32_t cx = idxs0.cx; cx <= idxs1.cx; cx++)
-  {
-    for (int32_t cy = idxs0.cy; cy <= idxs1.cy; cy++)
-    {
-      for (int32_t cz = idxs0.cz; cz <= idxs1.cz; cz++)
+  visitPt2PlSearchCells(
+      query, max_search_distance,
+      [&](const VoxelData& v)
       {
-        lambdaCheckCell({cx, cy, cz});
-      }
-    }
-  }
+        const auto& ndt = v.ndt();
+        if (!ndt)
+        {
+          return;
+        }
+        if (!ndt_is_plane(*ndt))
+        {
+          return;
+        }
+
+        const auto&                normal        = ndt->eigVectors[0];
+        const mrpt::math::TPoint3D planeCentroid = ndt->meanCov.mean.asTPoint();
+        const auto                 thePlane      = mrpt::math::TPlane(planeCentroid, normal);
+        const double               ptPlaneDist   = std::abs(thePlane.distance(query));
+
+        // Better than the current one? replace:
+        if (!ret.pairing || ptPlaneDist < ret.distance)
+        {
+          auto& pa              = ret.pairing.emplace();
+          pa.pt_local           = query;
+          pa.pl_global.centroid = planeCentroid;
+          pa.pl_global.plane    = thePlane;
+
+          ret.distance = static_cast<float>(ptPlaneDist);
+        }
+      });
 
   return ret;
+}
+
+void NDT::nn_visit_pt2pl_candidates(
+    const mrpt::math::TPoint3Df& query, const float max_search_distance,
+    const plane_candidate_visitor_t& visitor) const
+{
+  visitPt2PlSearchCells(
+      query, max_search_distance,
+      [&](const VoxelData& v)
+      {
+        const auto& ndt = v.ndt();
+        if (!ndt)
+        {
+          return;
+        }
+        if (!ndt_is_plane(*ndt))
+        {
+          return;
+        }
+
+        const auto&                normal        = ndt->eigVectors[0];
+        const mrpt::math::TPoint3D planeCentroid = ndt->meanCov.mean.asTPoint();
+        const auto                 thePlane      = mrpt::math::TPlane(planeCentroid, normal);
+
+        PlaneCandidate c;
+        c.pairing.pt_local           = query;
+        c.pairing.pl_global.centroid = planeCentroid;
+        c.pairing.pl_global.plane    = thePlane;
+        c.distance                   = static_cast<float>(std::abs(thePlane.distance(query)));
+        c.centroidDistance =
+            static_cast<float>((planeCentroid - mrpt::math::TPoint3D(query)).norm());
+
+        visitor(c);
+      });
 }
 
 bool NDT::nn_single_search(


### PR DESCRIPTION
## What

Adds `NDT::nn_visit_pt2pl_candidates()`, the `mp2p_icp::NearestPlaneCapable` entry point for matchers that combine candidate planes instead of selecting one of them. It is what lets `mp2p_icp::Matcher_NDT_Blend` see the cell Gaussians that `nn_search_pt2pl()` currently discards.

Both searches now walk the voxels through a shared `visitPt2PlSearchCells()` helper, so they cannot disagree about which cells a query examines.

## Behavior

`nn_search_pt2pl()` keeps its arithmetic and its comparison exactly as they were, including the double-precision distance test against a float member, so its results are unchanged. Nothing calls the new method unless a pipeline asks for the new matcher.

## Depends on

MOLAorg/mp2p_icp#91, which declares the virtual. Merge that first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enumerating planar candidates around a queried point, including point-to-plane and centroid distances.
  * Added compatibility with older `mp2p_icp` versions through a default nearest-plane implementation.
* **Improvements**
  * Improved NDT nearest-plane searches to consistently examine nearby map regions and select the closest valid plane.
  * Search behavior now remains consistent between direct nearest-plane lookup and candidate enumeration.
* **Documentation**
  * Updated documentation to describe NDT’s nearest-plane search and candidate enumeration capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->