### PR TITLE
mola_viz_imgui: show dataset playback time in the dataset UI panel

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -117,6 +117,12 @@ All plugin modules derive from these virtual base classes:
   ("unknown parentWindow 'main'" warnings on every call).
 - `Relocalization` — global localization / loop closure
 - `OfflineDatasetSource` — offline dataset handling
+- `Dataset_UI` — playback panel for offline dataset sources. Besides the
+  entry index and the play/pause/speed controls, sources may also report the
+  playback position in seconds via `datasetUI_time()` /
+  `datasetUI_total_time()` (feature macro `MOLA_KERNEL_DATASET_UI_HAS_TIME`).
+  Both default to `std::nullopt` ("unknown"), in which case the
+  `mola_viz_imgui` panel just shows the "entry / total entries" counter.
 - `SharedKeyframeMap` — central-map keyframe-insertion sink (new 2026, see
   `mola_mapper_3d`): front ends (LIO/VIO) push sparse keyframes via
   `requestInsertKeyframe()`, decoupled from their own local map/odometry

--- a/mola_input_lidar_bin_dataset/include/mola_input_lidar_bin_dataset/BinFileDataset.h
+++ b/mola_input_lidar_bin_dataset/include/mola_input_lidar_bin_dataset/BinFileDataset.h
@@ -93,6 +93,19 @@ class BinFileDataset : public OfflineDatasetSource, public RawDataSourceBase, pu
     auto lck       = mrpt::lockHelper(dataset_ui_mtx_);
     teleport_here_ = timestep;
   }
+  std::optional<double> datasetUI_time() const override
+  {
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    return ui_dataset_time_;
+  }
+  std::optional<double> datasetUI_total_time() const override
+  {
+    if (lst_timestamps_.size() < 2)
+    {
+      return {};
+    }
+    return lst_timestamps_.back() - lst_timestamps_.front();
+  }
 
  protected:
   // Internal data access
@@ -119,6 +132,10 @@ class BinFileDataset : public OfflineDatasetSource, public RawDataSourceBase, pu
 
   std::optional<mrpt::Clock::time_point> last_play_wallclock_time_;
   double                                 last_dataset_time_ = 0;
+
+  /// Playback time relative to the first scan, for the GUI. Guarded by
+  /// dataset_ui_mtx_.
+  double ui_dataset_time_ = 0;
 
   // Data cache
   mutable std::map<timestep_t, mrpt::obs::CObservation::Ptr> read_ahead_lidar_obs_;

--- a/mola_input_lidar_bin_dataset/src/BinFileDataset.cpp
+++ b/mola_input_lidar_bin_dataset/src/BinFileDataset.cpp
@@ -263,6 +263,7 @@ void BinFileDataset::spinOnce()
   {
     auto lck             = mrpt::lockHelper(dataset_ui_mtx_);
     last_used_tim_index_ = replay_next_tim_index_ > 0 ? replay_next_tim_index_ - 1 : 0;
+    ui_dataset_time_ = lst_timestamps_.empty() ? 0 : (last_dataset_time_ - lst_timestamps_.front());
   }
 
   // Read ahead to save delays in the next iteration:

--- a/mola_input_rawlog/include/mola_input_rawlog/RawlogDataset.h
+++ b/mola_input_rawlog/include/mola_input_rawlog/RawlogDataset.h
@@ -92,6 +92,16 @@ class RawlogDataset : public RawDataSourceBase, public OfflineDatasetSource, pub
     auto lck       = mrpt::lockHelper(dataset_ui_mtx_);
     teleport_here_ = timestep;
   }
+  std::optional<double> datasetUI_time() const override
+  {
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    return ui_dataset_time_;
+  }
+  std::optional<double> datasetUI_total_time() const override
+  {
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    return dataset_total_time_;
+  }
 
  protected:
   // See docs in base class
@@ -112,6 +122,16 @@ class RawlogDataset : public RawDataSourceBase, public OfflineDatasetSource, pub
 
   std::optional<mrpt::Clock::time_point> last_play_wallclock_time_;
   double                                 last_dataset_time_ = 0;
+
+  /// Copy of last_dataset_time_ for the GUI, guarded by dataset_ui_mtx_.
+  double ui_dataset_time_ = 0;
+
+  /// Dataset duration [s]. Only known if the whole rawlog was read at once.
+  std::optional<double> dataset_total_time_;
+
+  /** Returns the timestamp of the first (or last, if fromEnd) rawlog entry
+   *  that has one. Only valid if read_all_first_=true. */
+  std::optional<mrpt::Clock::time_point> findEntryTimestamp(bool fromEnd) const;
 
   void doReadAhead();
   void doReadAheadFromFile();

