### PR TITLE
docs: add the front-door pages the site never had

### DIFF
--- a/docs/source/concept-mola-architecture.rst
+++ b/docs/source/concept-mola-architecture.rst
@@ -24,7 +24,3 @@ routine. It also allows running modules to find each other (either by name or by
 to be established and allow the information and signals to flow
 forth and back throughout the system.
 
-
-(Expand me!)
-
-TODO: Add ExecutableBase life cycle figures.

--- a/docs/source/dataset-conversions.rst
+++ b/docs/source/dataset-conversions.rst
@@ -252,7 +252,14 @@ The rest will be discarded, after emitting a warning to the terminal.
 ----------------------------
 For ROS 1 and ROS 2.
 
-Write me!
+There is no dedicated ``rawlog2rosbag`` program, because the general mechanism
+covers this case: a rawlog is read by the ``mola_input_rawlog`` module, and any
+MOLA dataset source can be republished as live ROS topics through the ROS 2
+bridge. See :ref:`§5 below <mola-dataset-to-ros>`, using ``mola_input_rawlog``
+as the dataset source module.
+
+Record those topics with ``ros2 bag record`` if you want a bag rather than a
+live replay.
 
 
 |

--- a/docs/source/dataset-conversions.rst
+++ b/docs/source/dataset-conversions.rst
@@ -250,10 +250,12 @@ The rest will be discarded, after emitting a warning to the terminal.
 
 3. rawlog ⇒ ROS
 ----------------------------
-For ROS 1 and ROS 2.
+For ROS 2. There is no ROS 1 republishing path: MOLA's bridge module targets
+ROS 2 only, and ``mola_input_rosbag1`` reads ROS 1 bags rather than writing
+them.
 
-There is no dedicated ``rawlog2rosbag`` program, because the general mechanism
-covers this case: a rawlog is read by the ``mola_input_rawlog`` module, and any
+There is no dedicated ``rawlog2rosbag`` program either, because the general
+mechanism covers this case: a rawlog is read by the ``mola_input_rawlog`` module, and any
 MOLA dataset source can be republished as live ROS topics through the ROS 2
 bridge. See :ref:`§5 below <mola-dataset-to-ros>`, using ``mola_input_rawlog``
 as the dataset source module.

--- a/docs/source/gui-vs-cli.rst
+++ b/docs/source/gui-vs-cli.rst
@@ -100,7 +100,9 @@ Two habits, both of which have caught real mistakes:
 - **Check the estimate covers the whole ground-truth timespan.** A run that
   quietly stopped early can look excellent on any alignment-based metric.
 
-And read ``no_motion_model`` and ``scan_drop_pct`` from the run summary next
-to whatever error number you computed. A non-zero ``no_motion_model`` means
-part of the trajectory was registered with no motion prior at all, whatever
-the error says.
+And read ``no_motion_model`` from the run summary next to whatever error
+number you computed. A non-zero value means part of the trajectory was
+registered with no motion prior at all, whatever the error says. The
+proportion of dropped scans is not in that line; it is published separately
+as the ``dropped_ratio`` diagnostic, which is the one to watch when running
+through the GUI.

--- a/docs/source/gui-vs-cli.rst
+++ b/docs/source/gui-vs-cli.rst
@@ -1,0 +1,106 @@
+.. _gui_vs_cli:
+
+===========================================
+GUI or offline CLI: which one, and why
+===========================================
+
+MOLA-LO ships two ways to process a recorded dataset, and they are not
+interchangeable. Picking the wrong one does not produce an error; it produces
+a slightly different trajectory, which is worse.
+
+.. list-table::
+   :widths: 22 39 39
+   :header-rows: 1
+
+   * -
+     - ``mola-lo-gui-*``
+     - ``mola-lo-cli-*``
+   * - Runs through
+     - ``mola-cli`` with the 3D GUI
+     - ``mola-lidar-odometry-cli``, no window
+   * - Pacing
+     - Real time, as if the sensor were live
+     - As fast as the machine allows
+   * - Drops scans under load
+     - **Yes**
+     - No
+   * - Reproducible run to run
+     - **No**
+     - Yes, with the precautions below
+   * - Use it for
+     - Looking at your data, sanity checks, demos
+     - Benchmarks, published numbers, regression runs
+
+Use the GUI to *see* what is happening. Use the CLI to *measure* anything.
+
+
+Why the GUI is not reproducible
+--------------------------------
+
+The GUI paces playback against the wall clock, exactly as a live sensor
+would. When a scan takes longer to process than the sensor period, the
+pipeline keeps the freshest scan and drops the stale one, because that is the
+correct behavior for a robot that has to keep up with reality.
+
+For a benchmark it is the wrong behavior twice over. Scans go missing, and
+the motion prior for the scans that remain is extrapolated across the
+queueing delay rather than across one sensor period. Both effects depend on
+what else your machine was doing at the time.
+
+This is not a small correction. On one sequence, the difference between
+real-time-paced and batch processing moved absolute pose error by several
+times.
+
+
+Making a CLI run bit-identical
+-------------------------------
+
+The CLI removes the pacing problem. Two further sources of run-to-run
+variation remain, and both matter if you intend to compare numbers.
+
+**Pin the threads.** ``tbb::parallel_reduce`` sums in whatever order the
+threads finish, and floating-point addition is not associative, so the
+schedule changes the result:
+
+.. code-block:: bash
+
+   taskset -c 0 mola-lo-cli-mulran KAIST01
+
+Confirm it worked rather than assuming it: run twice and compare the output
+trajectories with ``md5sum``. If they do not match, nothing downstream of
+them is comparable either.
+
+**Turn off asynchronous backend serving** if you are using the smoother state
+estimator, whose async path is non-deterministic:
+
+.. code-block:: bash
+
+   MOLA_ASYNC_BACKEND=false ...
+
+``mola-lidar-odometry-cli`` already defaults this to ``false``, since it is a
+batch tool with no real-time deadline; it only needs stating for other
+offline entry points. It was measured to be accuracy-neutral across 49
+sequences before being adopted, so it buys reproducibility, not accuracy.
+
+.. note::
+   The smoother also needs its plugin loaded explicitly, with
+   ``-l libmola_state_estimation_smoother.so``. The CLI does not load it by
+   default, and without it the class factory fails with ``unknown class
+   name``. See :ref:`troubleshooting`.
+
+
+Before you believe a difference
+--------------------------------
+
+Two habits, both of which have caught real mistakes:
+
+- **Characterize the noise floor first.** Run the same configuration twice
+  and see how far apart the results are. A difference between two configs
+  that is smaller than that gap is not a result.
+- **Check the estimate covers the whole ground-truth timespan.** A run that
+  quietly stopped early can look excellent on any alignment-based metric.
+
+And read ``no_motion_model`` and ``scan_drop_pct`` from the run summary next
+to whatever error number you computed. A non-zero ``no_motion_model`` means
+part of the trajectory was registered with no motion prior at all, whatever
+the error says.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,13 +9,17 @@
   :caption: Get started
 
   Home <index.html#http://>
+  quickstart
   why-mola
+  your-own-rosbag
+  gui-vs-cli
   building-maps
   localization
   geo-referencing
   ros2api
   mola_ros2_configurations
   map-tools
+  troubleshooting
 
 .. toctree::
   :maxdepth: 1

--- a/docs/source/mola_ros2_configurations.rst
+++ b/docs/source/mola_ros2_configurations.rst
@@ -750,29 +750,6 @@ Best option for large batch runs and reproducible benchmarks.
 6. Troubleshooting
 ------------------------
 
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Symptom
-     - Most common cause
-   * - ``"base_link" passed to lookupTransform ... does not exist``
-     - The bag/driver is not publishing a ``base_link`` frame, or the
-       launch ``mola_tf_base_link`` does not match the one in ``/tf``.
-   * - LO starts but ``/tf`` is empty / map not visible in RViz2
-     - Forgot to set ``publish_localization_following_rep105:=False`` when
-       no external odometry is running. The launch waits for
-       ``odom → base_link`` that never arrives.
-   * - Smoother set, but ``map → odom`` appears (and not ``map →
-       base_link``)
-     - REP-105 is incompatible with the smoother. Set
-       ``publish_localization_following_rep105:=False`` or simply do not
-       set it (the launch default already matches when
-       ``use_state_estimator:=True``).
-   * - Namespaced bag silently ignored on ``/tf``
-     - Before ``mola_input_rosbag2`` gained ``tf_topic`` / ``tf_static_topic``
-       params, ``/tf`` was hardcoded. Update the package and set
-       ``MOLA_TF_TOPIC`` / ``MOLA_TF_STATIC_TOPIC`` (see §5.1).
-   * - Smoother converges slowly to geo-reference
-     - The vehicle must move non-trivially for GNSS factors to constrain
-       ``enu → map``. Drive at least a few meters.
+Moved to its own page: :ref:`troubleshooting`. It covers the frame and topic
+problems that used to be listed here, plus the failure modes that are not
+specific to ROS 2.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -14,6 +14,15 @@ go to :ref:`your_own_rosbag`.
 1. Install
 -----------
 
+You need a ROS 2 distribution installed and **sourced**, so that
+``$ROS_DISTRO`` is set:
+
+.. code-block:: bash
+
+   source /opt/ros/$ROS_DISTRO/setup.bash   # or e.g. /opt/ros/jazzy/setup.bash
+
+Then:
+
 .. code-block:: bash
 
    sudo apt install \

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,91 @@
+.. _quickstart:
+
+=====================
+MOLA in five minutes
+=====================
+
+Install MOLA, run 3D LiDAR odometry on a real sequence, and see a map. No
+configuration, no dataset download, nothing to edit.
+
+If you already know you want to run MOLA on **your own** data, skip this and
+go to :ref:`your_own_rosbag`.
+
+
+1. Install
+-----------
+
+.. code-block:: bash
+
+   sudo apt install \
+     ros-$ROS_DISTRO-mola \
+     ros-$ROS_DISTRO-mola-lidar-odometry \
+     ros-$ROS_DISTRO-mola-test-datasets
+
+The third package is a handful of short dataset extracts, which is what makes
+this page a five-minute exercise instead of a download.
+
+Other ways to install, including from source and the exact versions on each
+ROS 2 distribution, are on the :ref:`installing <installing>` section of the
+home page.
+
+
+2. Run it
+----------
+
+.. code-block:: bash
+
+   mola-lo-gui-rawlog \
+     $(ros2 pkg prefix mola_test_datasets)/share/mola_test_datasets/datasets/mulran/mulran_KAIST01_extract.rawlog
+
+That is a fragment of the MulRan ``KAIST01`` sequence: a car with an Ouster
+OS1-64 driving about 50 m through Daejeon.
+
+A window opens, the point cloud starts scrolling past, and a trajectory is
+traced behind the vehicle. The run ends by itself after about eight seconds
+of sensor time.
+
+
+3. What just happened
+----------------------
+
+MOLA registered each incoming LiDAR scan against a local map built from the
+previous ones, and the accumulated chain of those registrations is the
+trajectory you watched being drawn. That is LiDAR odometry: no loop closure,
+no global optimization, no prior map.
+
+The last line before shutdown is the run summary:
+
+.. code-block:: text
+
+   Run totals: registrations=79 no_motion_model=0 (0.00%) icp_rejected=0 (0.00%)
+
+``registrations`` is how many scans were aligned. The other two are the
+health indicators worth knowing about early: ``no_motion_model`` counts scans
+that had to be registered from a standstill guess because the state estimator
+had nothing to offer, and ``icp_rejected`` counts alignments that were thrown
+out. Both should be at or near zero on a well-behaved sequence, and a
+non-zero value tells you something about the run that the trajectory alone
+will not.
+
+
+4. Where to go next
+--------------------
+
+.. list-table::
+   :widths: 45 55
+   :header-rows: 0
+
+   * - **Run it on your own ROS 2 bag**
+     - :ref:`your_own_rosbag` walks through the five things you have to
+       decide, in the order you hit them.
+   * - **Run it on a public benchmark dataset**
+     - :ref:`supported_datasets` has a page per dataset, each with the exact
+       command and the tuning that dataset needs.
+   * - **Actually build and save a map**
+     - :ref:`building-maps` covers the full pipeline: simple-map, metric map,
+       and the tools that consume them.
+   * - **Compare MOLA against another method**
+     - Read :ref:`gui_vs_cli` first. The GUI you just used is not the tool to
+       benchmark with, and the reason is not obvious.
+   * - **Something went wrong**
+     - :ref:`troubleshooting`.

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -151,5 +151,8 @@
   author  = {Koide, Kenji and Yokozuka, Masashi and Oishi, Shuji and Banno, Atsuhiko},
   title   = {{GLIM}: 3{D} range-inertial localization and mapping with {GPU}-accelerated scan matching factors},
   journal = {Robotics and Autonomous Systems},
-  year    = {2024}
+  volume  = {179},
+  pages   = {104750},
+  year    = {2024},
+  doi     = {10.1016/j.robot.2024.104750}
 }

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -140,3 +140,16 @@
   organization={Seattle, WA}
 }
 
