### PR TITLE
Expose the two constants of the per-point plane regularization

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -338,6 +338,17 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
     /** Maximum distance [m] to search neighbors for the covariance estimate. */
     double max_distance_for_cov = 1.0;
 
+    /** Maximum distance [m] any neighbor may sit from the least-squares plane
+     *  through the neighborhood for that neighborhood to receive the plane
+     *  regularization below. 0 (default) disables the test. Same semantics as
+     *  the option of the same name on KeyframePointCloudMap. */
+    double max_plane_deviation_for_cov = 0;
+
+    /** Variance asserted along the estimated surface normal, the other two
+     *  being 1, i.e. the plane confidence ratio written as its reciprocal. The
+     *  shipped 1e-3 asserts 1000:1. Must be in (0, 1]. */
+    double plane_regularization_lambda = 1e-3;
+
     /** If `true`, the k-d tree index is serialized alongside the points (see
      *  `IncrementalPointCloud` serialization), so it does NOT have to be
      *  rebuilt (an O(N log N) bulk build) when the map is loaded. Requires an

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -440,6 +440,35 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      */
     double max_distance_for_cov = 1.0;
 
+    /** Maximum distance [meters] any neighbor may sit from the least-squares
+     *  plane through the whole neighborhood for that neighborhood to be given
+     *  the plane regularization below. 0 (default) disables the test, which is
+     *  the historical behavior: every neighborhood with enough neighbors is
+     *  regularized to a 1000:1 plane covariance whether or not it is planar.
+     *
+     *  This is Fast-LIO2's `esti_plane` gate. A neighborhood that fails it
+     *  falls back to an isotropic covariance, the same fallback the
+     *  too-few-neighbors case uses, so the pairing still constrains the
+     *  solution -- it just stops asserting a surface normal it cannot support.
+     *  The local density estimate is deliberately left untouched by a
+     *  rejection, so this knob moves the covariance and nothing else.
+     */
+    double max_plane_deviation_for_cov = 0;
+
+    /** The smallest of the three regularized singular values of a per-point
+     *  covariance, i.e. the variance asserted along the estimated surface
+     *  normal. The other two are 1, so this IS the plane confidence ratio:
+     *  the shipped 1e-3 asserts 1000:1.
+     *
+     *  Exposed because that ratio is not free. Information the whitening puts
+     *  into the normal direction it takes, relatively, from the two directions
+     *  in the surface, and on a ground vehicle the normal of the dominant
+     *  surface is the vertical -- the axis that is already best determined.
+     *  Raising this softens the assertion without changing which direction is
+     *  asserted. Must be in (0, 1].
+     */
+    double plane_regularization_lambda = 1e-3;
+
     /** Weight converting angular distance [rad] to equivalent linear
      *  distance [m] for keyframe proximity ranking. Higher values favor
      *  angularly-close (similar orientation) frames. */
@@ -572,10 +601,13 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
    public:
     KeyFrame(
         std::size_t k_correspondences_for_cov, std::size_t min_correspondences_for_cov,
-        double max_distance_for_cov)
+        double max_distance_for_cov, double max_plane_deviation_for_cov,
+        double plane_regularization_lambda)
         : k_correspondences_for_cov_(k_correspondences_for_cov),
           min_correspondences_for_cov_(min_correspondences_for_cov),
-          max_distance_for_cov_(max_distance_for_cov)
+          max_distance_for_cov_(max_distance_for_cov),
+          max_plane_deviation_for_cov_(max_plane_deviation_for_cov),
+          plane_regularization_lambda_(plane_regularization_lambda)
     {
     }
 
@@ -585,6 +617,8 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
           k_correspondences_for_cov_(other.k_correspondences_for_cov_),
           min_correspondences_for_cov_(other.min_correspondences_for_cov_),
           max_distance_for_cov_(other.max_distance_for_cov_),