--- a/mola_input_rawlog/src/RawlogDataset.cpp
+++ b/mola_input_rawlog/src/RawlogDataset.cpp
@@ -43,6 +43,34 @@ MRPT_INITIALIZER(do_register_RawlogDataset)  // NOLINT(misc-use-anonymous-namesp
 
 RawlogDataset::RawlogDataset() = default;
 
+std::optional<mrpt::Clock::time_point> RawlogDataset::findEntryTimestamp(bool fromEnd) const
+{
+  const size_t n = rawlog_entire_.size();
+  for (size_t k = 0; k < n; k++)
+  {
+    const size_t idx = fromEnd ? (n - 1 - k) : k;
+
+    switch (rawlog_entire_.getType(idx))
+    {
+      case mrpt::obs::CRawlog::etObservation:
+        if (auto o = rawlog_entire_.getAsObservation(idx); o)
+        {
+          return o->timestamp;
+        }
+        break;
+      case mrpt::obs::CRawlog::etSensoryFrame:
+        if (auto sf = rawlog_entire_.getAsObservations(idx); sf && !sf->empty())
+        {
+          return (*sf->begin())->timestamp;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return {};
+}
+
 void RawlogDataset::initialize_rds(const Yaml& c)
 {
   using namespace std::string_literals;
@@ -77,6 +105,14 @@ void RawlogDataset::initialize_rds(const Yaml& c)
     rawlog_entire_.loadFromRawLogFile(rawlog_filename_);
 
     MRPT_LOG_INFO_STREAM("Read ok, with " << rawlog_entire_.size() << " entries.");
+
+    // Dataset duration, for the GUI: first and last valid timestamps.
+    const auto tFirst = findEntryTimestamp(false /*from begin*/);
+    const auto tLast  = findEntryTimestamp(true /*from end*/);
+    if (tFirst && tLast)
+    {
+      dataset_total_time_ = mrpt::system::timeDifference(*tFirst, *tLast);
+    }
   }
   else
   {
@@ -165,10 +201,13 @@ void RawlogDataset::spinOnce()
                       << mrpt::system::dateTimeLocalToString(obs->timestamp));
   }
 
-  if (read_all_first_)
   {
-    auto lck             = mrpt::lockHelper(dataset_ui_mtx_);
-    last_used_tim_index_ = rawlog_next_idx_;
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    if (read_all_first_)
+    {
+      last_used_tim_index_ = rawlog_next_idx_;
+    }
+    ui_dataset_time_ = last_dataset_time_;
   }
 
   MRPT_END

--- a/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
+++ b/mola_input_rosbag2/include/mola_input_rosbag2/Rosbag2Dataset.h
@@ -108,6 +108,16 @@ class Rosbag2Dataset : public RawDataSourceBase,
     auto lck       = mrpt::lockHelper(dataset_ui_mtx_);
     teleport_here_ = timestep;
   }
+  std::optional<double> datasetUI_time() const override
+  {
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    return ui_dataset_time_;
+  }
+  std::optional<double> datasetUI_total_time() const override
+  {
+    auto lck = mrpt::lockHelper(dataset_ui_mtx_);
+    return dataset_total_time_;
+  }
 
   // Virtual interface of TransformTreeSource (see docs in base class)
   std::optional<TransformTree> transform_tree(
@@ -160,6 +170,12 @@ class Rosbag2Dataset : public RawDataSourceBase,
 
   std::optional<mrpt::Clock::time_point> last_play_wallclock_time_;
   double                                 last_dataset_time_ = 0;
+
+  /// Copy of last_dataset_time_ for the GUI, guarded by dataset_ui_mtx_.
+  double ui_dataset_time_ = 0;
+
+  /// Total duration of all input bags [s], from their metadata.
+  std::optional<double> dataset_total_time_;
 
   std::shared_ptr<rosbag2_cpp::readers::SequentialReader> reader_;
   size_t                                                  bagMessageCount_ = 0;

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -46,6 +46,7 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
 
+#include <chrono>
 #include <set>
 #include <tf2/buffer_core.hpp>
 #include <tf2/convert.hpp>
@@ -199,6 +200,10 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
   rosbag_storage_ids_.clear();
   std::map<std::string, rosbag2_storage::TopicMetadata> all_topics_by_name;
 
+  // Time span covered by all input bags, to report the total dataset duration:
+  using bag_time_point = std::chrono::time_point<std::chrono::high_resolution_clock>;
+  std::optional<std::pair<bag_time_point, bag_time_point>> bagsTimeSpan;
+
   for (const auto& path : rosbag_filenames_)
   {
     const bool pathIsDir  = mrpt::system::directoryExists(path);
@@ -226,9 +231,26 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
             inserted || it->second.type == t.type,
             "Topic '"s + t.name + "' has inconsistent types across input bags"s);
       }
-      const size_t cnt = static_cast<size_t>(tmpReader->get_metadata().message_count);
+      const auto&  md  = tmpReader->get_metadata();
+      const size_t cnt = static_cast<size_t>(md.message_count);
       per_bag_msg_counts_.push_back(cnt);
       bagMessageCount_ += cnt;
+
+      // Accumulate the total time span covered by all input bags:
+      if (cnt > 0)
+      {
+        const auto tIni = md.starting_time;
+        const auto tEnd = tIni + md.duration;
+        if (!bagsTimeSpan)
+        {
+          bagsTimeSpan = {tIni, tEnd};
+        }
+        else
+        {
+          bagsTimeSpan->first  = std::min(bagsTimeSpan->first, tIni);
+          bagsTimeSpan->second = std::max(bagsTimeSpan->second, tEnd);
+        }
+      }
       MRPT_LOG_INFO_STREAM(
           "Bag '" << path << "': " << cnt << " messages (storage: " << storageId << ")");
     }