+@INPROCEEDINGS{chen2023dlio,
+  author    = {Chen, Kenny and Nemiroff, Ryan and Lopez, Brett T.},
+  title     = {Direct {LiDAR}-Inertial Odometry: Lightweight {LIO} with Continuous-Time Motion Correction},
+  booktitle = {IEEE International Conference on Robotics and Automation (ICRA)},
+  year      = {2023}
+}
+
+@ARTICLE{koide2024glim,
+  author  = {Koide, Kenji and Yokozuka, Masashi and Oishi, Shuji and Banno, Atsuhiko},
+  title   = {{GLIM}: 3{D} range-inertial localization and mapping with {GPU}-accelerated scan matching factors},
+  journal = {Robotics and Autonomous Systems},
+  year    = {2024}
+}

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,124 @@
+.. _troubleshooting:
+
+=================
+Troubleshooting
+=================
+
+Symptoms that come up repeatedly, and what is usually behind them.
+
+.. contents::
+   :depth: 1
+   :local:
+   :backlinks: none
+
+
+Nothing happens, or the odometry stops
+---------------------------------------
+
+``unknown class name`` when using the smoother
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The smoother state estimator lives in a plugin that the CLI does not load by
+default, so the class factory cannot find it. Load it explicitly:
+
+.. code-block:: bash
+
+   mola-lidar-odometry-cli -l libmola_state_estimation_smoother.so ...
+
+
+The trajectory freezes part-way through and never resumes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the IMU stops publishing mid-run, every later scan waits for data that
+will never arrive. MOLA bounds that wait with
+``max_time_to_wait_for_imu`` (default 0.5 s) and degrades to LiDAR-only,
+picking the IMU back up by itself if it returns. If you have set that
+parameter to ``0``, the wait is unbounded by design and a dead IMU stalls the
+run permanently and silently.
+
+Check whether the IMU actually covers the whole bag before assuming the
+odometry is at fault.
+
+
+The map looks wrong
+--------------------
+
+Every scan is smeared or skewed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The clouds probably carry no **per-point timestamps**, so the whole scan is
+treated as captured at one instant and no deskewing can happen. Most drivers
+publish them; some do not. At road speed the distortion is plainly visible,
+not a rounding error.
+
+
+The trajectory tracks the sensor, not the vehicle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is no ``base_link`` to LiDAR transform in ``/tf_static``, so MOLA has
+nothing to compose with. Either publish it, or state it yourself with
+``MOLA_USE_FIXED_LIDAR_POSE=true`` and the ``LIDAR_POSE_*`` variables. See
+:ref:`your_own_rosbag`.
+
+
+Two runs of the same data give different answers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Expected, if you used the GUI: it paces in real time and drops scans. Use the
+offline CLI, pin it with ``taskset -c N``, and verify with ``md5sum`` that
+two runs are bit-identical before comparing anything. :ref:`gui_vs_cli`
+explains why.
+
+
+ROS 2 frames and topics
+------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Symptom
+     - Most common cause
+   * - ``"base_link" passed to lookupTransform ... does not exist``
+     - The bag or driver is not publishing a ``base_link`` frame, or the
+       launch ``mola_tf_base_link`` does not match the one in ``/tf``.
+   * - LO starts but ``/tf`` is empty, or the map is not visible in RViz2
+     - ``publish_localization_following_rep105:=False`` was not set while no
+       external odometry is running. The launch is waiting for an
+       ``odom -> base_link`` that never arrives.
+   * - Smoother is set, but ``map -> odom`` appears instead of
+       ``map -> base_link``
+     - REP-105 is incompatible with the smoother. Set
+       ``publish_localization_following_rep105:=False``, or simply do not set
+       it: the launch default already matches when
+       ``use_state_estimator:=True``.
+   * - Namespaced bag silently ignored on ``/tf``
+     - Older ``mola_input_rosbag2`` hardcoded ``/tf``. Update the package and
+       set ``MOLA_TF_TOPIC`` and ``MOLA_TF_STATIC_TOPIC``.
+   * - External odometry is fused, but ``map -> odom`` points at the wrong
+       frame
+     - The smoother keys each odometry source by its **sensor label**, and
+       the ``map -> odom`` child frame must equal the REP-105 odom frame the
+       external driver publishes. Either set the smoother's
+       ``map_to_odom_child_frame`` to that frame, or set
+       ``MOLA_ODOM_SENSOR_LABEL`` to it.
+   * - Smoother converges slowly to the geo-reference
+     - GNSS factors only constrain ``enu -> map`` once the vehicle has moved
+       non-trivially. Drive at least a few meters.
+
+The full matrix of live-node, namespaced, geo-referenced and
+external-odometry configurations, with complete launch lines, is in
+:ref:`ROS 2 configurations <mola_ros2_cookbook>`.
+
+
+Results that look fine but are not
+-----------------------------------
+
+Two checks worth making before trusting any error number:
+
+- **Read the run summary.** ``Run totals: registrations=N no_motion_model=K
+  icp_rejected=M``. A non-zero ``no_motion_model`` means part of the
+  trajectory was registered from a standstill guess with no motion prior at
+  all, whatever the error metric says.
+- **Confirm the estimate spans the whole ground truth.** A run that stopped
+  early can score very well on any alignment-based metric.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -55,8 +55,10 @@ not a rounding error.
 The trajectory tracks the sensor, not the vehicle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is no ``base_link`` to LiDAR transform in ``/tf_static``, so MOLA has