+          max_plane_deviation_for_cov_(other.max_plane_deviation_for_cov_),
+          plane_regularization_lambda_(other.plane_regularization_lambda_),
           pointcloud_(other.pointcloud_),
           pose_(other.pose_)
     {
@@ -600,6 +634,8 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
         k_correspondences_for_cov_   = other.k_correspondences_for_cov_;
         min_correspondences_for_cov_ = other.min_correspondences_for_cov_;
         max_distance_for_cov_        = other.max_distance_for_cov_;
+        max_plane_deviation_for_cov_ = other.max_plane_deviation_for_cov_;
+        plane_regularization_lambda_ = other.plane_regularization_lambda_;
         pointcloud_                  = other.pointcloud_;
         pose_                        = other.pose_;
         timestamp                    = other.timestamp;
@@ -667,11 +703,14 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      */
     void updateCovarianceParams(
         std::size_t k_correspondences_for_cov, std::size_t min_correspondences_for_cov,
-        double max_distance_for_cov)
+        double max_distance_for_cov, double max_plane_deviation_for_cov,
+        double plane_regularization_lambda)
     {
       k_correspondences_for_cov_   = k_correspondences_for_cov;
       min_correspondences_for_cov_ = min_correspondences_for_cov;
       max_distance_for_cov_        = max_distance_for_cov;
+      max_plane_deviation_for_cov_ = max_plane_deviation_for_cov;
+      plane_regularization_lambda_ = plane_regularization_lambda;
       invalidateCache();
     }
 
@@ -726,6 +765,8 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
     std::size_t k_correspondences_for_cov_;
     std::size_t min_correspondences_for_cov_;
     double      max_distance_for_cov_;
+    double      max_plane_deviation_for_cov_;
+    double      plane_regularization_lambda_;
 
     void updateBBox() const;
     void computeCovariancesAndDensity() const;

--- a/mola_metric_maps/src/IncrementalPointCloud.cpp
+++ b/mola_metric_maps/src/IncrementalPointCloud.cpp
@@ -920,6 +920,24 @@ void IncrementalPointCloud::computeCovariance(uint32_t slot) const
   }
   neighbors.colwise() -= Eigen::Vector3d(m_x[slot], m_y[slot], m_z[slot]);
 
+  // Planarity gate, off when the threshold is zero: do not assert a plane on a
+  // neighborhood that is not one. See KeyframePointCloudMap for the rationale.
+  if (creationOptions.max_plane_deviation_for_cov > 0)
+  {
+    const Eigen::Vector3d              centroid = neighbors.rowwise().mean();
+    const Eigen::Matrix<double, 3, -1> centered = neighbors.colwise() - centroid;
+
+    // Eigenvalues come out ascending, so column 0 is the plane normal.
+    const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(
+        (centered * centered.transpose()).eval());
+
+    if ((es.eigenvectors().col(0).transpose() * centered).cwiseAbs().maxCoeff() >
+        creationOptions.max_plane_deviation_for_cov)
+    {
+      return;  // keeps the isotropic covariance set at the top
+    }
+  }
+
   const Eigen::Matrix3d cov = neighbors * neighbors.transpose() / static_cast<double>(found);
 
   // Plane regularization of the singular values (see DLIO'2023, or Segal's
@@ -927,7 +945,7 @@ void IncrementalPointCloud::computeCovariance(uint32_t slot) const
   // plane normal direction.
   const Eigen::JacobiSVD<Eigen::Matrix3d> svd(cov, Eigen::ComputeFullU | Eigen::ComputeFullV);
 
-  const Eigen::Vector3d values(1.0, 1.0, 1e-3);
+  const Eigen::Vector3d values(1.0, 1.0, creationOptions.plane_regularization_lambda);
   cov_[slot] = svd.matrixU() * values.asDiagonal() * svd.matrixV().transpose();
 }
 
@@ -1362,6 +1380,8 @@ void IncrementalPointCloud::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR(alpha_deleted, float, c, s);
   MRPT_LOAD_CONFIG_VAR(reserve_points, uint64_t, c, s);
   MRPT_LOAD_CONFIG_VAR(k_correspondences_for_cov, uint64_t, c, s);