@@ -238,6 +260,12 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
   {
     MRPT_LOG_INFO_STREAM(
         "Total messages across " << rosbag_filenames_.size() << " bags: " << bagMessageCount_);
+  }
+
+  if (bagsTimeSpan)
+  {
+    dataset_total_time_ =
+        std::chrono::duration<double>(bagsTimeSpan->second - bagsTimeSpan->first).count();
   }
 
   // Open the first bag to read topic metadata and start replay.
@@ -785,6 +813,7 @@ void Rosbag2Dataset::spinOnce()
     auto lck = mrpt::lockHelper(dataset_ui_mtx_);
 
     last_used_tim_index_ = rosbag_next_idx_;
+    ui_dataset_time_     = last_dataset_time_;
   }
 
   MRPT_END

--- a/mola_input_video/include/mola_input_video/VideoDataset.h
+++ b/mola_input_video/include/mola_input_video/VideoDataset.h
@@ -51,6 +51,9 @@ class VideoDataset : public RawDataSourceBase, public Dataset_UI
   void   datasetUI_paused(bool paused) override;
   void   datasetUI_teleport(size_t timestep) override;
 
+  std::optional<double> datasetUI_time() const override;
+  std::optional<double> datasetUI_total_time() const override;
+
  protected:
   void initialize_rds(const Yaml& cfg) override;
 

--- a/mola_input_video/src/VideoDataset.cpp
+++ b/mola_input_video/src/VideoDataset.cpp
@@ -241,4 +241,23 @@ bool   VideoDataset::datasetUI_paused() const { return paused_; }
 void   VideoDataset::datasetUI_paused(bool paused) { paused_ = paused; }
 void   VideoDataset::datasetUI_teleport(size_t timestep) { teleport_here_ = timestep; }
 
+std::optional<double> VideoDataset::datasetUI_time() const
+{
+  if (input_mode_ != InputMode::ImageDirectory)
+  {
+    return {};
+  }
+  std::scoped_lock lck(dataset_ui_mtx_);
+  return last_dataset_time_;
+}
+
+std::optional<double> VideoDataset::datasetUI_total_time() const
+{
+  if (input_mode_ != InputMode::ImageDirectory || image_publish_rate_ <= 0)
+  {
+    return {};
+  }
+  return static_cast<double>(image_files_.size()) / image_publish_rate_;
+}
+
 }  // namespace mola

--- a/mola_kernel/include/mola_kernel/interfaces/Dataset_UI.h
+++ b/mola_kernel/include/mola_kernel/interfaces/Dataset_UI.h
@@ -19,6 +19,11 @@
 #pragma once
 
 #include <cstdlib>
+#include <optional>
+
+/** Feature macro: Dataset_UI exposes the dataset playback time via
+ *  datasetUI_time() / datasetUI_total_time(). */
+#define MOLA_KERNEL_DATASET_UI_HAS_TIME 1
 
 namespace mola
 {
@@ -46,6 +51,14 @@ class Dataset_UI
 
   /** Forces continue replaying in this moment in time */
   virtual void datasetUI_teleport(size_t timestep) = 0;
+
+  /** Current dataset playback time, in seconds elapsed since the beginning of
+   *  the dataset. Returns std::nullopt if the source cannot tell (default). */
+  virtual std::optional<double> datasetUI_time() const { return std::nullopt; }
+
+  /** Total dataset duration, in seconds. Returns std::nullopt if unknown
+   *  (default), e.g. for live sources or datasets read on the fly. */
+  virtual std::optional<double> datasetUI_total_time() const { return std::nullopt; }
   /** @} */
 };
 

