### PR TITLE
docs: make the site findable

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,6 +23,8 @@ Sphinx==7.2.6
 sphinxcontrib-applehelp==1.0.8
 sphinxcontrib-bibtex==2.6.2
 sphinxcontrib-mermaid==0.9.2
+sphinx-sitemap==2.6.0
+sphinxext-opengraph==0.9.1
 sphinxcontrib-devhelp==1.0.6
 sphinxcontrib-htmlhelp==2.0.5
 sphinxcontrib-jquery==4.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,26 @@ mermaid_version = '11.4.0'
 mermaid_output_format = 'raw'  # render via JS in the browser; keeps diagrams vector and diffable.
 
 extensions += ['doxyrest', 'cpplexer']
+extensions += ['sphinx_sitemap', 'sphinxext.opengraph']
+
+# --- Findability -----------------------------------------------------------
+# Canonical URL of the published site. Sphinx emits <link rel="canonical">
+# from this, which consolidates ranking signals onto one address, and
+# sphinx-sitemap needs it to build absolute URLs.
+html_baseurl = 'https://docs.mola-slam.org/latest/'
+
+# The site is published as a single 'latest/' directory, with no per-language
+# or per-version subdirectories, so the default '{lang}{version}{link}'
+# scheme would emit URLs that do not exist.
+sitemap_url_scheme = '{link}'
+
+# OpenGraph tags, so a link to these pages in chat or on social media shows
+# the page title and its own summary instead of a bare URL. Deliberately
+# text-only: the project logo is 120x120, and link previews expect roughly
+# 1200x630, so it would be upscaled into something worse than no image.
+ogp_site_url = html_baseurl
+ogp_site_name = 'MOLA documentation'
+ogp_description_length = 200
 
 bibtex_bibfiles = ['refs.bib']
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,10 @@
   bibliography
 
 
+=====================================================
+MOLA: LiDAR Odometry, SLAM and Localization for ROS 2
+=====================================================
+
 .. raw:: html
 
    <div style="text-align: center; margin: 1.5em 0 1em 0;">


### PR DESCRIPTION
Phase 4 of the docs plan: the site was invisible to search in ways that are cheap to fix.

## The homepage had no H1

Everything above the fold in `index.rst` is a `.. raw:: html` marketing banner, so the first actual heading in the document was **"Quick links"**, far down the page. That is what Sphinx puts in `<title>`:

```
<title>Quick links &mdash; MOLA v3.2.0 documentation</title>
```

The single most important page on the site was titled "Quick links" for search engines, for browser tabs, and for anyone pasting the link. It is now:

```
<title>MOLA: LiDAR Odometry, SLAM and Localization for ROS 2 &mdash; MOLA v3.2.0 documentation</title>
```

This also fixes a real accessibility problem, not just an SEO one: a landing page with no `<h1>` is a failure for screen-reader navigation.

## Canonical URLs

`html_baseurl = "https://docs.mola-slam.org/latest/"`, so every page emits `<link rel="canonical">`. Verified in the built output for both the homepage and a subpage.

## sitemap.xml

Via `sphinx-sitemap`. **92 URLs.** One thing worth noting: the site is published as a single `latest/` directory with no per-language or per-version subdirectories, so the extension's default `{lang}{version}{link}` scheme would have emitted URLs that do not exist. It is set to `{link}`.

A matching `robots.txt` is now served at the domain root (it lives on the docs host, outside the rsync target, since `latest/` is wiped on each publish). It points at the sitemap and excludes `_sources/` and `.doctrees/`. Live and returning 200.

## OpenGraph

Via `sphinxext-opengraph`: `og:title`, `og:type`, `og:url`, `og:site_name`, and a per-page `og:description` generated from the page's own opening text. Links to these pages in Slack, on X or on LinkedIn now show the page and its summary rather than a bare URL.

**Deliberately text-only, no `og:image`.** The only image available is `mola-slam-logo.png` at **120x120**; link previews expect roughly 1200x630, so it would be upscaled into something that looks worse than no image at all. Confirmed the build emits zero `og:image` tags. Worth revisiting if a proper card is ever designed.

## Not done, deliberately

The plan also listed adding **intersphinx to the MRPT docs**, on the grounds that it "kills hand-written absolute URLs". I counted them: there are **two**. Adding a build dependency and a network fetch of MRPT's `objects.inv` on every build to replace two links is a bad trade, so it is skipped and the reasoning is recorded in the plan.

## Verification

Built on the docs host with the real toolchain. Gate green, no new warnings. Confirmed in the output: the new `<title>`, canonical tags on multiple pages, 92 sitemap URLs, OpenGraph tags present, and no `og:image`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sitemap support to improve documentation discoverability.
  * Added OpenGraph metadata for richer link previews when documentation pages are shared.
  * Added a clear title to the documentation homepage.
  * Configured the documentation site’s canonical URL and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->