+  MRPT_LOAD_CONFIG_VAR(max_plane_deviation_for_cov, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(plane_regularization_lambda, double, c, s);
   MRPT_LOAD_CONFIG_VAR(min_correspondences_for_cov, uint64_t, c, s);
   MRPT_LOAD_CONFIG_VAR(max_distance_for_cov, double, c, s);
   MRPT_LOAD_CONFIG_VAR(serialize_kdtree, bool, c, s);
@@ -1377,6 +1397,8 @@ void IncrementalPointCloud::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(alpha_deleted, float);
   LOADABLEOPTS_DUMP_VAR(reserve_points, int);
   LOADABLEOPTS_DUMP_VAR(k_correspondences_for_cov, int);
+  LOADABLEOPTS_DUMP_VAR(max_plane_deviation_for_cov, double);
+  LOADABLEOPTS_DUMP_VAR(plane_regularization_lambda, double);
   LOADABLEOPTS_DUMP_VAR(min_correspondences_for_cov, int);
   LOADABLEOPTS_DUMP_VAR(max_distance_for_cov, double);
   LOADABLEOPTS_DUMP_VAR(serialize_kdtree, bool);
@@ -1385,12 +1407,13 @@ void IncrementalPointCloud::TCreationOptions::dumpToTextStream(std::ostream& out
 void IncrementalPointCloud::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  const int8_t version = 1;
+  const int8_t version = 2;
   out << version;
   out << remove_points_farther_than << async_rebuild << alpha_balance << alpha_deleted
       << reserve_points << k_correspondences_for_cov << min_correspondences_for_cov
       << max_distance_for_cov;
   out << serialize_kdtree;  // v1
+  out << max_plane_deviation_for_cov << plane_regularization_lambda;  // v2
 }
 
 void IncrementalPointCloud::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -1401,6 +1424,7 @@ void IncrementalPointCloud::TCreationOptions::readFromStream(mrpt::serialization
   {
     case 0:
     case 1:
+    case 2:
     {
       in >> remove_points_farther_than >> async_rebuild >> alpha_balance >> alpha_deleted >>
           reserve_points >> k_correspondences_for_cov >> min_correspondences_for_cov >>
@@ -1412,6 +1436,10 @@ void IncrementalPointCloud::TCreationOptions::readFromStream(mrpt::serialization
       else
       {
         serialize_kdtree = false;
+      }
+      if (version >= 2)
+      {
+        in >> max_plane_deviation_for_cov >> plane_regularization_lambda;
       }
     }
     break;

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -369,7 +369,9 @@ void KeyframePointCloudMap::serializeFrom(mrpt::serialization::CArchive& in, uin
 
         auto [it, isNew] = keyframes_.try_emplace(
             kf_id, creationOptions.k_correspondences_for_cov,
-            creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+            creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov,
+            creationOptions.max_plane_deviation_for_cov,
+            creationOptions.plane_regularization_lambda);
         KeyFrame& kf = it->second;
 
         in >> kf.timestamp;
@@ -821,7 +823,8 @@ void KeyframePointCloudMap::icp_get_prepared_as_global(  // NOLINT
   cached_.icp_search_submap.reset();
   cached_.icp_search_submap.emplace(
       creationOptions.k_correspondences_for_cov, creationOptions.min_correspondences_for_cov,
-      creationOptions.max_distance_for_cov);
+      creationOptions.max_distance_for_cov, creationOptions.max_plane_deviation_for_cov,
+      creationOptions.plane_regularization_lambda);
 
   for (const auto kf_id : kfs_to_search_limited)
   {
@@ -931,7 +934,8 @@ void KeyframePointCloudMap::merge_with(
     }
     auto [it, isNew] = keyframes_.try_emplace(
         next_free_kf_id_++, creationOptions.k_correspondences_for_cov,
-        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov,
+        creationOptions.max_plane_deviation_for_cov, creationOptions.plane_regularization_lambda);
     auto& new_kf = it->second;
 
     // copy
@@ -1682,14 +1686,14 @@ bool KeyframePointCloudMap::trySetCreationOptions(
   // already-built internal structures (each keyframe's own KD-tree, point clouds, etc.), so it
   // is always safe to apply them in place, regardless of whether the map already holds data.
   //
-  // Caveat: k_correspondences_for_cov/min_correspondences_for_cov/max_distance_for_cov are
-  // copied into each KeyFrame at construction time (used to lazily compute per-point
-  // covariances), instead of being read live from `creationOptions`. Propagate the new values
-  // to all existing keyframes and invalidate their cached covariances, so they get recomputed
-  // with the new parameters next time they are queried.
-  // Note on approximate_cov: icp_get_prepared_as_global() compares
-  // cached_.icp_search_built_approximate against the live option, so a change here (even
-  // with an unchanged active KF set) is picked up and forces a rebuild on the next call.
+  // Caveat: k_correspondences_for_cov/min_correspondences_for_cov/max_distance_for_cov/
+  // max_plane_deviation_for_cov are copied into each KeyFrame at construction time (used to lazily
+  // compute per-point covariances), instead of being read live from `creationOptions`. Propagate
+  // the new values to all existing keyframes and invalidate their cached covariances, so they get
+  // recomputed with the new parameters next time they are queried. Note on approximate_cov:
+  // icp_get_prepared_as_global() compares cached_.icp_search_built_approximate against the live
+  // option, so a change here (even with an unchanged active KF set) is picked up and forces a
+  // rebuild on the next call.
   TCreationOptions newOpts = creationOptions;
   newOpts.loadFromConfigFile(cfg, section);
   creationOptions = newOpts;
@@ -1699,7 +1703,8 @@ bool KeyframePointCloudMap::trySetCreationOptions(
   {
     kv.second.updateCovarianceParams(
         creationOptions.k_correspondences_for_cov, creationOptions.min_correspondences_for_cov,
-        creationOptions.max_distance_for_cov);
+        creationOptions.max_distance_for_cov, creationOptions.max_plane_deviation_for_cov,
+        creationOptions.plane_regularization_lambda);
   }
   return true;
 }
@@ -2035,7 +2040,8 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
 
     auto [it, isNew] = out->keyframes_.try_emplace(
         KeyFrameID{0}, creationOptions.k_correspondences_for_cov,
-        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov,
+        creationOptions.max_plane_deviation_for_cov, creationOptions.plane_regularization_lambda);
     KeyFrame& nkf = it->second;
     nkf.timestamp = seed.timestamp;
     nkf.pose(seed.pose);
@@ -2344,7 +2350,8 @@ std::shared_ptr<KeyframePointCloudMap> KeyframePointCloudMap::regroupKeyframes(
     // Insert as a new super-keyframe (caches build lazily on first use / load).
     auto [it, isNew] = out->keyframes_.try_emplace(
         nextId, creationOptions.k_correspondences_for_cov,
-        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov,
+        creationOptions.max_plane_deviation_for_cov, creationOptions.plane_regularization_lambda);
     KeyFrame& nkf = it->second;
     nkf.timestamp = seed.timestamp;
     nkf.pose(seed.pose);
@@ -2535,6 +2542,8 @@ void KeyframePointCloudMap::TCreationOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR_REQUIRED_CS(k_correspondences_for_cov, uint64_t);
   MRPT_LOAD_CONFIG_VAR_CS(min_correspondences_for_cov, uint64_t);
   MRPT_LOAD_CONFIG_VAR_CS(max_distance_for_cov, double);
+  MRPT_LOAD_CONFIG_VAR_CS(max_plane_deviation_for_cov, double);
+  MRPT_LOAD_CONFIG_VAR_CS(plane_regularization_lambda, double);
   MRPT_LOAD_CONFIG_VAR_CS(rotation_distance_weight, double);
   MRPT_LOAD_CONFIG_VAR_CS(num_diverse_keyframes, uint64_t);
   MRPT_LOAD_CONFIG_VAR_CS(use_view_direction_filter, bool);
@@ -2553,6 +2562,8 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
   LOADABLEOPTS_DUMP_VAR(k_correspondences_for_cov, int);
   LOADABLEOPTS_DUMP_VAR(min_correspondences_for_cov, int);
   LOADABLEOPTS_DUMP_VAR(max_distance_for_cov, double);
+  LOADABLEOPTS_DUMP_VAR(max_plane_deviation_for_cov, double);
+  LOADABLEOPTS_DUMP_VAR(plane_regularization_lambda, double);
   LOADABLEOPTS_DUMP_VAR(rotation_distance_weight, double);
   LOADABLEOPTS_DUMP_VAR(num_diverse_keyframes, int);
   LOADABLEOPTS_DUMP_VAR(use_view_direction_filter, bool);
@@ -2567,7 +2578,7 @@ void KeyframePointCloudMap::TCreationOptions::dumpToTextStream(std::ostream& out
 void KeyframePointCloudMap::TCreationOptions::writeToStream(
     mrpt::serialization::CArchive& out) const
 {
-  out.WriteAs<uint8_t>(7);  // version
+  out.WriteAs<uint8_t>(9);  // version
   out << max_search_keyframes << k_correspondences_for_cov;
   out << rotation_distance_weight << num_diverse_keyframes;  // v1
   out << use_view_direction_filter << max_view_angle_deg;  // v2
@@ -2576,6 +2587,8 @@ void KeyframePointCloudMap::TCreationOptions::writeToStream(
   out << approximate_cov;  // v5
   out << serialize_covariances;  // v6
   out << density_penalty_min_points << density_penalty_max_m;  // v7
+  out << max_plane_deviation_for_cov;  // v8
+  out << plane_regularization_lambda;  // v9
 }
 
 void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -2593,6 +2606,8 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
     case 5:
     case 6:
     case 7:
+    case 8:
+    case 9:
     {
       in >> max_search_keyframes >> k_correspondences_for_cov;
       if (version >= 1)
@@ -2623,6 +2638,14 @@ void KeyframePointCloudMap::TCreationOptions::readFromStream(mrpt::serialization
       if (version >= 7)
       {
         in >> density_penalty_min_points >> density_penalty_max_m;
+      }
+      if (version >= 8)
+      {
+        in >> max_plane_deviation_for_cov;
+      }
+      if (version >= 9)
+      {
+        in >> plane_regularization_lambda;
       }
     }
     break;
@@ -2725,7 +2748,8 @@ bool KeyframePointCloudMap::internal_insertObservation(
     // Add KF: allocate a fresh monotonic id (never reused, even after eviction).
     auto [it, isNew] = keyframes_.try_emplace(
         next_free_kf_id_++, creationOptions.k_correspondences_for_cov,
-        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov);
+        creationOptions.min_correspondences_for_cov, creationOptions.max_distance_for_cov,
+        creationOptions.max_plane_deviation_for_cov, creationOptions.plane_regularization_lambda);
     auto& new_kf = it->second;
 
     new_kf.timestamp = obs.timestamp;
@@ -2899,7 +2923,9 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
   // nanoflann's RKNNResultSet expects the maximum SEARCH DISTANCE SQUARED:
   const float MAX_DIST_SQR_FOR_COV =
       static_cast<float>(max_distance_for_cov_ * max_distance_for_cov_);
-  const auto normalization =
+  const double MAX_PLANE_DEVIATION = max_plane_deviation_for_cov_;
+  const double PLANE_REG_LAMBDA    = plane_regularization_lambda_;
+  const auto   normalization =
       static_cast<float>(((K_CORRESPONDENCES - 1) * (2 + K_CORRESPONDENCES))) / 2;
 
   const auto& xs = pointcloud_->getPointsBufferRef_x();
@@ -2963,6 +2989,39 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
           neighbors(2, static_cast<Eigen::Index>(j)) = static_cast<double>(zs[k_indices[j]]);
         }
 
+        // Planarity gate, off when the threshold is zero.
+        //
+        // The regularization below asserts a 1000:1 plane confidence on every
+        // neighborhood it is handed. This is Fast-LIO2's own test for whether
+        // that assertion is earned: fit a least-squares plane through the
+        // neighbors, and reject the neighborhood if any of them lies farther
+        // than the threshold from it. A rejected neighborhood falls back to an
+        // isotropic covariance, exactly as the too-few-neighbors case above.
+        //
+        // The density accumulator is deliberately NOT reset on a rejection:
+        // it feeds the adaptive matching threshold, and moving that too would
+        // make this knob a two-axis change.
+        if (MAX_PLANE_DEVIATION > 0)
+        {
+          const Eigen::Vector3d              centroid = neighbors.rowwise().mean();
+          const Eigen::Matrix<double, 3, -1> centered = neighbors.colwise() - centroid;
+
+          // Eigenvalues come out ascending, so column 0 is the plane normal.
+          const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(
+              (centered * centered.transpose()).eval());
+          const Eigen::Vector3d normal = es.eigenvectors().col(0);
+
+          if ((normal.transpose() * centered).cwiseAbs().maxCoeff() > MAX_PLANE_DEVIATION)
+          {
+            cached_cov_local_[i] = mrpt::math::CMatrixFloat33::Identity();
+#if defined(MOLA_METRIC_MAPS_USE_TBB)
+            return;
+#else
+        continue;
+#endif
+          }
+        }
+
         // neighbors.colwise() -= neighbors.rowwise().mean().eval();
         neighbors.colwise() -= Eigen::Vector3d(xs[i], ys[i], zs[i]);
         const Eigen::Matrix3d cov =
@@ -2975,7 +3034,7 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
 
         // SVD sorts eigenvalues in decreasing order, so the last one
         // is the smallest (normal direction of a plane):
-        const Eigen::Vector3d values = Eigen::Vector3d(1.0, 1.0, 1e-3);
+        const Eigen::Vector3d values = Eigen::Vector3d(1.0, 1.0, PLANE_REG_LAMBDA);
         cached_cov_local_[i] = svd.matrixU() * values.asDiagonal() * svd.matrixV().transpose();
 
 #if DO_VIZ_DEBUG


### PR DESCRIPTION
## What

Both map classes that estimate per-point covariances for cov-to-cov matching regularize the neighborhood scatter to `U*diag(1,1,1e-3)*U^T` — they assert a **1000:1 plane confidence on every neighborhood** with enough neighbors. Neither number in that sentence was reachable from a config file. This exposes both, on `KeyframePointCloudMap` and `IncrementalPointCloud`.

- **`max_plane_deviation_for_cov`** (default `0` = off) — Fast-LIO2's `esti_plane` test. Fit a least-squares plane through the `k` neighbors; if any of them lies farther than this from it, fall back to an isotropic covariance, so a neighborhood that is not planar stops asserting a normal it cannot support. Same fallback the too-few-neighbors case already uses.
- **`plane_regularization_lambda`** (default `1e-3`) — the asserted variance along the normal, i.e. the confidence ratio itself.

Both default to today's behavior **exactly**. Verified byte-identical trajectories with each wired in and left at its default.

## Why

Measured on KITTI 00-10 with the official devkit metric (translational drift %, rotational drift deg/100 m), against a baseline that reproduces the published `v2026.08.24-lio` results to six decimals:

| arm | trans [%] | rot [deg/100 m] |
|---|---:|---:|
| shipped | 0.6083 | 0.1760 |
| map-side gate `d`=0.20 | **0.5772** | 0.1748 |
| `IncrementalPointCloud` + gate `d`=0.20 | **0.5711** | **0.1215** |
| KISS-ICP (reference) | 0.5021 | 0.1479 |

The gate improves translational drift on **10 of 11** sequences at `d`=0.20, an interior optimum (0.05/0.10 are worse, 0.30/0.50 converge back to baseline). Combined with the incremental map it closes 35% of the gap to KISS-ICP on translation and puts rotational drift **18% ahead** of it.

`plane_regularization_lambda` is included for completeness and reproducibility, **not** as a tuning knob: raising it measured monotonically negative (1e-1 costs +55% translational drift on kitti-00). That result is what established the 1000:1 assertion is load-bearing, and that the gate helps by being *selective* rather than by weakening plane confidence in general.

## Notes

- A rejection deliberately leaves the local density estimate untouched — it feeds the adaptive matching threshold, and moving both at once would make this a two-axis change.
- Creation-options serialization bumped on both classes (v9 / v2), with the usual backward-compatible read path.
- `mola_metric_maps`: 18/18 tests pass on this branch.
- A companion PR in `mola_lidar_odometry` wires these to env vars in `lidar3d-gicp.yaml`; unknown creation-option keys are ignored, so merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoWrKM3HNosCFeJBEQjYS3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable covariance estimation controls for point-cloud neighborhoods.
  * Added an optional planarity threshold; non-planar neighborhoods now use isotropic covariance.
  * Added configurable plane-normal variance regularization for improved covariance stability.
  * Existing map data remains compatible while preserving the new settings across saves and loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->