--- a/mola_viz_imgui/src/MolaVizImGui.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui.cpp
@@ -33,7 +33,10 @@
 #include <mrpt/system/string_utils.h>
 #include <mrpt/system/thread_name.h>
 
+#include <cmath>
+#include <cstdint>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 using namespace mola;
@@ -349,6 +352,29 @@ void MolaVizImGui::gui_thread()
 // Dataset UI
 // ---------------------------------------------------------------------------
 
+namespace
+{
+/** Compact "[h:]mm:ss.s" rendering of a time interval, for the dataset
+ *  playback panel. */
+std::string format_playback_time(double t)
+{
+  if (t < 0 || !std::isfinite(t))
+  {
+    t = 0;
+  }
+  const auto   totalSecs = static_cast<uint64_t>(t);
+  const auto   hours     = static_cast<unsigned int>(totalSecs / 3600);
+  const auto   mins      = static_cast<unsigned int>((totalSecs / 60) % 60);
+  const double secs      = t - static_cast<double>(hours * 3600 + mins * 60);
+
+  if (hours > 0)
+  {
+    return mrpt::format("%u:%02u:%04.1f", hours, mins, secs);
+  }
+  return mrpt::format("%u:%04.1f", mins, secs);
+}
+}  // namespace
+
 void MolaVizImGui::dataset_ui_check_new_modules()
 {
   auto datasetUIs = findService<Dataset_UI>();
@@ -386,7 +412,7 @@ void MolaVizImGui::dataset_ui_check_new_modules()
     mola::gui::WindowDescription desc;
     desc.title               = module->getModuleInstanceName();
     desc.position            = {300, 5};
-    desc.size                = {650, 70};
+    desc.size                = {800, 70};
     desc.dock_top_by_default = true;
 
     mola::gui::Tab tab{"Controls", {}};
@@ -449,7 +475,20 @@ void MolaVizImGui::dataset_ui_update()
     if (!mod || !e.lbPlaybackPosition) continue;
     const size_t pos = mod->datasetUI_lastQueriedTimestep();
     const size_t N   = mod->datasetUI_size();
-    e.lbPlaybackPosition->set(mrpt::format("%zu / %zu", pos, N));
+
+    std::string txt = mrpt::format("%zu / %zu", pos, N);
+
+    // Dataset playback time, if the source can tell it:
+    if (const auto t = mod->datasetUI_time(); t.has_value())
+    {
+      txt += "  |  " + format_playback_time(*t);
+      if (const auto T = mod->datasetUI_total_time(); T.has_value())
+      {
+        txt += " / " + format_playback_time(*T);
+      }
+    }
+
+    e.lbPlaybackPosition->set(txt);
     if (e.liveSliderPos) e.liveSliderPos->set(static_cast<float>(pos));
   }
 }


### PR DESCRIPTION
The per-dataset playback panel of the `mola_viz_imgui` backend now shows the dataset replay time and the total dataset duration, next to the existing "entry / total entries" counter:

```
120 / 200  |  0:12.0 / 0:20.0
```

### How

Two new **optional** virtual methods in `mola::Dataset_UI`:

- `datasetUI_time()`: playback position, in seconds from the beginning of the dataset.
- `datasetUI_total_time()`: total dataset duration [s].

Both default to `std::nullopt` ("unknown"), so out-of-tree dataset sources keep compiling unchanged and the panel just shows the entry counter as before. Feature macro: `MOLA_KERNEL_DATASET_UI_HAS_TIME`.

The GUI shows `t / T` when both are known, only `t` when the duration is unknown (e.g. a rawlog replayed on the fly, without `read_all_first`).

### Implemented for

| Dataset source | time | total time |
|---|---|---|
| `RawlogDataset` | yes | only if `read_all_first` (first/last entry timestamps) |
| `Rosbag2Dataset` | yes | yes, from the bag(s) metadata time span |
| `BinFileDataset` | yes | yes |
| `VideoDataset` | image-directory mode | image-directory mode |

`agents.md` updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset playback controls now display elapsed time and total duration when available.
  * Added compact playback time formatting in hours, minutes, and seconds.
  * Time information is supported for binary scans, rawlogs, ROS bags, and image-directory datasets.

* **Documentation**
  * Documented optional playback time reporting for dataset sources.
  * Datasets without timing information continue to show the entry counter only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->