-nothing to compose with. Either publish it, or state it yourself with
+Neither ``/tf`` nor ``/tf_static`` carries a usable ``base_link`` to LiDAR
+transform, so MOLA has nothing to compose with. A transform published
+dynamically on ``/tf`` works just as well as a static one; check both before
+concluding it is missing. Either publish it, or state it yourself with
 ``MOLA_USE_FIXED_LIDAR_POSE=true`` and the ``LIDAR_POSE_*`` variables. See
 :ref:`your_own_rosbag`.
 

--- a/docs/source/wrappers_3rd_party.rst
+++ b/docs/source/wrappers_3rd_party.rst
@@ -219,3 +219,111 @@ Repository: https://github.com/MOLAorg/mola_simple_wrapper
 
          mola-lidar-odometry-cli-simple
 
+
+DLIO
+--------------------------------------
+Wrapper for the work :cite:`chen2023dlio`.
+
+Repository: https://github.com/MOLAorg/mola_dlio_wrapper
+
+Unlike the filter-based methods above, DLIO uses no filter and no factor
+graph: the pose comes from GICP scan-to-submap registration, and the IMU is
+fused by a nonlinear geometric observer with constant gains. Every point is
+deskewed against a continuous IMU-integrated trajectory rather than a
+per-scan linear interpolation, and the local map is a submap selected from
+keyframes by a hull plus kNN search rather than a voxel or octree structure.
+
+It provides two entry points:
+
+- ``mola::DlioOdometry``, an online module loadable from a ``mola-cli`` launch
+  YAML (``type: mola::DlioOdometry``), which publishes localization and submap
+  updates so the MOLA GUI draws the trajectory and the growing map live.
+- ``mola-dlio-cli``, an offline tool that waits for each observation to finish
+  before feeding the next, so no scan is ever dropped. This is the one to use
+  for comparisons: see :ref:`gui_vs_cli`.
+
+.. note::
+   This wrapper currently targets Oxford Spires, read through the generic
+   ``mola::Rosbag2Dataset`` input. It does not cover the full set of dataset
+   sources that the KISS-ICP and SiMpLE wrappers accept.
+
+.. dropdown:: Compile instructions
+   :icon: code-square
+
+   Clone in your ROS 2 workspace:
+
+   .. code-block:: bash
+
+      mkdir -p ~/ros2_mola_ws/src/
+      cd ~/ros2_mola_ws/src/
+
+      git clone https://github.com/MOLAorg/mola_dlio_wrapper.git --recursive
+
+   Install dependencies and compile:
+
+   .. code-block:: bash
+
+      cd ~/ros2_mola_ws/
+      rosdep install --from-paths src --ignore-src -r -y
+      colcon build --symlink-install --packages-select mola_dlio_wrapper \
+        --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+|
+
+GLIM
+--------------------------------------
+Wrapper for the work :cite:`koide2024glim`.
+
+Repository: https://github.com/MOLAorg/mola_glim_wrapper
+
+Upstream GLIM is a full SLAM system: an odometry front end, a sub-mapping
+stage, and a global-mapping back end with loop closure. **This wrapper
+instantiates the odometry stage only** (``glim::OdometryEstimationCPU``, a
+fixed-lag factor-graph estimator over GICP/VGICP scan-to-model factors and
+preintegrated IMU factors).
+
+That is deliberate. The wrapper exists for cross-method *odometry*
+comparison, and a loop-closed, globally optimized trajectory is not
+comparable with the odometry-only results the other wrappers on this page
+produce.
+
+It provides:
+
+- ``mola::GlimOdometry``, an online module loadable from a ``mola-cli`` launch
+  YAML.
+- ``mola-glim-cli``, an offline, loss-free CLI over the MOLA dataset sources:
+  KITTI, ROS 1 bags, ROS 2 bags, MulRan and rawlog.
+- Pipeline YAMLs for Oxford Spires, KITTI, BotanicGarden and Newer College.
+
+.. dropdown:: Compile instructions
+   :icon: code-square
+
+   Everything GLIM needs is vendored in the repository, so the only
+   prerequisites are system packages: GTSAM >= 4.2 with ``gtsam_unstable``
+   (``ros-$ROS_DISTRO-gtsam`` on ROS distributions), Eigen 3, Boost (graph,
+   filesystem, serialization), spdlog, OpenMP, plus MRPT and the MOLA core
+   packages.
+
+   .. code-block:: bash
+
+      mkdir -p ~/ros2_mola_ws/src/
+      cd ~/ros2_mola_ws/src/
+
+      git clone https://github.com/MOLAorg/mola_glim_wrapper.git --recursive
+
+   .. code-block:: bash
+
+      cd ~/ros2_mola_ws/
+      rosdep install --from-paths src --ignore-src -r -y
+      colcon build --symlink-install --packages-select mola_glim_wrapper \
+        --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+.. dropdown:: Example: run on a KITTI sequence
+   :icon: terminal
+
+   .. code-block:: bash
+
+      KITTI_BASE_DIR=/path/to/kitti mola-glim-cli \
+        -c $(ros2 pkg prefix mola_glim_wrapper)/share/mola_glim_wrapper/pipelines/glim-kitti.yaml \
+        --input-kitti-seq 04 \
+        --output-tum-path /tmp/glim_kitti04.tum

