### PR TITLE
fix(bridge_ros2): keep the TF buffer current under bridge executor load

### DIFF
--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -286,16 +286,18 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
 
     // TF buffer + listener -- pass rosNode_ so the listener's /tf and
     // /tf_static subscriptions share the same DDS participant, clock, and
-    // use_sim_time setting as the bridge.  spin_thread=false: rosNode_ is
-    // already spun by the loop below; a second spinner would be redundant.
+    // use_sim_time setting as the bridge. spin_thread=true puts those two
+    // subscriptions on their own callback group and thread, so how fresh the
+    // buffer is does not depend on what else the bridge executor is handling;
+    // tf2::BufferCore serialises its readers and writers on its own mutex.
     tf_buffer_ = std::make_shared<tf2::BufferCore>();
     if constexpr (HasRequiredInterfaces<tf2_ros::TransformListener>::value)
     {
-      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, *rosNode_, false);
+      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, *rosNode_, true);
     }
     else
     {
-      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, rosNode_, false);
+      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, rosNode_, true);
     }
 
     // TF broadcaster:

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -416,11 +416,18 @@ void BridgeROS2::ros_node_thread_main(Yaml cfg)
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(rosNode_);
 
+    // spin_once() waits for work, bounded so the loop still observes shouldExit_;
+    // spin_all() then drains whatever else is ready. spin_some() would collect the
+    // ready set once and so take a single message per subscription per iteration,
+    // leaving any topic that arrives faster permanently behind by its queue depth.
+    constexpr auto IDLE_WAIT   = std::chrono::milliseconds(10);
+    constexpr auto DRAIN_LIMIT = std::chrono::milliseconds(10);
+
     isSpinning_ = true;
     while (rclcpp::ok() && !shouldExit_)
     {
-      executor.spin_some();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      executor.spin_once(IDLE_WAIT);
+      executor.spin_all(DRAIN_LIMIT);
     }
     if (owned_rclcpp_ && rclcpp::ok())
     {


### PR DESCRIPTION
## Summary

Two independent ways the bridge's TF buffer ends up answering lookups from stale
data, both silent: the lookups still succeed, they just report a pose from a
buffer that is behind, and the result looks plausible. Kept as two commits since
either can stand alone.

**1. The spin loop takes one message per subscription per 10 ms.**
The ROS thread runs `executor.spin_some()` followed by a 10 ms sleep. The loop
replaced a blocking `rclcpp::spin()` so the destructor could stop the thread via
`shouldExit_`, and the sleep was only there to keep that flag poll from
busy-waiting. But `spin_some()` collects the ready set once and executes each
ready entity at most once per call, so the pair caps every subscription at
roughly one message per 10 ms. Any topic arriving faster than ~100 Hz keeps its
queue permanently full and every message the node sees is stale by the whole
queue depth. `/tf` is the worst case, since it aggregates every broadcaster on
the graph: with a few hundred transforms/s, the listener's `KeepLast(100)` queue
leaves the buffer several hundred ms behind. The visible symptom is REP-105
composition falling back to the stale odom transform with "extrapolation into
the future", while the odom broadcaster is publishing on time and a normally-spun
listener on the same graph reads it as current. A 200 Hz IMU on the same node
loses about half its samples the same way.

Replaced with `spin_once(10ms)` + `spin_all(10ms)`: `spin_once()` blocks until
there is work while still bounding how long `shouldExit_` goes unchecked, and
`spin_all()` then drains whatever else is ready. Both are needed — `spin_some()`
and `spin_all()` each call `wait_for_work(0ms)`, so `spin_all()` alone returns
immediately when idle and would busy-wait. Measured with two TF listeners
subscribed to the same `/tf`, one per spin strategy: draining fully leaves the
buffer 12.6 ms behind the broadcaster, taking one message per 10 ms tick leaves
it 358 ms behind. The only cost is that the two timeouts stack, so the worst case
for observing `shouldExit_` goes from 10 ms to 20 ms.

**2. TF ingestion is coupled to the bridge executor.**
`tf2_ros::TransformListener` is constructed with `spin_thread=false`, against
tf2's own default, so `/tf` and `/tf_static` are dispatched by the bridge's
executor. Buffer freshness is therefore a function of everything else the node is
handling — sensor callbacks, timers, map publishing. With `spin_thread=true` the
two subscriptions move to a callback group and executor the listener owns, so
ingestion is independent of that load.

No new sharing is introduced. The buffer is already read from other threads —
`publishLocalizationTf()` from the localization source's thread,
`transform_tree()` from whichever module calls it — and `tf2::BufferCore`
serialises readers and writers on a single mutex. The listener's group is created
with `automatically_add_to_executor_with_node=false`, so `add_node()` does not
adopt it and no second executor can dispatch those subscriptions. Its destructor
cancels and joins its thread, and it is declared after `tf_buffer_` and
`rosNode_`, so that happens while both are still alive.

A blocking `spin()` cancelled via `executor.cancel()` would remove the poll loop
in (1) altogether and is probably the better end state, but `cancel()` racing the
`spinning.exchange(true)` in `spin()` means the destructor has to retry until the
thread joins. Happy to do that here instead if you'd prefer it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROS 2 transform listener responsiveness and reliability.
  * Updated event processing to handle callbacks more consistently and prevent unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->