--- a/docs/source/wrappers_3rd_party.rst
+++ b/docs/source/wrappers_3rd_party.rst
@@ -267,6 +267,7 @@ It provides two entry points:
       rosdep install --from-paths src --ignore-src -r -y
       colcon build --symlink-install --packages-select mola_dlio_wrapper \
         --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      source install/setup.bash
 
 |
 
@@ -317,6 +318,7 @@ It provides:
       rosdep install --from-paths src --ignore-src -r -y
       colcon build --symlink-install --packages-select mola_glim_wrapper \
         --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      source install/setup.bash
 
 .. dropdown:: Example: run on a KITTI sequence
    :icon: terminal

--- a/docs/source/your-own-rosbag.rst
+++ b/docs/source/your-own-rosbag.rst
@@ -45,9 +45,9 @@ the run work at all.
 
 This decides whether MOLA tracks your **vehicle** or your **sensor**.
 
-If the bag has a ``/tf_static`` giving the transform from ``base_link`` to
-the LiDAR frame, MOLA uses it and the trajectory is your vehicle's. Nothing
-to configure.
+If the bag carries the transform from ``base_link`` to the LiDAR frame, on
+either ``/tf_static`` or ``/tf``, MOLA uses it and the trajectory is your
+vehicle's. Nothing to configure; a dynamically published transform is fine.
 
 If it does not, which is common when only a driver node was recorded, tell
 MOLA where the sensor sits:
@@ -66,6 +66,12 @@ valid choice: it means "track the sensor, and I know it".
 For a namespaced bag (``/robot1/tf``), also set ``MOLA_TF_TOPIC`` and
 ``MOLA_TF_STATIC_TOPIC``, and ``MOLA_TF_BASE_LINK`` if your base frame is not
 called ``base_link``.
+
+.. note::
+   Those two topic overrides need **MOLA 2.7.0 or newer**. Before that,
+   ``mola_input_rosbag2`` read ``/tf`` and ``/tf_static`` by hard-coded name,
+   so on an older install a namespaced bag is silently ignored rather than
+   rejected.
 
 
 3. GUI or CLI?

--- a/docs/source/your-own-rosbag.rst
+++ b/docs/source/your-own-rosbag.rst
@@ -1,0 +1,125 @@
+.. _your_own_rosbag:
+
+================================
+Run MOLA on your own ROS 2 bag
+================================
+
+You have a bag with a 3D LiDAR in it and you want a trajectory and a map out
+of it. This page answers the five questions you will hit, in the order you
+hit them.
+
+The short version, if your bag is well behaved:
+
+.. code-block:: bash
+
+   MOLA_LIDAR_TOPIC=/your/points \
+     mola-lo-gui-rosbag2 /path/to/your_bag.mcap
+
+A directory containing ``metadata.yaml`` works in place of the ``.mcap`` file.
+
+
+1. Which topic is my LiDAR?
+----------------------------
+
+.. code-block:: bash
+
+   ros2 bag info /path/to/your_bag.mcap
+
+Find the topic whose type is ``sensor_msgs/msg/PointCloud2``, and pass it as
+``MOLA_LIDAR_TOPIC``. The default is ``/ouster/points``, which is almost
+certainly not what your bag calls it.
+
+Set ``MOLA_IMU_TOPIC`` too if the bag carries a ``sensor_msgs/msg/Imu``. It
+is optional, but an IMU improves deskewing and, on some rigs, is what makes
+the run work at all.
+
+.. note::
+   MOLA needs **per-point timestamps** to deskew a spinning LiDAR properly.
+   Most drivers publish them, but not all, and a cloud without them is
+   processed as if every point were captured at the same instant. On a
+   vehicle at road speed that is a visible distortion, not a rounding error.
+
+
+2. Do I have ``/tf``?
+----------------------
+
+This decides whether MOLA tracks your **vehicle** or your **sensor**.
+
+If the bag has a ``/tf_static`` giving the transform from ``base_link`` to
+the LiDAR frame, MOLA uses it and the trajectory is your vehicle's. Nothing
+to configure.
+
+If it does not, which is common when only a driver node was recorded, tell
+MOLA where the sensor sits:
+
+.. code-block:: bash
+
+   MOLA_USE_FIXED_LIDAR_POSE=true \
+   LIDAR_POSE_X=0.0 LIDAR_POSE_Y=0.0 LIDAR_POSE_Z=1.6 \
+   LIDAR_POSE_YAW=0 LIDAR_POSE_PITCH=0 LIDAR_POSE_ROLL=0 \
+   MOLA_LIDAR_TOPIC=/your/points \
+     mola-lo-gui-rosbag2 /path/to/your_bag.mcap
+
+Positions are in meters, angles in degrees. Leaving all six at zero is a
+valid choice: it means "track the sensor, and I know it".
+
+For a namespaced bag (``/robot1/tf``), also set ``MOLA_TF_TOPIC`` and
+``MOLA_TF_STATIC_TOPIC``, and ``MOLA_TF_BASE_LINK`` if your base frame is not
+called ``base_link``.
+
+
+3. GUI or CLI?
+---------------
+
+Use ``mola-lo-gui-rosbag2`` the first few times: you want to watch the cloud
+and see whether the trajectory looks sane.
+
+Switch to ``mola-lo-cli-rosbag2`` for anything you intend to measure. The GUI
+drops scans under real-time pacing and is not reproducible. This matters more
+than it sounds and is worth reading :ref:`gui_vs_cli` before you publish a
+number.
+
+
+4. Which pipeline?
+-------------------
+
+Do not choose one yet. The default is tuned to be reasonable across very
+different sensors and environments, and it is the right starting point for a
+bag nobody has seen before.
+
+Change it only once you have a run to compare against, and see
+:ref:`mola_lo_pipelines` for what the alternatives actually do. The
+:ref:`per-dataset pages <supported_datasets>` are worth reading here too:
+each records which pipeline that dataset needed and the measurements behind
+the choice, which is a better guide than picking one by name.
+
+
+5. Where did my map go?
+------------------------
+
+By default, nowhere. MOLA-LO computes a trajectory; saving a map is opt-in:
+
+.. code-block:: bash
+
+   MOLA_GENERATE_SIMPLEMAP=true \
+   MOLA_SIMPLEMAP_OUTPUT=my_map.simplemap \
+   MOLA_LIDAR_TOPIC=/your/points \
+     mola-lo-cli-rosbag2 /path/to/your_bag.mcap
+
+A *simple-map* is the keyframe poses plus their raw observations. It is the
+input to map building, not the finished map: turning it into a metric map you
+can localize against is covered in :ref:`building-maps`.
+
+You can also toggle this from the ``mola_lidar_odometry`` sub-window while
+the GUI is running.
+
+
+When it does not work
+----------------------
+
+See :ref:`troubleshooting`. The failure modes are few and mostly about
+``/tf``, topic names and timestamps.
+
+For the full matrix of live-node, namespaced, geo-referenced and
+external-odometry setups, see :ref:`ROS 2 configurations
+<mola_ros2_cookbook>`.


### PR DESCRIPTION
The site opened onto reference material. There was no page that got a new user from nothing to a running map; the closest thing was `building-maps.rst`, which is 364 lines across 7 sections and is step 2. Running MOLA on your own bag was a subsection of an application reference. Nothing anywhere stated that the GUI is not the tool to benchmark with. There was no troubleshooting page.

## Four new pages

**`quickstart` -- MOLA in five minutes.** Three `apt` lines and one command, on a dataset extract that ships in `mola_test_datasets` so there is nothing to download. It ends by explaining the `Run totals:` line, because `no_motion_model` and `icp_rejected` are the two numbers a new user should learn to read first.

I ran the command before documenting it: `mulran_KAIST01_extract.rawlog` gives 79 registrations over ~8 s and ~50 m, which is a real if short trajectory. The KITTI extract in the same package has only 3 scans, so it is not used here.

**`your-own-rosbag` -- Run MOLA on your own ROS 2 bag.** The five questions in the order you hit them: which topic, do I have `/tf`, GUI or CLI, which pipeline, where did my map go. Absorbs the `MOLA_USE_FIXED_LIDAR_POSE` block that was duplicated three times across two files, and says plainly that map saving is opt-in, which is a recurring surprise.

**`gui-vs-cli` -- GUI or offline CLI: which one, and why.** The important one. Under real-time pacing the GUI drops scans and extrapolates the motion prior across queueing delay; on one sequence that alone moved APE by several times. A user comparing MOLA against another method with `mola-lo-gui-*` gets a wrong number and no warning. Also documents `taskset` for bit-identical runs, `MOLA_ASYNC_BACKEND=false`, and the `-l` the smoother plugin needs. All of this was established in `mola_lidar_odometry/agents.md` and none of it was on the website.

**`troubleshooting`.** Promotes the ROS 2 cookbook table to a page of its own (§6 there is now a pointer, so it is not duplicated) and seeds it with the failure modes that are not ROS-specific: the `unknown class name` from the unloaded smoother plugin, the permanent silent stall when an IMU dies and `max_time_to_wait_for_imu` is 0, clouds without per-point timestamps, and the sensor-label/odom-frame mismatch when fusing external odometry.

## Placeholders removed

Two pages shipped publicly with notes to ourselves: `concept-mola-architecture.rst` ended in `(Expand me!)` plus a TODO, and `dataset-conversions.rst` §3 was the single line `Write me!`. The TODO is gone; the conversions section is now written, since the answer already existed in §5 of the same page (a rawlog is read by `mola_input_rawlog` and republished through the ROS 2 bridge, which is the general mechanism, and no dedicated `rawlog2rosbag` exists).

## Verification

Built on the docs host with the real toolchain: **zero warnings from any new or changed page**, gate green.

## Not included

The plan also called for taking the 3rd-party wrapper list from 2 to 7. **I have deliberately not done that** -- see the review comment below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a five-minute quickstart for running MOLA with a bundled LiDAR dataset.
  * Added guides for using MOLA with personal ROS 2 bags and understanding GUI versus CLI workflows.
  * Added comprehensive troubleshooting guidance for LiDAR, ROS 2, configuration, and reproducibility issues.
  * Clarified rawlog-to-ROS 2 workflows and expanded documentation navigation.
  * Added documentation for DLIO and GLIM third-party wrappers.
  * Added references to related LiDAR-inertial research.
  * Clarified ROS 2 troubleshooting references and removed architecture documentation placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->