### PR TITLE
Add mola::TSDF, a truncated signed distance field local map

### DIFF
--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -79,6 +79,7 @@ set(LIB_SRCS
   src/register.cpp
   src/SparseTreesPointCloud.cpp
   src/SparseVoxelPointCloud.cpp
+  src/TSDF.cpp
 )
 set(LIB_PUBLIC_HDRS
   include/mola_metric_maps/FixedDenseGrid3D.h
@@ -91,6 +92,7 @@ set(LIB_PUBLIC_HDRS
   include/mola_metric_maps/OptionsIniIO.h
   include/mola_metric_maps/SparseTreesPointCloud.h
   include/mola_metric_maps/SparseVoxelPointCloud.h
+  include/mola_metric_maps/TSDF.h
 )
 
 # The map class is always built; only the k-d tree backend is conditional (see

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -391,8 +391,8 @@ class TSDF : public mrpt::maps::CMetricMap,
     /** Neighbors used for the warm-up plane fit. */
     uint32_t bootstrap_knn = 10;
 
-    /** Maximum RMS distance [m] of the neighborhood from the plane fitted
-     *  through it, for that plane to be used, or <=0 to accept every fit.
+    /** Maximum distance [m] any neighbor may sit from the plane fitted through
+     *  the neighborhood, for that plane to be used, or <=0 to accept every fit.
      *
      *  The default is deliberately loose, near the decimation voxel size of a
      *  typical pipeline, because the warm-up turns out to need *many* pairings

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -367,29 +367,41 @@ class TSDF : public mrpt::maps::CMetricMap,
      */
     bool bootstrap_with_points = true;
 
-    /** Scans to accumulate before the field is tested at all. */
-    uint32_t bootstrap_min_scans = 2;
+    /** Scans to accumulate before the field is tested at all.
+     *
+     *  This and `bootstrap_max_plane_deviation` interact, and neither works
+     *  alone: on the sequences a fine voxel fails to start, lengthening the
+     *  warm-up by itself and loosening the plane test by itself each leave the
+     *  run incomplete, while doing both completes it.
+     */
+    uint32_t bootstrap_min_scans = 10;
 
     /** Hard bound on the warm-up, in scans. If the field still cannot answer by
      *  then, the switch happens anyway and a message is printed: a map that
      *  quietly stayed a point cloud under this class's name would misreport
      *  what was measured.
      */
-    uint32_t bootstrap_max_scans = 20;
+    uint32_t bootstrap_max_scans = 200;
 
     /** Fraction of the last scan's points at which the field must return a
      *  valid query for the warm-up to end.
      */
-    double bootstrap_field_ready_fraction = 0.5;
+    double bootstrap_field_ready_fraction = 0.9;
 
     /** Neighbors used for the warm-up plane fit. */
     uint32_t bootstrap_knn = 10;
 
     /** Maximum distance [m] any neighbor may sit from the fitted plane for that
-     *  plane to be used. A neighborhood that is not locally planar has no
-     *  tangent plane to offer, and a bad one is worse than none.
+     *  plane to be used, or <=0 to accept every fit.
+     *
+     *  The default is deliberately loose, near the decimation voxel size of a
+     *  typical pipeline, because the warm-up turns out to need *many* pairings
+     *  more than it needs good ones: a poorly fitted plane is diluted by the
+     *  others in the same solve, while a rejected one removes its information
+     *  outright. Tightening this starves the first registrations and the run
+     *  fails to start, which is the very thing the warm-up exists to prevent.
      */
-    double bootstrap_max_plane_deviation = 0.10;
+    double bootstrap_max_plane_deviation = 0.5;
 
     /** @} */
   };

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -391,8 +391,8 @@ class TSDF : public mrpt::maps::CMetricMap,
     /** Neighbors used for the warm-up plane fit. */
     uint32_t bootstrap_knn = 10;
 
-    /** Maximum distance [m] any neighbor may sit from the fitted plane for that
-     *  plane to be used, or <=0 to accept every fit.
+    /** Maximum RMS distance [m] of the neighborhood from the plane fitted
+     *  through it, for that plane to be used, or <=0 to accept every fit.
      *
      *  The default is deliberately loose, near the decimation voxel size of a
      *  typical pipeline, because the warm-up turns out to need *many* pairings

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -29,6 +29,7 @@
 #include <tsl/robin_map.h>
 
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <optional>
 
@@ -129,7 +130,34 @@ class TSDF : public mrpt::maps::CMetricMap,
     float weight = 0;
   };
 
-  using grids_map_t = tsl::robin_map<global_index3d_t, VoxelData, index3d_hash<int32_t>>;
+  /** Spatial hash for the field's voxels.
+   *
+   *  `mola::index3d_hash` truncates to 20 bits, which caps it at 2^20 distinct
+   *  values. That is ample for a point-based voxel map, which holds one cell
+   *  per occupied voxel at a decimetre-to-metre cell size, and no map class in
+   *  this library had ever come near it. A field map is the first that does: it
+   *  fills a band around *every* surface at a fine voxel, so it passes a
+   *  million voxels within seconds of driving, and past that point every new
+   *  key collides with an existing hash and the container degrades from a
+   *  measured 51 bytes per voxel to effectively unbounded -- 112 GB on a single
+   *  KITTI sequence.
+   *
+   *  So this class uses the full 64-bit mix. The shared functor is deliberately
+   *  left alone: changing it would alter the iteration order of every existing
+   *  voxel map, and with it the summation order of anything that accumulates
+   *  over one.
+   */
+  struct voxel_hash_t
+  {
+    std::size_t operator()(const global_index3d_t& k) const noexcept
+    {
+      return (static_cast<uint64_t>(static_cast<uint32_t>(k.cx)) * 73856093ULL) ^
+             (static_cast<uint64_t>(static_cast<uint32_t>(k.cy)) * 19349663ULL) ^
+             (static_cast<uint64_t>(static_cast<uint32_t>(k.cz)) * 83492791ULL);
+    }
+  };
+
+  using grids_map_t = tsl::robin_map<global_index3d_t, VoxelData, voxel_hash_t>;
 
   /** @} */
 

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -1,0 +1,372 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   TSDF.h
+ * @brief  Truncated signed distance field (TSDF) 3D map representation
+ * @author Jose Luis Blanco Claraco
+ * @date   Sep 02, 2026
+ */
+#pragma once
+
+#include <mola_metric_maps/OptionsCapable.h>
+#include <mola_metric_maps/index3d_t.h>
+#include <mp2p_icp/NearestPlaneCapable.h>
+#include <mrpt/img/TColor.h>
+#include <mrpt/maps/CMetricMap.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/math/TBoundingBox.h>
+#include <mrpt/math/TPoint3D.h>
+#include <tsl/robin_map.h>
+
+#include <cmath>
+#include <functional>
+#include <optional>
+
+namespace mola
+{
+/** Truncated signed distance field (TSDF) map, stored as a voxel hash map.
+ *
+ * Each measured point contributes a signed distance sample to every voxel
+ * inside a narrow cylinder around its measurement ray, within
+ * `truncation_distance` of the surface. Samples are combined by a weighted
+ * running average, so the surface a query sees is the *fused* estimate over
+ * every measurement of it, rather than any one stored point.
+ *
+ * Three consequences make this a distinct map class rather than another point
+ * container, and they are the reason it exists:
+ *
+ * - There is no representative point per cell, so the "which point stands for
+ *   this cell" selection disappears entirely.
+ * - There is no correspondence search: the residual of a query point is the
+ *   interpolated field value at it, and the surface normal is the field
+ *   gradient. What the ICP engine consumes is still a point-to-plane pairing,
+ *   so no new matcher or solver is required.
+ * - The field is continuous (trilinear) inside the mapped region, so the
+ *   residual has no jumps as the state moves.
+ *
+ * The map exposes `mp2p_icp::NearestPlaneCapable` and is therefore usable by
+ * `mp2p_icp::Matcher_Point2Plane` with no changes.
+ *
+ * @note For a per-voxel Gaussian instead of a distance field, see `mola::NDT`.
+ */
+class TSDF : public mrpt::maps::CMetricMap,
+             public mp2p_icp::NearestPlaneCapable,
+             public mola::OptionsCapable
+{
+  DEFINE_SERIALIZABLE(TSDF, mola)
+ public:
+  TSDF(const TSDF&)            = default;
+  TSDF& operator=(const TSDF&) = default;
+  TSDF(TSDF&&)                 = default;
+  TSDF& operator=(TSDF&&)      = default;
+
+  using global_index3d_t = index3d_t<int32_t>;
+
+  /** @name Basic API for construction and main parameters
+   *  @{ */
+
+  /**
+   * @brief Constructor
+   * @param voxel_size Voxel size [meters]
+   */
+  TSDF(float voxel_size = 0.30f);
+
+  ~TSDF() override;
+
+  /** Resets the voxel size, and *clears* all current map contents. */
+  void setVoxelProperties(float voxel_size);
+
+  float voxelSize() const { return voxel_size_; }
+
+  /** @} */
+
+  /** @name Indices and coordinates
+   *  @{ */
+
+  /// Global index of the voxel containing a point.
+  inline global_index3d_t coordToGlobalIdx(const mrpt::math::TPoint3Df& pt) const
+  {
+    return global_index3d_t(
+        static_cast<int32_t>(std::floor(pt.x * voxel_size_inv_)),  //
+        static_cast<int32_t>(std::floor(pt.y * voxel_size_inv_)),  //
+        static_cast<int32_t>(std::floor(pt.z * voxel_size_inv_)));
+  }
+
+  /// Coordinates of the *center* of a voxel. The field is sampled at centers,
+  /// so this, and not the corner, is what the interpolation is built on.
+  inline mrpt::math::TPoint3Df globalIdxToCenter(const global_index3d_t idx) const
+  {
+    return {
+        (static_cast<float>(idx.cx) + 0.5f) * voxel_size_,  //
+        (static_cast<float>(idx.cy) + 0.5f) * voxel_size_,  //
+        (static_cast<float>(idx.cz) + 0.5f) * voxel_size_};
+  }
+
+  /** @} */
+
+  /** @name Data structures
+   *  @{ */
+
+  struct VoxelData
+  {
+    VoxelData() = default;
+
+    /// Truncated signed distance to the surface, in meters. Positive on the
+    /// free-space side, i.e. towards the sensor that measured it.
+    float dist = 0;
+
+    /// Accumulated weight of the samples averaged into `dist`.
+    float weight = 0;
+  };
+
+  using grids_map_t = tsl::robin_map<global_index3d_t, VoxelData, index3d_hash<int32_t>>;
+
+  /** @} */
+
+  /** @name Data access API
+   *  @{ */
+
+  /// Returns the voxel by global index, or nullptr if it does not exist.
+  inline const VoxelData* voxelByGlobalIdxs(const global_index3d_t& idx) const
+  {
+    auto it = voxels_.find(idx);
+    return it == voxels_.end() ? nullptr : &it.value();
+  }
+
+  /** Fuses one measured point into the field.
+   *  @param pt        Measured point, in map coordinates.
+   *  @param sensorPt  Origin of the measurement ray, in map coordinates.
+   */
+  void insertPoint(const mrpt::math::TPoint3Df& pt, const mrpt::math::TPoint3Df& sensorPt);
+
+  /** Result of a field query. */
+  struct FieldQuery
+  {
+    bool                   valid = false;
+    float                  dist  = 0;  //!< Interpolated signed distance [m]
+    mrpt::math::TVector3Df gradient{};  //!< Interpolated gradient, unnormalized
+  };
+
+  /** Trilinear interpolation of the field, and its analytical gradient, at an
+   *  arbitrary point. The query is `valid` only if all eight surrounding
+   *  voxels exist and carry at least `min_weight_for_query` of evidence: a
+   *  partially observed neighborhood would otherwise extrapolate a surface
+   *  from one measurement.
+   */
+  FieldQuery queryField(const mrpt::math::TPoint3Df& p) const;
+
+  const grids_map_t& voxels() const { return voxels_; }
+
+  size_t size() const { return voxels_.size(); }
+
+  mrpt::math::TBoundingBoxf boundingBox() const override;
+
+  void visitAllVoxels(
+      const std::function<void(const global_index3d_t&, const VoxelData&)>& f) const;
+
+  /** @} */
+
+  /** @name API of the NearestPlaneCapable virtual interface
+   *  @{ */
+
+  /** Returns the local tangent plane of the zero level set, as seen from the
+   *  query point: the plane through the point's own projection onto the
+   *  surface, with the field gradient as normal. There is no candidate set and
+   *  no selection, so `nn_visit_pt2pl_candidates()` reports exactly this one
+   *  pairing.
+   */
+  NearestPlaneResult nn_search_pt2pl(
+      const mrpt::math::TPoint3Df& point, const float max_search_distance) const override;
+
+  /** @} */
+
+  /** @name Public virtual methods implementation for CMetricMap
+   *  @{ */
+
+  std::string asString() const override;
+
+  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+
+  bool isEmpty() const override;
+
+  void saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const override;
+
+  /// Zero-crossing points of the field, for visualization and for the
+  /// MOLA->ROS2 bridge only. Not efficient.
+  const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const override;
+
+  /** @} */
+
+  /** Options that configure the map's internal structure. Changing
+   *  `voxel_size` after the map holds data discards its contents.
+   */
+  struct TCreationOptions : public mrpt::config::CLoadableOptions
+  {
+    TCreationOptions() = default;
+
+    void loadFromConfigFile(
+        const mrpt::config::CConfigFileBase& source, const std::string& section) override;
+    void dumpToTextStream(std::ostream& out) const override;
+
+    float voxel_size = 0.30f;
+  };
+  TCreationOptions creationOptions;
+
+  /** Options for insertObservation() */
+  struct TInsertionOptions : public mrpt::config::CLoadableOptions
+  {
+    TInsertionOptions() = default;
+
+    void loadFromConfigFile(
+        const mrpt::config::CConfigFileBase& source, const std::string& section) override;
+    void dumpToTextStream(std::ostream& out) const override;
+
+    void writeToStream(mrpt::serialization::CArchive& out) const;
+    void readFromStream(mrpt::serialization::CArchive& in);
+
+    /** Half-width of the band updated around each surface, in meters. If <=0,
+     *  it defaults to `truncation_voxels` times the voxel size.
+     *  This is also the maximum distance at which a query can find a surface,
+     *  so it must comfortably exceed the expected registration prior error.
+     */
+    double truncation_distance = .0;
+
+    /** Used only when `truncation_distance` is <= 0. */
+    double truncation_voxels = 4.0;
+
+    /** Radius of the cylinder around each measurement ray that receives
+     *  samples, in units of the voxel size. This is the **coverage** knob: it
+     *  has to reach at least half the spacing between adjacent beams at working
+     *  range, or the field is undefined between them and most scan points find
+     *  no surface to pair against.
+     */
+    double ray_tube_voxels = 1.5;
+
+    /** Standard deviation of the Gaussian profile applied across the tube, in
+     *  units of the voxel size, or <=0 for a flat profile. This is the **bias**
+     *  knob, and it is separate from the coverage one on purpose.
+     *
+     *  A sample is stored as its distance *along its own ray*, which for an
+     *  off-axis voxel over-estimates the distance to the surface, so averaging
+     *  samples over a wide tube pushes the zero level set away from the sensor.
+     *  Making the profile narrow keeps the average dominated by near-axis rays
+     *  while the cutoff above still fills the gaps between beams.
+     */
+    double tube_sigma_voxels = 0.4;
+
+    /** Weight cap of a voxel. It bounds how slowly the field can follow a
+     *  change in the scene, and it is what makes the average a running one.
+     */
+    double max_weight = 64.0;
+
+    /** Minimum accumulated weight for a voxel to take part in a query. */
+    double min_weight_for_query = 1.0;
+
+    /** If !=0, remove voxels farther (Chebyshev distance) than this, in
+     *  meters, from the current sensor pose. */
+    double remove_voxels_farther_than = .0;
+
+    /** If true, each sample is weighted by `(ref_range/range)^2`, the usual
+     *  range-dependent confidence of a range measurement. Default off, so the
+     *  map class is one axis on its own.
+     */
+    bool weight_by_range = false;
+
+    /** Reference range for `weight_by_range`, in meters. */
+    double weight_range_ref = 10.0;
+
+    /** If true, each sample is weighted by the cosine of the incidence angle
+     *  between the ray and the local surface normal, approximated by the field
+     *  gradient already present. Default off, for the same reason.
+     */
+    bool weight_by_incidence = false;
+  };
+  TInsertionOptions insertionOptions;
+
+  /** Rendering options, used in getVisualizationInto() */
+  struct TRenderOptions : public mrpt::config::CLoadableOptions
+  {
+    void loadFromConfigFile(
+        const mrpt::config::CConfigFileBase& source, const std::string& section) override;
+    void dumpToTextStream(std::ostream& out) const override;
+
+    void writeToStream(mrpt::serialization::CArchive& out) const;
+    void readFromStream(mrpt::serialization::CArchive& in);
+
+    float              point_size = 2.0f;
+    mrpt::img::TColorf points_color{.0f, .8f, .0f};
+  };
+  TRenderOptions renderOptions;
+
+  // mola::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
+  bool                                                                 trySetCreationOptions(
+                                                                      const mrpt::config::CConfigFileBase& cfg, const std::string& section) override;
+
+ public:
+  // Interface for use within a mrpt::maps::CMultiMetricMap:
+  MAP_DEFINITION_START(TSDF)
+  float voxel_size = 0.30f;
+
+  mola::TSDF::TInsertionOptions insertionOpts;
+  mola::TSDF::TRenderOptions    renderOpts;
+  MAP_DEFINITION_END(TSDF)
+
+ private:
+  float voxel_size_ = 0.30f;
+
+  // Calculated from the above, in setVoxelProperties():
+  float voxel_size_inv_ = 1.0f / voxel_size_;
+
+  /// Effective truncation distance, resolved from insertionOptions.
+  float truncation() const
+  {
+    return insertionOptions.truncation_distance > 0
+               ? static_cast<float>(insertionOptions.truncation_distance)
+               : static_cast<float>(insertionOptions.truncation_voxels) * voxel_size_;
+  }
+
+  grids_map_t voxels_;
+
+  mutable std::optional<mrpt::math::TBoundingBoxf> cachedBoundingBox_;
+  mutable mrpt::maps::CSimplePointsMap::Ptr        cachedPoints_;
+
+  void invalidateCaches();
+
+ protected:
+  // See docs in base CMetricMap class:
+  void internal_clear() override;
+
+ private:
+  // See docs in base CMetricMap class:
+  bool internal_insertObservation(
+      const mrpt::obs::CObservation&                   obs,
+      const std::optional<const mrpt::poses::CPose3D>& robotPose = std::nullopt) override;
+
+  double internal_computeObservationLikelihood(
+      const mrpt::obs::CObservation& obs, const mrpt::poses::CPose3D& takenFrom) const override;
+
+  bool internal_canComputeObservationLikelihood(const mrpt::obs::CObservation& obs) const override;
+
+  /** Removes voxels far from the given sensor position. */
+  void pruneFarVoxels(const mrpt::math::TPoint3Df& sensorPt);
+
+  /** - (xs,ys,zs): sensed point coordinates in the sensor frame.
+   *  - pc_in_map: SE(3) pose of the sensor in the map frame.
+   */
+  void internal_insertPointCloud3D(
+      const mrpt::poses::CPose3D& pc_in_map, const float* xs, const float* ys, const float* zs,
+      const std::size_t num_pts);
+};
+
+}  // namespace mola

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <vector>
 
 namespace mola
 {
@@ -197,6 +198,16 @@ class TSDF : public mrpt::maps::CMetricMap,
 
   size_t size() const { return voxels_.size(); }
 
+  /** True while queries are still answered from the warm-up point cloud
+   *  instead of from the field. \sa TInsertionOptions::bootstrap_with_points
+   */
+  bool isBootstrapping() const { return bootstrapping_; }
+
+  /** Fraction of the last inserted scan at which the field returned a valid
+   *  query. This is the quantity that ends the warm-up.
+   */
+  double lastFieldReadyFraction() const { return fieldReadyFraction_; }
+
   mrpt::math::TBoundingBoxf boundingBox() const override;
 
   void visitAllVoxels(
@@ -340,6 +351,47 @@ class TSDF : public mrpt::maps::CMetricMap,
      *  gradient already present. Default off, for the same reason.
      */
     bool weight_by_incidence = false;
+
+    /** @name Warm-up
+     *  @{ */
+
+    /** Answer queries from a point cloud accumulated over the first scans, and
+     *  switch to the field once the field can answer.
+     *
+     *  A field map is empty in a way a point map is not. One scan of points is
+     *  immediately queryable; one scan of field is not, because a trilinear
+     *  query needs all eight surrounding voxels and adjacent beams are more
+     *  than a voxel apart at working range. Without a warm-up the first
+     *  registration finds no surface at all, the caller discards the map as a
+     *  failed start, and the run never gets going.
+     */
+    bool bootstrap_with_points = true;
+
+    /** Scans to accumulate before the field is tested at all. */
+    uint32_t bootstrap_min_scans = 2;
+
+    /** Hard bound on the warm-up, in scans. If the field still cannot answer by
+     *  then, the switch happens anyway and a message is printed: a map that
+     *  quietly stayed a point cloud under this class's name would misreport
+     *  what was measured.
+     */
+    uint32_t bootstrap_max_scans = 20;
+
+    /** Fraction of the last scan's points at which the field must return a
+     *  valid query for the warm-up to end.
+     */
+    double bootstrap_field_ready_fraction = 0.5;
+
+    /** Neighbors used for the warm-up plane fit. */
+    uint32_t bootstrap_knn = 10;
+
+    /** Maximum distance [m] any neighbor may sit from the fitted plane for that
+     *  plane to be used. A neighborhood that is not locally planar has no
+     *  tangent plane to offer, and a bad one is worse than none.
+     */
+    double bootstrap_max_plane_deviation = 0.10;
+
+    /** @} */
   };
   TInsertionOptions insertionOptions;
 
@@ -392,6 +444,38 @@ class TSDF : public mrpt::maps::CMetricMap,
   mutable mrpt::maps::CSimplePointsMap::Ptr        cachedPoints_;
 
   void invalidateCaches();
+
+  /** @name Warm-up state
+   *  Everything below is live only until the field can answer, and is released
+   *  at that point. \sa TInsertionOptions::bootstrap_with_points
+   *  @{ */
+
+  bool     bootstrapping_      = true;
+  bool     bootstrapWarned_    = false;
+  uint32_t bootstrapScans_     = 0;
+  double   fieldReadyFraction_ = 0;
+
+  /// Points of the scans seen so far, in the map frame. Held in an optional so
+  /// that ending the warm-up actually releases the storage.
+  std::optional<mrpt::maps::CSimplePointsMap> bootstrapPoints_;
+
+  /// A decimated copy of the scan being inserted, in the map frame. Querying
+  /// the field at these is what measures whether it is ready.
+  std::vector<mrpt::math::TPoint3Df> bootstrapProbe_;
+
+  /// k-NN plane fit over `bootstrapPoints_`: the warm-up stand-in for a field
+  /// query, returning the same point-to-plane pairing.
+  NearestPlaneResult bootstrapSearch(
+      const mrpt::math::TPoint3Df& query, float max_search_distance) const;
+
+  /// Called once per inserted observation: measures the field's readiness and
+  /// ends the warm-up when it is ready, or when it has gone on too long.
+  void updateBootstrapState();
+
+  /// Drops the warm-up point cloud and starts answering from the field.
+  void endBootstrap();
+
+  /** @} */
 
  protected:
   // See docs in base CMetricMap class:

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -273,8 +273,30 @@ class TSDF : public mrpt::maps::CMetricMap,
     double min_weight_for_query = 1.0;
 
     /** If !=0, remove voxels farther (Chebyshev distance) than this, in
-     *  meters, from the current sensor pose. */
+     *  meters, from the current sensor pose.
+     *
+     *  A field map must not be given a point map's extent. It allocates a band
+     *  of voxels around every surface rather than one cell per measured point,
+     *  so its footprint grows with the retained volume and with the inverse
+     *  cube of the voxel size, not with the point count.
+     */
     double remove_voxels_farther_than = .0;
+
+    /** If !=0, a hard ceiling on the number of voxels. Once exceeded, the
+     *  effective extent is shrunk until the map fits, so the footprint is
+     *  bounded whatever the voxel size, the scene density or the trajectory.
+     *
+     *  This exists because `remove_voxels_farther_than` alone does not bound
+     *  anything usefully: at a fixed extent the voxel count still scales as the
+     *  inverse cube of the voxel size and with how much surface the scene puts
+     *  inside that extent, and a run that diverges sweeps an arbitrary volume.
+     *  Measured on kitti-05 at a 0.3 m voxel, a 155 m extent peaked at 110 GB.
+     *
+     *  The eviction is by distance, not by age, so it stays a pure function of
+     *  the map contents and the sensor pose and does not depend on insertion
+     *  order.
+     */
+    uint64_t max_voxels = 0;
 
     /** If true, each sample is weighted by `(ref_range/range)^2`, the usual
      *  range-dependent confidence of a range measurement. Default off, so the

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -39,6 +39,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 using namespace mola;
 
@@ -426,23 +428,50 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::nn_search_pt2pl(
 
 void TSDF::pruneFarVoxels(const mrpt::math::TPoint3Df& sensorPt)
 {
-  if (insertionOptions.remove_voxels_farther_than <= 0)
+  const bool byExtent = insertionOptions.remove_voxels_farther_than > 0;
+  const bool byCount =
+      insertionOptions.max_voxels > 0 && voxels_.size() > insertionOptions.max_voxels;
+
+  if (!byExtent && !byCount)
   {
     return;
   }
 
-  const int distInGrid =
-      static_cast<int>(std::ceil(insertionOptions.remove_voxels_farther_than * voxel_size_inv_));
-
   const auto idxCurObs = coordToGlobalIdx(sensorPt);
+
+  const auto chebyshev = [&idxCurObs](const global_index3d_t& i)
+  {
+    return mrpt::max3(
+        std::abs(i.cx - idxCurObs.cx), std::abs(i.cy - idxCurObs.cy),
+        std::abs(i.cz - idxCurObs.cz));
+  };
+
+  int distInGrid = std::numeric_limits<int>::max();
+  if (byExtent)
+  {
+    distInGrid =
+        static_cast<int>(std::ceil(insertionOptions.remove_voxels_farther_than * voxel_size_inv_));
+  }
+
+  if (byCount)
+  {
+    // Shrink the effective radius until the map fits under the ceiling. Taking
+    // the n-th smallest distance keeps this a pure function of the contents and
+    // the sensor pose, so it does not depend on insertion order.
+    std::vector<int> dists;
+    dists.reserve(voxels_.size());
+    for (const auto& [idx, v] : voxels_)
+    {
+      dists.push_back(chebyshev(idx));
+    }
+    const size_t keep = insertionOptions.max_voxels;
+    std::nth_element(dists.begin(), dists.begin() + keep, dists.end());
+    distInGrid = std::min(distInGrid, dists[keep]);
+  }
 
   for (auto it = voxels_.begin(); it != voxels_.end();)
   {
-    const int dist = mrpt::max3(
-        std::abs(it->first.cx - idxCurObs.cx), std::abs(it->first.cy - idxCurObs.cy),
-        std::abs(it->first.cz - idxCurObs.cz));
-
-    if (dist > distInGrid)
+    if (chebyshev(it->first) > distInGrid)
     {
       it = voxels_.erase(it);
     }
@@ -751,6 +780,8 @@ void TSDF::TInsertionOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR(max_weight, double, c, s);
   MRPT_LOAD_CONFIG_VAR(min_weight_for_query, double, c, s);
   MRPT_LOAD_CONFIG_VAR(remove_voxels_farther_than, double, c, s);
+  max_voxels =
+      static_cast<uint64_t>(c.read_double(s, "max_voxels", static_cast<double>(max_voxels)));
   MRPT_LOAD_CONFIG_VAR(weight_by_range, bool, c, s);
   MRPT_LOAD_CONFIG_VAR(weight_range_ref, double, c, s);
   MRPT_LOAD_CONFIG_VAR(weight_by_incidence, bool, c, s);
@@ -766,6 +797,7 @@ void TSDF::TInsertionOptions::dumpToTextStream(std::ostream& out) const
   LOADABLEOPTS_DUMP_VAR(max_weight, double);
   LOADABLEOPTS_DUMP_VAR(min_weight_for_query, double);
   LOADABLEOPTS_DUMP_VAR(remove_voxels_farther_than, double);
+  out << mrpt::format("max_voxels = %lu\n", static_cast<unsigned long>(max_voxels));
   LOADABLEOPTS_DUMP_VAR(weight_by_range, bool);
   LOADABLEOPTS_DUMP_VAR(weight_range_ref, double);
   LOADABLEOPTS_DUMP_VAR(weight_by_incidence, bool);
@@ -776,8 +808,8 @@ void TSDF::TInsertionOptions::writeToStream(mrpt::serialization::CArchive& out) 
   const int8_t version = 0;
   out << version;
   out << truncation_distance << truncation_voxels << ray_tube_voxels << tube_sigma_voxels
-      << max_weight << min_weight_for_query << remove_voxels_farther_than << weight_by_range
-      << weight_range_ref << weight_by_incidence;
+      << max_weight << min_weight_for_query << remove_voxels_farther_than << max_voxels
+      << weight_by_range << weight_range_ref << weight_by_incidence;
 }
 
 void TSDF::TInsertionOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -788,8 +820,8 @@ void TSDF::TInsertionOptions::readFromStream(mrpt::serialization::CArchive& in)
   {
     case 0:
       in >> truncation_distance >> truncation_voxels >> ray_tube_voxels >> tube_sigma_voxels >>
-          max_weight >> min_weight_for_query >> remove_voxels_farther_than >> weight_by_range >>
-          weight_range_ref >> weight_by_incidence;
+          max_weight >> min_weight_for_query >> remove_voxels_farther_than >> max_voxels >>
+          weight_by_range >> weight_range_ref >> weight_by_incidence;
       break;
     default:
       MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -29,6 +29,7 @@
 #include <mola_metric_maps/TSDF.h>
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/math/geometry.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
@@ -39,6 +40,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <limits>
 #include <vector>
 
@@ -95,7 +97,7 @@ IMPLEMENTS_SERIALIZABLE(TSDF, CMetricMap, mola)
 // Serialization
 // =====================================
 
-uint8_t TSDF::serializeGetVersion() const { return 0; }
+uint8_t TSDF::serializeGetVersion() const { return 1; }
 
 void TSDF::serializeTo(mrpt::serialization::CArchive& out) const
 {
@@ -111,6 +113,15 @@ void TSDF::serializeTo(mrpt::serialization::CArchive& out) const
     out << idx.cx << idx.cy << idx.cz;
     out << voxel.dist << voxel.weight;
   }
+
+  // Warm-up state (v1). A map saved mid-warm-up would otherwise come back
+  // answering from a field that cannot yet answer.
+  out << bootstrapping_ << bootstrapScans_ << fieldReadyFraction_;
+  out << bootstrapPoints_.has_value();
+  if (bootstrapPoints_)
+  {
+    out << *bootstrapPoints_;
+  }
 }
 
 void TSDF::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
@@ -118,6 +129,7 @@ void TSDF::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
   switch (version)
   {
     case 0:
+    case 1:
     {
       float vxSize = 0;
       in >> vxSize;
@@ -138,6 +150,27 @@ void TSDF::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
         in >> v.dist >> v.weight;
         voxels_[idx] = v;
       }
+
+      if (version >= 1)
+      {
+        in >> bootstrapping_ >> bootstrapScans_ >> fieldReadyFraction_;
+        bool hasPoints = false;
+        in >> hasPoints;
+        if (hasPoints)
+        {
+          in >> bootstrapPoints_.emplace();
+        }
+        else
+        {
+          bootstrapPoints_.reset();
+        }
+      }
+      else
+      {
+        // A map written before the warm-up existed is a finished map.
+        endBootstrap();
+      }
+
       invalidateCaches();
     }
     break;
@@ -170,6 +203,14 @@ void TSDF::setVoxelProperties(float voxel_size)
 void TSDF::internal_clear()
 {
   voxels_.clear();
+
+  bootstrapping_      = true;
+  bootstrapWarned_    = false;
+  bootstrapScans_     = 0;
+  fieldReadyFraction_ = 0;
+  bootstrapPoints_.reset();
+  bootstrapProbe_.clear();
+
   invalidateCaches();
 }
 
@@ -380,6 +421,15 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::nn_search_pt2pl(
 {
   NearestPlaneCapable::NearestPlaneResult ret;
 
+  // While the field is still filling in, the same pairing comes from a plane
+  // fitted to the accumulated points. A map built through the low-level
+  // insertPoint() API has no warm-up cloud and goes straight to the field.
+  if (bootstrapping_ && insertionOptions.bootstrap_with_points && bootstrapPoints_ &&
+      !bootstrapPoints_->empty())
+  {
+    return bootstrapSearch(query, max_search_distance);
+  }
+
   const auto q = queryField(query);
   if (!q.valid)
   {
@@ -420,6 +470,160 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::nn_search_pt2pl(
   ret.distance = std::abs(step);
 
   return ret;
+}
+
+// =====================================
+// Warm-up
+// =====================================
+
+mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::bootstrapSearch(
+    const mrpt::math::TPoint3Df& query, const float max_search_distance) const
+{
+  NearestPlaneCapable::NearestPlaneResult ret;
+
+  const size_t knn = insertionOptions.bootstrap_knn;
+  ASSERT_GE_(knn, 3U);
+
+  if (!bootstrapPoints_ || bootstrapPoints_->size() < knn)
+  {
+    return ret;
+  }
+
+  // The neighbor search is deliberately not capped at `max_search_distance`.
+  // That bound is on the distance to the *surface*, which is what the field
+  // applies too, while the patch needed to fit a plane is necessarily wider
+  // than it. What bounds the search instead is the map's own declared reach.
+  std::vector<size_t> idxs;
+  std::vector<float>  distsSqr;
+  bootstrapPoints_->kdTreeNClosestPoint3DIdx(query.x, query.y, query.z, knn, idxs, distsSqr);
+
+  if (idxs.size() < knn)
+  {
+    return ret;
+  }
+
+  const float reach = std::max(max_search_distance, truncation());
+  if (distsSqr.front() > reach * reach)
+  {
+    return ret;
+  }
+
+  const auto& xs = bootstrapPoints_->getPointsBufferRef_x();
+  const auto& ys = bootstrapPoints_->getPointsBufferRef_y();
+  const auto& zs = bootstrapPoints_->getPointsBufferRef_z();
+
+  std::vector<mrpt::math::TPoint3D> neighbors;
+  neighbors.reserve(knn);
+  for (const size_t i : idxs)
+  {
+    neighbors.emplace_back(xs[i], ys[i], zs[i]);
+  }
+
+  mrpt::math::TPlane plane;
+  mrpt::math::getRegressionPlane(neighbors, plane);
+  plane.unitarize();
+
+  // A neighborhood that is not locally planar has no tangent plane to offer,
+  // and a bad one is worse than none.
+  const auto maxDev = static_cast<double>(insertionOptions.bootstrap_max_plane_deviation);
+  if (maxDev > 0)
+  {
+    for (const auto& n : neighbors)
+    {
+      if (std::abs(plane.evaluatePoint(n)) > maxDev)
+      {
+        return ret;
+      }
+    }
+  }
+
+  const mrpt::math::TPoint3D q3d(query.x, query.y, query.z);
+
+  // Unitarized, this is the signed distance along the plane normal. Its sign
+  // depends on the arbitrary orientation the fit gave the normal, which the
+  // point-to-plane residual is invariant to: flipping the normal flips the
+  // residual too, and the product is unchanged.
+  const double signedDist = plane.evaluatePoint(q3d);
+  if (std::abs(signedDist) > max_search_distance)
+  {
+    return ret;
+  }
+
+  const mrpt::math::TVector3D normal = plane.getNormalVector();
+
+  const mrpt::math::TPoint3D foot = {
+      q3d.x - signedDist * normal.x,  //
+      q3d.y - signedDist * normal.y,  //
+      q3d.z - signedDist * normal.z};
+
+  auto& pa              = ret.pairing.emplace();
+  pa.pt_local           = query;
+  pa.pl_global.centroid = foot;
+  pa.pl_global.plane    = mrpt::math::TPlane(foot, normal);
+
+  ret.distance = static_cast<float>(std::abs(signedDist));
+
+  return ret;
+}
+
+void TSDF::updateBootstrapState()
+{
+  if (!bootstrapping_)
+  {
+    return;
+  }
+
+  if (!insertionOptions.bootstrap_with_points)
+  {
+    endBootstrap();
+    return;
+  }
+
+  bootstrapScans_++;
+
+  size_t valid = 0;
+  for (const auto& p : bootstrapProbe_)
+  {
+    if (queryField(p).valid)
+    {
+      valid++;
+    }
+  }
+  fieldReadyFraction_ =
+      bootstrapProbe_.empty() ? .0 : double(valid) / double(bootstrapProbe_.size());
+  bootstrapProbe_.clear();
+
+  const bool ready = bootstrapScans_ >= insertionOptions.bootstrap_min_scans &&
+                     fieldReadyFraction_ >= insertionOptions.bootstrap_field_ready_fraction;
+
+  if (ready)
+  {
+    endBootstrap();
+    return;
+  }
+
+  if (bootstrapScans_ >= insertionOptions.bootstrap_max_scans)
+  {
+    if (!bootstrapWarned_)
+    {
+      bootstrapWarned_ = true;
+      std::cerr << "[mola::TSDF] Warning: the field could only answer "
+                << mrpt::format("%.1f%%", 100.0 * fieldReadyFraction_) << " of the last scan after "
+                << bootstrapScans_
+                << " scans, below the configured bootstrap_field_ready_fraction. Switching to the "
+                   "field anyway. A coarser voxel_size, a wider ray_tube_voxels or a lower "
+                   "min_weight_for_query would each let it fill in sooner.\n";
+    }
+    endBootstrap();
+  }
+}
+
+void TSDF::endBootstrap()
+{
+  bootstrapping_ = false;
+  bootstrapPoints_.reset();
+  bootstrapProbe_.clear();
+  bootstrapProbe_.shrink_to_fit();
 }
 
 // =====================================
@@ -489,11 +693,44 @@ void TSDF::internal_insertPointCloud3D(
 {
   const auto sensorPt = pc_in_map.translation().cast<float>();
 
+  const bool warmingUp = bootstrapping_ && insertionOptions.bootstrap_with_points;
+  if (warmingUp)
+  {
+    if (!bootstrapPoints_)
+    {
+      bootstrapPoints_.emplace();
+      bootstrapPoints_->insertionOptions.minDistBetweenLaserPoints = .0f;
+    }
+    bootstrapPoints_->reserve(bootstrapPoints_->size() + num_pts);
+  }
+
+  // One point in this many is kept to probe the field's readiness, so the test
+  // costs a fixed fraction of the insertion whatever the scan size.
+  constexpr std::size_t PROBE_DECIMATION = 20;
+
   for (std::size_t i = 0; i < num_pts; i++)
   {
     const auto gPt = pc_in_map.composePoint(mrpt::math::TPoint3Df(xs[i], ys[i], zs[i]));
     insertPoint(gPt, sensorPt);
+
+    if (warmingUp)
+    {
+      bootstrapPoints_->insertPointFast(gPt.x, gPt.y, gPt.z);
+      if (i % PROBE_DECIMATION == 0)
+      {
+        bootstrapProbe_.push_back(gPt);
+      }
+    }
   }
+
+  if (warmingUp)
+  {
+    bootstrapPoints_->mark_as_modified();
+  }
+
+  // Called here, and not per observation, because this is the one path every
+  // observation type funnels through.
+  updateBootstrapState();
 }
 
 bool TSDF::internal_insertObservation(
@@ -615,9 +852,17 @@ bool TSDF::isEmpty() const { return voxels_.empty(); }
 
 std::string TSDF::asString() const
 {
-  return mrpt::format(
+  std::string ret = mrpt::format(
       "TSDF, voxel_size=%.03f truncation=%.03f voxels=%u", voxel_size_, truncation(),
       static_cast<unsigned int>(voxels_.size()));
+
+  if (bootstrapping_)
+  {
+    ret += mrpt::format(
+        " [warming up: %u scans, field answers %.1f%% of the last one]", bootstrapScans_,
+        100.0 * fieldReadyFraction_);
+  }
+  return ret;
 }
 
 void TSDF::visitAllVoxels(
@@ -785,6 +1030,16 @@ void TSDF::TInsertionOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR(weight_by_range, bool, c, s);
   MRPT_LOAD_CONFIG_VAR(weight_range_ref, double, c, s);
   MRPT_LOAD_CONFIG_VAR(weight_by_incidence, bool, c, s);
+
+  MRPT_LOAD_CONFIG_VAR(bootstrap_with_points, bool, c, s);
+  bootstrap_min_scans = static_cast<uint32_t>(
+      c.read_int(s, "bootstrap_min_scans", static_cast<int>(bootstrap_min_scans)));
+  bootstrap_max_scans = static_cast<uint32_t>(
+      c.read_int(s, "bootstrap_max_scans", static_cast<int>(bootstrap_max_scans)));
+  MRPT_LOAD_CONFIG_VAR(bootstrap_field_ready_fraction, double, c, s);
+  bootstrap_knn =
+      static_cast<uint32_t>(c.read_int(s, "bootstrap_knn", static_cast<int>(bootstrap_knn)));
+  MRPT_LOAD_CONFIG_VAR(bootstrap_max_plane_deviation, double, c, s);
 }
 
 void TSDF::TInsertionOptions::dumpToTextStream(std::ostream& out) const
@@ -801,15 +1056,24 @@ void TSDF::TInsertionOptions::dumpToTextStream(std::ostream& out) const
   LOADABLEOPTS_DUMP_VAR(weight_by_range, bool);
   LOADABLEOPTS_DUMP_VAR(weight_range_ref, double);
   LOADABLEOPTS_DUMP_VAR(weight_by_incidence, bool);
+  LOADABLEOPTS_DUMP_VAR(bootstrap_with_points, bool);
+  out << mrpt::format("bootstrap_min_scans = %u\n", bootstrap_min_scans);
+  out << mrpt::format("bootstrap_max_scans = %u\n", bootstrap_max_scans);
+  LOADABLEOPTS_DUMP_VAR(bootstrap_field_ready_fraction, double);
+  out << mrpt::format("bootstrap_knn = %u\n", bootstrap_knn);
+  LOADABLEOPTS_DUMP_VAR(bootstrap_max_plane_deviation, double);
 }
 
 void TSDF::TInsertionOptions::writeToStream(mrpt::serialization::CArchive& out) const
 {
-  const int8_t version = 0;
+  const int8_t version = 1;
   out << version;
   out << truncation_distance << truncation_voxels << ray_tube_voxels << tube_sigma_voxels
       << max_weight << min_weight_for_query << remove_voxels_farther_than << max_voxels
       << weight_by_range << weight_range_ref << weight_by_incidence;
+  // v1:
+  out << bootstrap_with_points << bootstrap_min_scans << bootstrap_max_scans
+      << bootstrap_field_ready_fraction << bootstrap_knn << bootstrap_max_plane_deviation;
 }
 
 void TSDF::TInsertionOptions::readFromStream(mrpt::serialization::CArchive& in)
@@ -819,9 +1083,15 @@ void TSDF::TInsertionOptions::readFromStream(mrpt::serialization::CArchive& in)
   switch (version)
   {
     case 0:
+    case 1:
       in >> truncation_distance >> truncation_voxels >> ray_tube_voxels >> tube_sigma_voxels >>
           max_weight >> min_weight_for_query >> remove_voxels_farther_than >> max_voxels >>
           weight_by_range >> weight_range_ref >> weight_by_incidence;
+      if (version >= 1)
+      {
+        in >> bootstrap_with_points >> bootstrap_min_scans >> bootstrap_max_scans >>
+            bootstrap_field_ready_fraction >> bootstrap_knn >> bootstrap_max_plane_deviation;
+      }
       break;
     default:
       MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -27,9 +27,9 @@
 */
 
 #include <mola_metric_maps/TSDF.h>
-#include <mp2p_icp/estimate_points_eigen.h>
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/math/geometry.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
@@ -512,44 +512,52 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::bootstrapSearch(
   const auto& ys = bootstrapPoints_->getPointsBufferRef_y();
   const auto& zs = bootstrapPoints_->getPointsBufferRef_z();
 
-  // The principal components of the neighborhood, which is how every other map
-  // class in this library fits a local plane. It also reports the degenerate
-  // cases instead of throwing on them, and a neighborhood of collinear points
-  // is not rare here: on the first scans it can easily be a single scan line.
-  const mp2p_icp::PointCloudEigen pca =
-      mp2p_icp::estimate_points_eigen(xs.data(), ys.data(), zs.data(), idxs);
+  std::vector<mrpt::math::TPoint3D> neighbors;
+  neighbors.reserve(knn);
+  for (const size_t i : idxs)
+  {
+    neighbors.emplace_back(xs[i], ys[i], zs[i]);
+  }
 
-  // Eigenvalues ascending. This tests numerical degeneracy only: a neighborhood
-  // with no second spread direction has no tangent plane at all, and asking for
-  // one yields an arbitrary normal. Planarity proper belongs to the deviation
-  // gate below; testing it here instead rejects the merely elongated
-  // neighborhoods that scan lines produce in quantity on the first scans, and
-  // starves exactly the registrations the warm-up exists to feed.
-  if (!(pca.eigVals[2] > 0) || pca.eigVals[1] < 1e-9 * pca.eigVals[2])
+  // The regression plane through the neighborhood. It throws when its points
+  // are collinear, which a k-NN neighborhood over the first scans genuinely can
+  // be: LiDAR samples are far denser along a scan ring than across rings, so
+  // the nearest neighbors of a point often all come from one ring. That is a
+  // "no plane here" answer, not an error, and it must not escape into the
+  // matcher, whose caller treats any exception as fatal and stops the run.
+  mrpt::math::TPlane plane;
+  try
+  {
+    mrpt::math::getRegressionPlane(neighbors, plane);
+  }
+  catch (const std::exception&)
   {
     return ret;
   }
+  plane.unitarize();
 
-  // The smallest eigenvalue is the variance across the fitted plane, so its
-  // square root is the neighborhood's RMS distance from that plane: a
-  // neighborhood that is not locally planar has no plane worth pairing against.
+  // A neighborhood that is not locally planar has no tangent plane to offer,
+  // and a bad one is worse than none.
   const auto maxDev = static_cast<double>(insertionOptions.bootstrap_max_plane_deviation);
-  if (maxDev > 0 && std::sqrt(std::max(.0, pca.eigVals[0])) > maxDev)
+  if (maxDev > 0)
   {
-    return ret;
+    for (const auto& n : neighbors)
+    {
+      if (std::abs(plane.evaluatePoint(n)) > maxDev)
+      {
+        return ret;
+      }
+    }
   }
 
-  const mrpt::math::TVector3D normal   = pca.eigVectors[0];
-  const mrpt::math::TPoint3D  centroid = pca.meanCov.mean.asTPoint();
-  const mrpt::math::TPoint3D  q3d(query.x, query.y, query.z);
+  const mrpt::math::TPoint3D q3d(query.x, query.y, query.z);
 
-  // Signed distance along the plane normal. Its sign depends on the arbitrary
-  // orientation the decomposition gave the normal, which the point-to-plane
-  // residual is invariant to: flipping the normal flips the residual too, and
-  // the product is unchanged.
-  const double signedDist = normal.x * (q3d.x - centroid.x) +  //
-                            normal.y * (q3d.y - centroid.y) +  //
-                            normal.z * (q3d.z - centroid.z);
+  // Unitarized, this is the signed distance along the plane normal. Its sign
+  // depends on the arbitrary orientation the fit gave the normal, which the
+  // point-to-plane residual is invariant to: flipping the normal flips the
+  // residual too, and the product is unchanged.
+  const double                signedDist = plane.evaluatePoint(q3d);
+  const mrpt::math::TVector3D normal     = plane.getNormalVector();
 
   if (std::abs(signedDist) > max_search_distance)
   {
@@ -734,8 +742,14 @@ void TSDF::internal_insertPointCloud3D(
   }
 
   // Called here, and not per observation, because this is the one path every
-  // observation type funnels through.
-  updateBootstrapState();
+  // observation type funnels through. An observation that carried no points
+  // says nothing about the field, and counting it would let a run of empty
+  // scans exhaust the warm-up and throw away the fallback cloud before any
+  // real scan had arrived.
+  if (num_pts > 0)
+  {
+    updateBootstrapState();
+  }
 }
 
 bool TSDF::internal_insertObservation(
@@ -1044,13 +1058,16 @@ void TSDF::TInsertionOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR(weight_by_incidence, bool, c, s);
 
   MRPT_LOAD_CONFIG_VAR(bootstrap_with_points, bool, c, s);
+  // Clamped before the conversion: a negative value would wrap to a huge
+  // unsigned bound, and an unbounded warm-up keeps every scan it has seen.
   bootstrap_min_scans = static_cast<uint32_t>(
-      c.read_int(s, "bootstrap_min_scans", static_cast<int>(bootstrap_min_scans)));
+      std::max(0, c.read_int(s, "bootstrap_min_scans", static_cast<int>(bootstrap_min_scans))));
   bootstrap_max_scans = static_cast<uint32_t>(
-      c.read_int(s, "bootstrap_max_scans", static_cast<int>(bootstrap_max_scans)));
+      std::max(0, c.read_int(s, "bootstrap_max_scans", static_cast<int>(bootstrap_max_scans))));
   MRPT_LOAD_CONFIG_VAR(bootstrap_field_ready_fraction, double, c, s);
-  bootstrap_knn =
-      static_cast<uint32_t>(c.read_int(s, "bootstrap_knn", static_cast<int>(bootstrap_knn)));
+  // The plane fit needs three points, and bootstrapSearch() asserts as much.
+  bootstrap_knn = static_cast<uint32_t>(
+      std::max(3, c.read_int(s, "bootstrap_knn", static_cast<int>(bootstrap_knn))));
   MRPT_LOAD_CONFIG_VAR(bootstrap_max_plane_deviation, double, c, s);
 }
 

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -792,6 +792,12 @@ bool TSDF::internal_insertObservation(
     pp.takeIntoAccountSensorPoseOnRobot = true;
 
     mrpt::maps::CSimplePointsMap pointMap;
+
+    // The two sources do not deliver points in the same frame: the stored
+    // points3D_* are in the sensor frame, while unprojectInto() with the
+    // parameter above already brings them into the robot frame.
+    mrpt::poses::CPose3D cloudPose = robotPose3D;
+
     if (o.hasPoints3D)
     {
       pointMap.insertionOptions.minDistBetweenLaserPoints = .0f;
@@ -799,6 +805,7 @@ bool TSDF::internal_insertObservation(
       {
         pointMap.insertPointFast(o.points3D_x[i], o.points3D_y[i], o.points3D_z[i]);
       }
+      cloudPose = robotPose3D + o.sensorPose;
     }
     else if (o.hasRangeImage)
     {
@@ -813,7 +820,7 @@ bool TSDF::internal_insertObservation(
     const auto& ys = pointMap.getPointsBufferRef_y();
     const auto& zs = pointMap.getPointsBufferRef_z();
 
-    internal_insertPointCloud3D(robotPose3D, xs.data(), ys.data(), zs.data(), xs.size());
+    internal_insertPointCloud3D(cloudPose, xs.data(), ys.data(), zs.data(), xs.size());
     return true;
   }
 
@@ -1102,16 +1109,18 @@ void TSDF::TRenderOptions::loadFromConfigFile(
     const mrpt::config::CConfigFileBase& c, const std::string& s)
 {
   MRPT_LOAD_CONFIG_VAR(point_size, float, c, s);
-  points_color = mrpt::img::TColorf(
-      c.read_float(s, "points_color_r", points_color.R),
-      c.read_float(s, "points_color_g", points_color.G),
-      c.read_float(s, "points_color_b", points_color.B));
+  MRPT_LOAD_CONFIG_VAR(points_color.R, float, c, s);
+  MRPT_LOAD_CONFIG_VAR(points_color.G, float, c, s);
+  MRPT_LOAD_CONFIG_VAR(points_color.B, float, c, s);
 }
 
 void TSDF::TRenderOptions::dumpToTextStream(std::ostream& out) const
 {
   out << "\n------ [TSDF::TRenderOptions] ------- \n\n";
   LOADABLEOPTS_DUMP_VAR(point_size, float);
+  LOADABLEOPTS_DUMP_VAR(points_color.R, float);
+  LOADABLEOPTS_DUMP_VAR(points_color.G, float);
+  LOADABLEOPTS_DUMP_VAR(points_color.B, float);
 }
 
 void TSDF::TRenderOptions::writeToStream(mrpt::serialization::CArchive& out) const

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -519,9 +519,13 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::bootstrapSearch(
   const mp2p_icp::PointCloudEigen pca =
       mp2p_icp::estimate_points_eigen(xs.data(), ys.data(), zs.data(), idxs);
 
-  // Eigenvalues ascending. A line or a point has no second spread direction and
-  // therefore no tangent plane; taking one anyway yields an arbitrary normal.
-  if (pca.eigVals[1] < 1e-3 * pca.eigVals[2])
+  // Eigenvalues ascending. This tests numerical degeneracy only: a neighborhood
+  // with no second spread direction has no tangent plane at all, and asking for
+  // one yields an arbitrary normal. Planarity proper belongs to the deviation
+  // gate below; testing it here instead rejects the merely elongated
+  // neighborhoods that scan lines produce in quantity on the first scans, and
+  // starves exactly the registrations the warm-up exists to feed.
+  if (!(pca.eigVals[2] > 0) || pca.eigVals[1] < 1e-9 * pca.eigVals[2])
   {
     return ret;
   }

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -27,9 +27,9 @@
 */
 
 #include <mola_metric_maps/TSDF.h>
+#include <mp2p_icp/estimate_points_eigen.h>
 #include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
 #include <mrpt/maps/CSimplePointsMap.h>
-#include <mrpt/math/geometry.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
@@ -512,44 +512,45 @@ mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::bootstrapSearch(
   const auto& ys = bootstrapPoints_->getPointsBufferRef_y();
   const auto& zs = bootstrapPoints_->getPointsBufferRef_z();
 
-  std::vector<mrpt::math::TPoint3D> neighbors;
-  neighbors.reserve(knn);
-  for (const size_t i : idxs)
-  {
-    neighbors.emplace_back(xs[i], ys[i], zs[i]);
-  }
+  // The principal components of the neighborhood, which is how every other map
+  // class in this library fits a local plane. It also reports the degenerate
+  // cases instead of throwing on them, and a neighborhood of collinear points
+  // is not rare here: on the first scans it can easily be a single scan line.
+  const mp2p_icp::PointCloudEigen pca =
+      mp2p_icp::estimate_points_eigen(xs.data(), ys.data(), zs.data(), idxs);
 
-  mrpt::math::TPlane plane;
-  mrpt::math::getRegressionPlane(neighbors, plane);
-  plane.unitarize();
-
-  // A neighborhood that is not locally planar has no tangent plane to offer,
-  // and a bad one is worse than none.
-  const auto maxDev = static_cast<double>(insertionOptions.bootstrap_max_plane_deviation);
-  if (maxDev > 0)
-  {
-    for (const auto& n : neighbors)
-    {
-      if (std::abs(plane.evaluatePoint(n)) > maxDev)
-      {
-        return ret;
-      }
-    }
-  }
-
-  const mrpt::math::TPoint3D q3d(query.x, query.y, query.z);
-
-  // Unitarized, this is the signed distance along the plane normal. Its sign
-  // depends on the arbitrary orientation the fit gave the normal, which the
-  // point-to-plane residual is invariant to: flipping the normal flips the
-  // residual too, and the product is unchanged.
-  const double signedDist = plane.evaluatePoint(q3d);
-  if (std::abs(signedDist) > max_search_distance)
+  // Eigenvalues ascending. A line or a point has no second spread direction and
+  // therefore no tangent plane; taking one anyway yields an arbitrary normal.
+  if (pca.eigVals[1] < 1e-3 * pca.eigVals[2])
   {
     return ret;
   }
 
-  const mrpt::math::TVector3D normal = plane.getNormalVector();
+  // The smallest eigenvalue is the variance across the fitted plane, so its
+  // square root is the neighborhood's RMS distance from that plane: a
+  // neighborhood that is not locally planar has no plane worth pairing against.
+  const auto maxDev = static_cast<double>(insertionOptions.bootstrap_max_plane_deviation);
+  if (maxDev > 0 && std::sqrt(std::max(.0, pca.eigVals[0])) > maxDev)
+  {
+    return ret;
+  }
+
+  const mrpt::math::TVector3D normal   = pca.eigVectors[0];
+  const mrpt::math::TPoint3D  centroid = pca.meanCov.mean.asTPoint();
+  const mrpt::math::TPoint3D  q3d(query.x, query.y, query.z);
+
+  // Signed distance along the plane normal. Its sign depends on the arbitrary
+  // orientation the decomposition gave the normal, which the point-to-plane
+  // residual is invariant to: flipping the normal flips the residual too, and
+  // the product is unchanged.
+  const double signedDist = normal.x * (q3d.x - centroid.x) +  //
+                            normal.y * (q3d.y - centroid.y) +  //
+                            normal.z * (q3d.z - centroid.z);
+
+  if (std::abs(signedDist) > max_search_distance)
+  {
+    return ret;
+  }
 
   const mrpt::math::TPoint3D foot = {
       q3d.x - signedDist * normal.x,  //

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -1,0 +1,834 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   TSDF.cpp
+ * @brief  Truncated signed distance field (TSDF) 3D map representation
+ * @author Jose Luis Blanco Claraco
+ * @date   Sep 02, 2026
+ */
+
+/* A voxel-hashed truncated signed distance field in the line of:
+    Curless and Levoy, "A volumetric method for building complex models from
+    range images", SIGGRAPH 1996;
+    Niessner et al., "Real-time 3D reconstruction at scale using voxel
+    hashing", ACM TOG 2013.
+   The registration side follows the correspondence-free formulation used by
+   distance-field odometry: the residual of a point is the field value at it.
+*/
+
+#include <mola_metric_maps/TSDF.h>
+#include <mrpt/config/CConfigFileBase.h>  // MRPT_LOAD_CONFIG_VAR
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CObservation3DRangeScan.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/obs/CObservationVelodyneScan.h>
+#include <mrpt/opengl/CPointCloud.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/system/os.h>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace mola;
+
+//  =========== Begin of Map definition ============
+MAP_DEFINITION_REGISTER("mola::TSDF,TSDF", mola::TSDF)
+
+TSDF::TMapDefinition::TMapDefinition() = default;
+
+void TSDF::TMapDefinition::loadFromConfigFile_map_specific(
+    const mrpt::config::CConfigFileBase& s, const std::string& sectionPrefix)
+{
+  using namespace std::string_literals;
+
+  // [<sectionNamePrefix>+"_creationOpts"]
+  const std::string sSectCreation = sectionPrefix + "_creationOpts"s;
+  MRPT_LOAD_CONFIG_VAR(voxel_size, float, s, sSectCreation);
+
+  ASSERT_(s.sectionExists(sectionPrefix + "_insertOpts"s));
+  insertionOpts.loadFromConfigFile(s, sectionPrefix + "_insertOpts"s);
+
+  if (s.sectionExists(sectionPrefix + "_renderOpts"s))
+  {
+    renderOpts.loadFromConfigFile(s, sectionPrefix + "_renderOpts"s);
+  }
+}
+
+void TSDF::TMapDefinition::dumpToTextStream_map_specific(std::ostream& out) const
+{
+  LOADABLEOPTS_DUMP_VAR(voxel_size, float);
+
+  insertionOpts.dumpToTextStream(out);
+  renderOpts.dumpToTextStream(out);
+}
+
+mrpt::maps::CMetricMap::Ptr TSDF::internal_CreateFromMapDefinition(
+    const mrpt::maps::TMetricMapInitializer& _def)
+{
+  const TSDF::TMapDefinition* def = dynamic_cast<const TSDF::TMapDefinition*>(&_def);
+  ASSERT_(def);
+  auto obj = TSDF::Create(def->voxel_size);
+
+  obj->insertionOptions = def->insertionOpts;
+  obj->renderOptions    = def->renderOpts;
+
+  return obj;
+}
+//  =========== End of Map definition Block =========
+
+IMPLEMENTS_SERIALIZABLE(TSDF, CMetricMap, mola)
+
+// =====================================
+// Serialization
+// =====================================
+
+uint8_t TSDF::serializeGetVersion() const { return 0; }
+
+void TSDF::serializeTo(mrpt::serialization::CArchive& out) const
+{
+  // params:
+  out << voxel_size_;
+  insertionOptions.writeToStream(out);
+  renderOptions.writeToStream(out);
+
+  // data:
+  out.WriteAs<uint32_t>(voxels_.size());
+  for (const auto& [idx, voxel] : voxels_)
+  {
+    out << idx.cx << idx.cy << idx.cz;
+    out << voxel.dist << voxel.weight;
+  }
+}
+
+void TSDF::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
+{
+  switch (version)
+  {
+    case 0:
+    {
+      float vxSize = 0;
+      in >> vxSize;
+      setVoxelProperties(vxSize);
+
+      insertionOptions.readFromStream(in);
+      renderOptions.readFromStream(in);
+
+      const auto nVoxels = in.ReadAs<uint32_t>();
+      voxels_.clear();
+      voxels_.reserve(nVoxels);
+      for (uint32_t i = 0; i < nVoxels; i++)
+      {
+        global_index3d_t idx;
+        in >> idx.cx >> idx.cy >> idx.cz;
+
+        VoxelData v;
+        in >> v.dist >> v.weight;
+        voxels_[idx] = v;
+      }
+      invalidateCaches();
+    }
+    break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  };
+}
+
+// =====================================
+// Construction
+// =====================================
+
+TSDF::TSDF(float voxel_size) { setVoxelProperties(voxel_size); }
+
+TSDF::~TSDF() = default;
+
+void TSDF::setVoxelProperties(float voxel_size)
+{
+  ASSERT_GT_(voxel_size, .0f);
+
+  voxel_size_     = voxel_size;
+  voxel_size_inv_ = 1.0f / voxel_size_;
+
+  creationOptions.voxel_size = voxel_size;
+
+  // Clear contents, which are tied to the discretization:
+  this->clear();
+}
+
+void TSDF::internal_clear()
+{
+  voxels_.clear();
+  invalidateCaches();
+}
+
+void TSDF::invalidateCaches()
+{
+  cachedBoundingBox_.reset();
+  cachedPoints_.reset();
+}
+
+// =====================================
+// The field itself
+// =====================================
+
+void TSDF::insertPoint(const mrpt::math::TPoint3Df& pt, const mrpt::math::TPoint3Df& sensorPt)
+{
+  const float rayX  = pt.x - sensorPt.x;
+  const float rayY  = pt.y - sensorPt.y;
+  const float rayZ  = pt.z - sensorPt.z;
+  const float range = std::sqrt(rayX * rayX + rayY * rayY + rayZ * rayZ);
+
+  if (range < 1e-3f)
+  {
+    return;  // degenerate: no ray direction to define a sign with
+  }
+
+  // Unit ray direction, pointing away from the sensor:
+  const float ux = rayX / range;
+  const float uy = rayY / range;
+  const float uz = rayZ / range;
+
+  const float trunc    = truncation();
+  const float tubeR    = static_cast<float>(insertionOptions.ray_tube_voxels) * voxel_size_;
+  const float tubeRSqr = tubeR * tubeR;
+
+  const float tubeSigma = static_cast<float>(insertionOptions.tube_sigma_voxels) * voxel_size_;
+  const float tubeInvTwoSigmaSqr = tubeSigma > 0 ? 0.5f / (tubeSigma * tubeSigma) : .0f;
+
+  float sampleWeight = 1.0f;
+  if (insertionOptions.weight_by_range)
+  {
+    const float refR = static_cast<float>(insertionOptions.weight_range_ref);
+    sampleWeight *= std::min(1.0f, (refR * refR) / (range * range));
+  }
+  if (insertionOptions.weight_by_incidence)
+  {
+    // The gradient already accumulated at the surface is the best available
+    // estimate of the local normal at insertion time.
+    const auto q = queryField(pt);
+    if (q.valid)
+    {
+      const float gn = std::sqrt(
+          q.gradient.x * q.gradient.x + q.gradient.y * q.gradient.y + q.gradient.z * q.gradient.z);
+      if (gn > 1e-6f)
+      {
+        const float cosInc =
+            std::abs((q.gradient.x * ux + q.gradient.y * uy + q.gradient.z * uz) / gn);
+        sampleWeight *= std::max(0.05f, cosInc);
+      }
+    }
+  }
+
+  const float maxW = static_cast<float>(insertionOptions.max_weight);
+
+  // The updated region is a cylinder of radius `tubeR` around the ray segment
+  // [pt - trunc*u, pt + trunc*u]. Its axis-aligned box is much tighter than a
+  // cube of side 2*trunc whenever the ray is close to an axis, which is the
+  // common case for the ground returns that dominate a lidar scan.
+  const float hx = trunc * std::abs(ux) + tubeR;
+  const float hy = trunc * std::abs(uy) + tubeR;
+  const float hz = trunc * std::abs(uz) + tubeR;
+
+  const global_index3d_t i0 = coordToGlobalIdx({pt.x - hx, pt.y - hy, pt.z - hz});
+  const global_index3d_t i1 = coordToGlobalIdx({pt.x + hx, pt.y + hy, pt.z + hz});
+
+  for (int32_t cx = i0.cx; cx <= i1.cx; cx++)
+  {
+    for (int32_t cy = i0.cy; cy <= i1.cy; cy++)
+    {
+      for (int32_t cz = i0.cz; cz <= i1.cz; cz++)
+      {
+        const auto c = globalIdxToCenter({cx, cy, cz});
+
+        // Vector from the voxel center to the measured point:
+        const float vx = pt.x - c.x;
+        const float vy = pt.y - c.y;
+        const float vz = pt.z - c.z;
+
+        // Signed distance along the ray. Positive means the voxel sits between
+        // the sensor and the surface, i.e. on the free-space side.
+        const float sd = vx * ux + vy * uy + vz * uz;
+        if (std::abs(sd) > trunc)
+        {
+          continue;
+        }
+
+        // Perpendicular offset from the ray:
+        const float px      = vx - sd * ux;
+        const float py      = vy - sd * uy;
+        const float pz      = vz - sd * uz;
+        const float perpSqr = px * px + py * py + pz * pz;
+        if (perpSqr > tubeRSqr)
+        {
+          continue;
+        }
+
+        float w = sampleWeight;
+        if (tubeInvTwoSigmaSqr > 0)
+        {
+          w *= std::exp(-perpSqr * tubeInvTwoSigmaSqr);
+          if (w < 1e-6f)
+          {
+            continue;
+          }
+        }
+
+        auto& v = voxels_[{cx, cy, cz}];
+
+        const float wSum = v.weight + w;
+        v.dist           = (v.dist * v.weight + sd * w) / wSum;
+        v.weight         = std::min(wSum, maxW);
+      }
+    }
+  }
+
+  invalidateCaches();
+}
+
+TSDF::FieldQuery TSDF::queryField(const mrpt::math::TPoint3Df& p) const
+{
+  FieldQuery ret;
+
+  // Continuous voxel-center coordinates: the center of voxel i sits at
+  // (i + 0.5) * voxel_size, so shifting by half a voxel puts the interpolation
+  // lattice on integer coordinates.
+  const float tx = p.x * voxel_size_inv_ - 0.5f;
+  const float ty = p.y * voxel_size_inv_ - 0.5f;
+  const float tz = p.z * voxel_size_inv_ - 0.5f;
+
+  const float fx = std::floor(tx);
+  const float fy = std::floor(ty);
+  const float fz = std::floor(tz);
+
+  const auto ix = static_cast<int32_t>(fx);
+  const auto iy = static_cast<int32_t>(fy);
+  const auto iz = static_cast<int32_t>(fz);
+
+  const float ax = tx - fx;
+  const float ay = ty - fy;
+  const float az = tz - fz;
+
+  const float minW = static_cast<float>(insertionOptions.min_weight_for_query);
+
+  // Field values at the 8 surrounding voxel centers. A partially observed
+  // neighborhood is rejected rather than extrapolated: a surface inferred from
+  // one corner is not a measurement.
+  float d[2][2][2];
+  for (int dx = 0; dx < 2; dx++)
+  {
+    for (int dy = 0; dy < 2; dy++)
+    {
+      for (int dz = 0; dz < 2; dz++)
+      {
+        const VoxelData* v = voxelByGlobalIdxs({ix + dx, iy + dy, iz + dz});
+        if (!v || v->weight < minW)
+        {
+          return ret;  // invalid
+        }
+        d[dx][dy][dz] = v->dist;
+      }
+    }
+  }
+
+  const float bx = 1.0f - ax;
+  const float by = 1.0f - ay;
+  const float bz = 1.0f - az;
+
+  // Trilinear interpolation:
+  const float c00 = d[0][0][0] * bx + d[1][0][0] * ax;
+  const float c01 = d[0][0][1] * bx + d[1][0][1] * ax;
+  const float c10 = d[0][1][0] * bx + d[1][1][0] * ax;
+  const float c11 = d[0][1][1] * bx + d[1][1][1] * ax;
+
+  const float c0 = c00 * by + c10 * ay;
+  const float c1 = c01 * by + c11 * ay;
+
+  ret.dist = c0 * bz + c1 * az;
+
+  // Analytical gradient of the same trilinear interpolant, in meters per
+  // meter. Using the interpolant's own gradient, rather than central
+  // differences over neighboring cells, keeps the normal consistent with the
+  // residual the solver is given.
+  const float ddx = ((d[1][0][0] - d[0][0][0]) * by + (d[1][1][0] - d[0][1][0]) * ay) * bz +
+                    ((d[1][0][1] - d[0][0][1]) * by + (d[1][1][1] - d[0][1][1]) * ay) * az;
+
+  const float ddy = ((d[0][1][0] - d[0][0][0]) * bx + (d[1][1][0] - d[1][0][0]) * ax) * bz +
+                    ((d[0][1][1] - d[0][0][1]) * bx + (d[1][1][1] - d[1][0][1]) * ax) * az;
+
+  const float ddz = (c01 - c00) * by + (c11 - c10) * ay;
+
+  ret.gradient = {ddx * voxel_size_inv_, ddy * voxel_size_inv_, ddz * voxel_size_inv_};
+  ret.valid    = true;
+
+  return ret;
+}
+
+mp2p_icp::NearestPlaneCapable::NearestPlaneResult TSDF::nn_search_pt2pl(
+    const mrpt::math::TPoint3Df& query, const float max_search_distance) const
+{
+  NearestPlaneCapable::NearestPlaneResult ret;
+
+  const auto q = queryField(query);
+  if (!q.valid)
+  {
+    return ret;
+  }
+
+  const float dist = std::abs(q.dist);
+  if (dist > max_search_distance)
+  {
+    return ret;
+  }
+
+  const float gn = std::sqrt(
+      q.gradient.x * q.gradient.x + q.gradient.y * q.gradient.y + q.gradient.z * q.gradient.z);
+  if (gn < 1e-3f)
+  {
+    // A flat gradient means the field carries no surface direction here, which
+    // happens where measurements from opposite sides average out.
+    return ret;
+  }
+
+  const mrpt::math::TVector3D normal = {q.gradient.x / gn, q.gradient.y / gn, q.gradient.z / gn};
+
+  // The point's own projection onto the zero level set. The field is a
+  // projective distance, so its magnitude is an over-estimate at grazing
+  // incidence; dividing by the gradient norm converts it back to a metric
+  // distance, which is what the point-to-plane residual expects.
+  const float step = q.dist / gn;
+
+  const mrpt::math::TPoint3D foot = {
+      query.x - step * normal.x, query.y - step * normal.y, query.z - step * normal.z};
+
+  auto& pa              = ret.pairing.emplace();
+  pa.pt_local           = query;
+  pa.pl_global.centroid = foot;
+  pa.pl_global.plane    = mrpt::math::TPlane(foot, normal);
+
+  ret.distance = std::abs(step);
+
+  return ret;
+}
+
+// =====================================
+// Insertion
+// =====================================
+
+void TSDF::pruneFarVoxels(const mrpt::math::TPoint3Df& sensorPt)
+{
+  if (insertionOptions.remove_voxels_farther_than <= 0)
+  {
+    return;
+  }
+
+  const int distInGrid =
+      static_cast<int>(std::ceil(insertionOptions.remove_voxels_farther_than * voxel_size_inv_));
+
+  const auto idxCurObs = coordToGlobalIdx(sensorPt);
+
+  for (auto it = voxels_.begin(); it != voxels_.end();)
+  {
+    const int dist = mrpt::max3(
+        std::abs(it->first.cx - idxCurObs.cx), std::abs(it->first.cy - idxCurObs.cy),
+        std::abs(it->first.cz - idxCurObs.cz));
+
+    if (dist > distInGrid)
+    {
+      it = voxels_.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+  invalidateCaches();
+}
+
+void TSDF::internal_insertPointCloud3D(
+    const mrpt::poses::CPose3D& pc_in_map, const float* xs, const float* ys, const float* zs,
+    const std::size_t num_pts)
+{
+  const auto sensorPt = pc_in_map.translation().cast<float>();
+
+  for (std::size_t i = 0; i < num_pts; i++)
+  {
+    const auto gPt = pc_in_map.composePoint(mrpt::math::TPoint3Df(xs[i], ys[i], zs[i]));
+    insertPoint(gPt, sensorPt);
+  }
+}
+
+bool TSDF::internal_insertObservation(
+    const mrpt::obs::CObservation& obs, const std::optional<const mrpt::poses::CPose3D>& robotPose)
+{
+  MRPT_START
+
+  using namespace mrpt::obs;
+
+  mrpt::poses::CPose3D robotPose3D;
+  if (robotPose)
+  {
+    robotPose3D = (*robotPose);
+  }
+
+  pruneFarVoxels(robotPose3D.translation().cast<float>());
+
+  if (IS_CLASS(obs, CObservationPointCloud))
+  {
+    const auto& o = dynamic_cast<const CObservationPointCloud&>(obs);
+    if (!o.pointcloud)
+    {
+      return false;
+    }
+
+    const auto& xs = o.pointcloud->getPointsBufferRef_x();
+    const auto& ys = o.pointcloud->getPointsBufferRef_y();
+    const auto& zs = o.pointcloud->getPointsBufferRef_z();
+
+    // The sensor pose on the robot is already applied by whoever built the
+    // cloud in the observation, as elsewhere in this library.
+    internal_insertPointCloud3D(robotPose3D, xs.data(), ys.data(), zs.data(), xs.size());
+    return true;
+  }
+
+  if (IS_CLASS(obs, CObservation2DRangeScan))
+  {
+    const auto& o = dynamic_cast<const CObservation2DRangeScan&>(obs);
+
+    const auto* scanPoints = o.buildAuxPointsMap<mrpt::maps::CPointsMap>();
+    if (scanPoints->empty())
+    {
+      return false;
+    }
+
+    const auto& xs = scanPoints->getPointsBufferRef_x();
+    const auto& ys = scanPoints->getPointsBufferRef_y();
+    const auto& zs = scanPoints->getPointsBufferRef_z();
+
+    internal_insertPointCloud3D(robotPose3D, xs.data(), ys.data(), zs.data(), xs.size());
+    return true;
+  }
+
+  if (IS_CLASS(obs, CObservation3DRangeScan))
+  {
+    const auto& o = dynamic_cast<const CObservation3DRangeScan&>(obs);
+
+    mrpt::obs::T3DPointsProjectionParams pp;
+    pp.takeIntoAccountSensorPoseOnRobot = true;
+
+    mrpt::maps::CSimplePointsMap pointMap;
+    if (o.hasPoints3D)
+    {
+      pointMap.insertionOptions.minDistBetweenLaserPoints = .0f;
+      for (size_t i = 0; i < o.points3D_x.size(); i++)
+      {
+        pointMap.insertPointFast(o.points3D_x[i], o.points3D_y[i], o.points3D_z[i]);
+      }
+    }
+    else if (o.hasRangeImage)
+    {
+      const_cast<CObservation3DRangeScan&>(o).unprojectInto(pointMap, pp);
+    }
+    else
+    {
+      return false;
+    }
+
+    const auto& xs = pointMap.getPointsBufferRef_x();
+    const auto& ys = pointMap.getPointsBufferRef_y();
+    const auto& zs = pointMap.getPointsBufferRef_z();
+
+    internal_insertPointCloud3D(robotPose3D, xs.data(), ys.data(), zs.data(), xs.size());
+    return true;
+  }
+
+  if (IS_CLASS(obs, CObservationVelodyneScan))
+  {
+    const auto& o = dynamic_cast<const CObservationVelodyneScan&>(obs);
+
+    // Automatically generate the point cloud if it was not done before:
+    const_cast<CObservationVelodyneScan&>(o).generatePointCloud();
+
+    mrpt::maps::CSimplePointsMap pointMap;
+    for (size_t i = 0; i < o.point_cloud.x.size(); i++)
+    {
+      pointMap.insertPointFast(o.point_cloud.x[i], o.point_cloud.y[i], o.point_cloud.z[i]);
+    }
+
+    const auto& xs = pointMap.getPointsBufferRef_x();
+    const auto& ys = pointMap.getPointsBufferRef_y();
+    const auto& zs = pointMap.getPointsBufferRef_z();
+
+    internal_insertPointCloud3D(
+        robotPose3D + o.sensorPose, xs.data(), ys.data(), zs.data(), xs.size());
+    return true;
+  }
+
+  return false;
+
+  MRPT_END
+}
+
+// =====================================
+// CMetricMap interface
+// =====================================
+
+bool TSDF::isEmpty() const { return voxels_.empty(); }
+
+std::string TSDF::asString() const
+{
+  return mrpt::format(
+      "TSDF, voxel_size=%.03f truncation=%.03f voxels=%u", voxel_size_, truncation(),
+      static_cast<unsigned int>(voxels_.size()));
+}
+
+void TSDF::visitAllVoxels(
+    const std::function<void(const global_index3d_t&, const VoxelData&)>& f) const
+{
+  for (const auto& [idx, v] : voxels_)
+  {
+    f(idx, v);
+  }
+}
+
+mrpt::math::TBoundingBoxf TSDF::boundingBox() const
+{
+  if (!cachedBoundingBox_)
+  {
+    if (voxels_.empty())
+    {
+      cachedBoundingBox_.emplace();
+      cachedBoundingBox_->min = {0, 0, 0};
+      cachedBoundingBox_->max = {0, 0, 0};
+    }
+    else
+    {
+      cachedBoundingBox_ = mrpt::math::TBoundingBoxf::PlusMinusInfinity();
+      const float h      = 0.5f * voxel_size_;
+      for (const auto& [idx, v] : voxels_)
+      {
+        const auto c = globalIdxToCenter(idx);
+        cachedBoundingBox_->updateWithPoint(mrpt::math::TPoint3Df(c.x - h, c.y - h, c.z - h));
+        cachedBoundingBox_->updateWithPoint(mrpt::math::TPoint3Df(c.x + h, c.y + h, c.z + h));
+      }
+    }
+  }
+  return *cachedBoundingBox_;
+}
+
+const mrpt::maps::CSimplePointsMap* TSDF::getAsSimplePointsMap() const
+{
+  if (!cachedPoints_)
+  {
+    cachedPoints_ = mrpt::maps::CSimplePointsMap::Create();
+
+    // Report the voxel centers whose field is close to the zero level set, as
+    // a stand-in surface sampling for visualization and for the ROS bridge.
+    const float minW = static_cast<float>(insertionOptions.min_weight_for_query);
+    for (const auto& [idx, v] : voxels_)
+    {
+      if (v.weight < minW || std::abs(v.dist) > 0.5f * voxel_size_)
+      {
+        continue;
+      }
+      const auto c = globalIdxToCenter(idx);
+      cachedPoints_->insertPointFast(c.x, c.y, c.z);
+    }
+    cachedPoints_->mark_as_modified();
+  }
+  return cachedPoints_.get();
+}
+
+void TSDF::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+{
+  auto pts = mrpt::opengl::CPointCloud::Create();
+  pts->setPointSize(renderOptions.point_size);
+  pts->setColor(renderOptions.points_color);
+
+  const auto* surface = getAsSimplePointsMap();
+  for (size_t i = 0; i < surface->size(); i++)
+  {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    surface->getPointFast(i, x, y, z);
+    pts->insertPoint(x, y, z);
+  }
+
+  outObj.insert(pts);
+}
+
+void TSDF::saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const
+{
+  using namespace std::string_literals;
+
+  const auto fil = filNamePrefix + ".txt"s;
+
+  FILE* f = mrpt::system::os::fopen(fil.c_str(), "wt");
+  if (!f)
+  {
+    return;
+  }
+  for (const auto& [idx, v] : voxels_)
+  {
+    const auto c = globalIdxToCenter(idx);
+    mrpt::system::os::fprintf(f, "%f %f %f %f %f\n", c.x, c.y, c.z, v.dist, v.weight);
+  }
+  mrpt::system::os::fclose(f);
+}
+
+double TSDF::internal_computeObservationLikelihood(
+    [[maybe_unused]] const mrpt::obs::CObservation& obs,
+    [[maybe_unused]] const mrpt::poses::CPose3D&    takenFrom) const
+{
+  THROW_EXCEPTION("Observation likelihood not implemented for mola::TSDF");
+}
+
+bool TSDF::internal_canComputeObservationLikelihood(
+    [[maybe_unused]] const mrpt::obs::CObservation& obs) const
+{
+  return false;
+}
+
+// =====================================
+// Options
+// =====================================
+
+std::map<std::string, mrpt::config::CLoadableOptions*> TSDF::optionsByName()
+{
+  return {
+      {"creationOptions", &creationOptions},
+      {"insertionOptions", &insertionOptions},
+      {"renderOptions", &renderOptions},
+  };
+}
+
+void TSDF::TCreationOptions::loadFromConfigFile(
+    const mrpt::config::CConfigFileBase& c, const std::string& s)
+{
+  MRPT_LOAD_CONFIG_VAR(voxel_size, float, c, s);
+}
+
+void TSDF::TCreationOptions::dumpToTextStream(std::ostream& out) const
+{
+  out << "\n------ [TSDF::TCreationOptions] ------- \n\n";
+  LOADABLEOPTS_DUMP_VAR(voxel_size, float);
+}
+
+bool TSDF::trySetCreationOptions(
+    const mrpt::config::CConfigFileBase& cfg, const std::string& section)
+{
+  TCreationOptions newOpts = creationOptions;
+  newOpts.loadFromConfigFile(cfg, section);
+
+  if (newOpts.voxel_size != creationOptions.voxel_size)
+  {
+    if (!isEmpty())
+    {
+      return false;  // would require discarding existing voxels
+    }
+    setVoxelProperties(newOpts.voxel_size);
+  }
+  return true;
+}
+
+void TSDF::TInsertionOptions::loadFromConfigFile(
+    const mrpt::config::CConfigFileBase& c, const std::string& s)
+{
+  MRPT_LOAD_CONFIG_VAR(truncation_distance, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(truncation_voxels, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(ray_tube_voxels, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(tube_sigma_voxels, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(max_weight, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(min_weight_for_query, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(remove_voxels_farther_than, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(weight_by_range, bool, c, s);
+  MRPT_LOAD_CONFIG_VAR(weight_range_ref, double, c, s);
+  MRPT_LOAD_CONFIG_VAR(weight_by_incidence, bool, c, s);
+}
+
+void TSDF::TInsertionOptions::dumpToTextStream(std::ostream& out) const
+{
+  out << "\n------ [TSDF::TInsertionOptions] ------- \n\n";
+  LOADABLEOPTS_DUMP_VAR(truncation_distance, double);
+  LOADABLEOPTS_DUMP_VAR(truncation_voxels, double);
+  LOADABLEOPTS_DUMP_VAR(ray_tube_voxels, double);
+  LOADABLEOPTS_DUMP_VAR(tube_sigma_voxels, double);
+  LOADABLEOPTS_DUMP_VAR(max_weight, double);
+  LOADABLEOPTS_DUMP_VAR(min_weight_for_query, double);
+  LOADABLEOPTS_DUMP_VAR(remove_voxels_farther_than, double);
+  LOADABLEOPTS_DUMP_VAR(weight_by_range, bool);
+  LOADABLEOPTS_DUMP_VAR(weight_range_ref, double);
+  LOADABLEOPTS_DUMP_VAR(weight_by_incidence, bool);
+}
+
+void TSDF::TInsertionOptions::writeToStream(mrpt::serialization::CArchive& out) const
+{
+  const int8_t version = 0;
+  out << version;
+  out << truncation_distance << truncation_voxels << ray_tube_voxels << tube_sigma_voxels
+      << max_weight << min_weight_for_query << remove_voxels_farther_than << weight_by_range
+      << weight_range_ref << weight_by_incidence;
+}
+
+void TSDF::TInsertionOptions::readFromStream(mrpt::serialization::CArchive& in)
+{
+  int8_t version = 0;
+  in >> version;
+  switch (version)
+  {
+    case 0:
+      in >> truncation_distance >> truncation_voxels >> ray_tube_voxels >> tube_sigma_voxels >>
+          max_weight >> min_weight_for_query >> remove_voxels_farther_than >> weight_by_range >>
+          weight_range_ref >> weight_by_incidence;
+      break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  }
+}
+
+void TSDF::TRenderOptions::loadFromConfigFile(
+    const mrpt::config::CConfigFileBase& c, const std::string& s)
+{
+  MRPT_LOAD_CONFIG_VAR(point_size, float, c, s);
+  points_color = mrpt::img::TColorf(
+      c.read_float(s, "points_color_r", points_color.R),
+      c.read_float(s, "points_color_g", points_color.G),
+      c.read_float(s, "points_color_b", points_color.B));
+}
+
+void TSDF::TRenderOptions::dumpToTextStream(std::ostream& out) const
+{
+  out << "\n------ [TSDF::TRenderOptions] ------- \n\n";
+  LOADABLEOPTS_DUMP_VAR(point_size, float);
+}
+
+void TSDF::TRenderOptions::writeToStream(mrpt::serialization::CArchive& out) const
+{
+  const int8_t version = 0;
+  out << version;
+  out << point_size << points_color.R << points_color.G << points_color.B;
+}
+
+void TSDF::TRenderOptions::readFromStream(mrpt::serialization::CArchive& in)
+{
+  int8_t version = 0;
+  in >> version;
+  switch (version)
+  {
+    case 0:
+      in >> point_size >> points_color.R >> points_color.G >> points_color.B;
+      break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  }
+}

--- a/mola_metric_maps/src/register.cpp
+++ b/mola_metric_maps/src/register.cpp
@@ -29,6 +29,7 @@
 #include <mola_metric_maps/OccGrid.h>
 #include <mola_metric_maps/SparseTreesPointCloud.h>
 #include <mola_metric_maps/SparseVoxelPointCloud.h>
+#include <mola_metric_maps/TSDF.h>
 #include <mrpt/core/initializer.h>
 #include <mrpt/rtti/CObject.h>
 
@@ -48,4 +49,5 @@ MRPT_INITIALIZER(do_register_mola_metric_maps)  // NOLINT(misc-use-anonymous-nam
   registerClass(CLASS_ID(mola::OccGrid));
   registerClass(CLASS_ID(mola::SparseTreesPointCloud));
   registerClass(CLASS_ID(mola::SparseVoxelPointCloud));
+  registerClass(CLASS_ID(mola::TSDF));
 }

--- a/mola_metric_maps/tests/CMakeLists.txt
+++ b/mola_metric_maps/tests/CMakeLists.txt
@@ -28,6 +28,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test-mola_metric_maps_tsdf
+  SOURCES test-mola_metric_maps_tsdf.cpp
+  LINK_LIBRARIES
+  mola_metric_maps
+)
+
+mola_add_test(
   TARGET  test-mola_metric_maps_serialization
   SOURCES test-serialization.cpp
   LINK_LIBRARIES

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -22,6 +22,7 @@
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/serialization/CArchive.h>
 
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <random>
@@ -132,6 +133,67 @@ void test_surface_is_not_displaced()
       std::abs(atNarrow) < 0.003,
       mrpt::format("narrow profile still displaces the surface by %.2f mm", atNarrow * 1000));
   ASSERT_LT_(std::abs(atNarrow), std::abs(atDefault));
+}
+
+/** The gradient the matcher uses as a surface normal is the analytical
+ *  gradient of the trilinear interpolant, not a difference of neighbors, so it
+ *  is worth checking against finite differences of the field itself: a sign or
+ *  a scale error there would tilt every plane the solver is given, and would
+ *  not show up on a horizontal plane where two of the three components are
+ *  zero.
+ */
+void test_gradient_against_finite_differences()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels = 4.0;
+
+  // A tilted plane, so all three gradient components are exercised:
+  // z = 0.3*x - 0.2*y, seen from above.
+  const mrpt::math::TPoint3Df sensor(.0f, .0f, 4.0f);
+  for (float x = -PLANE_SPAN; x <= PLANE_SPAN; x += PLANE_STEP)
+  {
+    for (float y = -PLANE_SPAN; y <= PLANE_SPAN; y += PLANE_STEP)
+    {
+      map.insertPoint({x, y, 0.3f * x - 0.2f * y}, sensor);
+    }
+  }
+
+  constexpr float H = 0.02f;
+  size_t          n = 0;
+  for (const float qx : {-1.0f, 0.4f, 1.3f})
+  {
+    for (const float qy : {-0.7f, 0.6f})
+    {
+      const mrpt::math::TPoint3Df q{qx, qy, 0.3f * qx - 0.2f * qy + 0.2f};
+      const auto                  f = map.queryField(q);
+      if (!f.valid)
+      {
+        continue;
+      }
+      const std::array<mrpt::math::TVector3Df, 3> axes = {
+          mrpt::math::TVector3Df{H, 0, 0}, mrpt::math::TVector3Df{0, H, 0},
+          mrpt::math::TVector3Df{0, 0, H}};
+      const std::array<float, 3> analytic = {f.gradient.x, f.gradient.y, f.gradient.z};
+
+      for (int k = 0; k < 3; k++)
+      {
+        const auto& d  = axes[k];
+        const auto  fp = map.queryField({q.x + d.x, q.y + d.y, q.z + d.z});
+        const auto  fm = map.queryField({q.x - d.x, q.y - d.y, q.z - d.z});
+        if (!fp.valid || !fm.valid)
+        {
+          continue;
+        }
+        const float numeric = (fp.dist - fm.dist) / (2 * H);
+        ASSERTMSG_(
+            std::abs(numeric - analytic[k]) < 0.05f,
+            mrpt::format("gradient[%i] analytic %.4f != numeric %.4f", k, analytic[k], numeric));
+        n++;
+      }
+    }
+  }
+  ASSERT_GT_(n, 10U);
+  std::cout << "test_gradient_against_finite_differences: OK (" << n << " checks)" << std::endl;
 }
 
 void test_pt2pl_pairing_of_a_plane()
@@ -280,6 +342,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
   {
     test_field_of_a_plane();
     test_surface_is_not_displaced();
+    test_gradient_against_finite_differences();
     test_pt2pl_pairing_of_a_plane();
     test_noise_averaging();
     test_serialization_roundtrip();

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -381,6 +381,45 @@ void test_pruning()
 
   std::cout << "test_pruning: OK" << std::endl;
 }
+/** The extent bound alone does not bound anything usefully: at a fixed extent
+ *  the voxel count still grows as the inverse cube of the voxel size and with
+ *  how much surface the scene puts inside it. The count ceiling has to hold
+ *  whatever the extent says.
+ */
+void test_voxel_budget_is_a_ceiling()
+{
+  constexpr uint64_t CAP = 2000;
+
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels          = 4.0;
+  map.insertionOptions.remove_voxels_farther_than = 1000.0;  // deliberately useless
+  map.insertionOptions.max_voxels                 = CAP;
+
+  fill_ground_plane(map);
+
+  // Nothing prunes until an observation is inserted, which is where the
+  // sensor pose the eviction is measured from comes from.
+  mrpt::obs::CObservationPointCloud obs;
+  obs.pointcloud = mrpt::maps::CSimplePointsMap::Create();
+  obs.pointcloud->insertPointFast(0.1f, 0.1f, -2.0f);
+  map.insertObservation(obs, mrpt::poses::CPose3D::Identity());
+
+  std::cout << "test_voxel_budget_is_a_ceiling: " << map.size() << " voxels under a cap of " << CAP
+            << std::endl;
+
+  // Ties at the cut radius are all kept, so the cap is approached from above by
+  // at most one shell; a factor of two is a generous allowance for that.
+  ASSERTMSG_(
+      map.size() <= 2 * CAP, mrpt::format(
+                                 "voxel budget not enforced: %zu voxels against a cap of %lu",
+                                 map.size(), static_cast<unsigned long>(CAP)));
+
+  // What survives has to be what is nearest the sensor, not an arbitrary
+  // subset: the field around the origin must still answer.
+  const auto q = map.queryField({.0f, .0f, .0f});
+  ASSERT_(q.valid);
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -395,6 +434,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_noise_averaging();
     test_serialization_roundtrip();
     test_pruning();
+    test_voxel_budget_is_a_ceiling();
   }
   catch (const std::exception& e)
   {

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -229,6 +229,53 @@ void test_pt2pl_pairing_of_a_plane()
 /** The point of the map class: fusing many noisy views of one surface must
  *  estimate it better than any single measurement does.
  */
+/** The solver's point-to-plane residual is signed: it is the vector
+ *  -n/|n|^2 * (n.g + d), which points from the transformed query towards the
+ *  plane and reverses on the far side. So the plane this map emits has to carry
+ *  the field's own sign convention through to the optimizer, not just its
+ *  magnitude -- a normal flipped between the two sides would leave the squared
+ *  cost unchanged while sending the Gauss-Newton step the wrong way.
+ *
+ *  Unlike a plane fitted by PCA, whose normal sign is arbitrary, the gradient
+ *  of a signed field always points towards free space. Pin that.
+ */
+void test_plane_sign_is_carried_through()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels = 4.0;
+
+  fill_ground_plane(map);
+
+  // The same lateral position, once in free space above the ground and once
+  // inside it below.
+  for (const float zq : {0.3f, -0.3f})
+  {
+    const mrpt::math::TPoint3Df q(0.5f, 0.5f, zq);
+    const auto                  r = map.nn_search_pt2pl(q, 1.0f);
+    ASSERTMSG_(r.pairing.has_value(), mrpt::format("no pairing at z=%.2f", zq));
+
+    const auto& pl = r.pairing->pl_global.plane;
+
+    // The normal must point towards the sensor, i.e. up, on BOTH sides.
+    const double nz = pl.coefs[2];
+    ASSERTMSG_(nz > 0.9, mrpt::format("normal points down at z=%.2f (nz=%.3f)", zq, nz));
+
+    // And the plane's own signed evaluation must reproduce the query's height,
+    // with the sign, so the residual handed to the solver reverses across the
+    // surface.
+    const double modN = std::sqrt(
+        pl.coefs[0] * pl.coefs[0] + pl.coefs[1] * pl.coefs[1] + pl.coefs[2] * pl.coefs[2]);
+    const double signedDist =
+        (pl.coefs[0] * q.x + pl.coefs[1] * q.y + pl.coefs[2] * q.z + pl.coefs[3]) / modN;
+
+    ASSERTMSG_(
+        std::abs(signedDist - zq) < 0.02,
+        mrpt::format("signed plane distance %.4f != %.2f", signedDist, zq));
+  }
+
+  std::cout << "test_plane_sign_is_carried_through: OK" << std::endl;
+}
+
 void test_noise_averaging()
 {
   constexpr float SIGMA = 0.05f;
@@ -344,6 +391,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_surface_is_not_displaced();
     test_gradient_against_finite_differences();
     test_pt2pl_pairing_of_a_plane();
+    test_plane_sign_is_carried_through();
     test_noise_averaging();
     test_serialization_roundtrip();
     test_pruning();

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -19,7 +19,9 @@
 
 #include <mola_metric_maps/TSDF.h>
 #include <mrpt/io/CMemoryStream.h>
+#include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
 
 #include <array>
@@ -335,6 +337,117 @@ void test_noise_averaging()
   ASSERTMSG_(std::abs(mean) < 0.03, mrpt::format("fused surface is biased: mean=%.4f", mean));
 }
 
+/** One scan of a horizontal plane z=0, as an observation, so that insertion
+ *  goes through the path that drives the warm-up. `step` sets how far apart
+ *  the measured points are, which is what decides whether one scan alone can
+ *  fill the eight corners a trilinear query needs.
+ */
+mrpt::obs::CObservationPointCloud::Ptr plane_scan(float step, float zPlane = .0f)
+{
+  auto obs                                        = mrpt::obs::CObservationPointCloud::Create();
+  obs->sensorPose                                 = mrpt::poses::CPose3D::Identity();
+  auto pts                                        = mrpt::maps::CSimplePointsMap::Create();
+  pts->insertionOptions.minDistBetweenLaserPoints = .0f;
+
+  for (float x = -PLANE_SPAN; x <= PLANE_SPAN; x += step)
+  {
+    for (float y = -PLANE_SPAN; y <= PLANE_SPAN; y += step)
+    {
+      // Coordinates in the sensor frame: the sensor sits SENSOR_HEIGHT above.
+      pts->insertPointFast(x, y, zPlane - SENSOR_HEIGHT);
+    }
+  }
+  pts->mark_as_modified();
+  obs->pointcloud = pts;
+  return obs;
+}
+
+const mrpt::poses::CPose3D SENSOR_POSE = mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+    .0, .0, static_cast<double>(SENSOR_HEIGHT), .0, .0, .0);
+
+/** The warm-up must produce a pairing where the field cannot yet, and the two
+ *  must agree once the field can, or the switch would move the residual under
+ *  the optimizer.
+ */
+void test_bootstrap_answers_before_the_field_can()
+{
+  const mrpt::math::TPoint3Df query{0.3f, -0.2f, 0.15f};
+
+  // A scan whose points are far enough apart that one of them alone leaves
+  // most cells with fewer than eight populated corners.
+  auto sparseScan = plane_scan(4.0f * TEST_VOXEL);
+
+  {
+    mola::TSDF map(TEST_VOXEL);
+    map.insertionOptions.ray_tube_voxels = 0.5;  // no coverage help from the tube
+    map.insertObservation(*sparseScan, SENSOR_POSE);
+
+    ASSERT_(map.isBootstrapping());
+    ASSERT_(!map.queryField(query).valid);
+
+    // ... and yet the map answers, because the warm-up cloud does.
+    const auto np = map.nn_search_pt2pl(query, 1.0f);
+    ASSERT_(np.pairing.has_value());
+    std::cout << "test_bootstrap_answers_before_the_field_can: warm-up distance = " << np.distance
+              << " m, field ready = " << map.lastFieldReadyFraction() << "\n";
+    ASSERT_NEAR_(np.distance, 0.15f, 0.02f);
+  }
+
+  // With a dense scan the field is ready at once, and the two answers agree.
+  {
+    mola::TSDF map(TEST_VOXEL);
+    map.insertionOptions.bootstrap_min_scans = 1;
+    auto denseScan                           = plane_scan(0.05f);
+
+    map.insertObservation(*denseScan, SENSOR_POSE);
+    ASSERT_(!map.isBootstrapping());
+    ASSERT_(map.queryField(query).valid);
+
+    const auto fromField = map.nn_search_pt2pl(query, 1.0f);
+    ASSERT_(fromField.pairing.has_value());
+
+    mola::TSDF pointsOnly(TEST_VOXEL);
+    pointsOnly.insertionOptions.bootstrap_min_scans = 100;  // never leaves the warm-up
+    pointsOnly.insertionOptions.bootstrap_max_scans = 100;
+    pointsOnly.insertObservation(*denseScan, SENSOR_POSE);
+    ASSERT_(pointsOnly.isBootstrapping());
+
+    const auto fromPoints = pointsOnly.nn_search_pt2pl(query, 1.0f);
+    ASSERT_(fromPoints.pairing.has_value());
+
+    std::cout << "test_bootstrap_answers_before_the_field_can: field = " << fromField.distance
+              << " m, points = " << fromPoints.distance << " m\n";
+
+    // Both must find the same surface. They are not the same estimator, so the
+    // tolerance is the field's own tube displacement, not zero.
+    ASSERT_NEAR_(fromField.distance, fromPoints.distance, 0.03f);
+  }
+}
+
+/** The warm-up must be bounded: a field that never becomes ready must not
+ *  leave the map silently answering as a point cloud for the whole run.
+ */
+void test_bootstrap_is_bounded()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.ray_tube_voxels = 0.5;
+  // A readiness that can never be reached, so only the bound can end it.
+  map.insertionOptions.bootstrap_field_ready_fraction = 2.0;
+  map.insertionOptions.bootstrap_min_scans            = 1;
+  map.insertionOptions.bootstrap_max_scans            = 3;
+
+  auto scan = plane_scan(4.0f * TEST_VOXEL);
+
+  map.insertObservation(*scan, SENSOR_POSE);
+  ASSERT_(map.isBootstrapping());
+  map.insertObservation(*scan, SENSOR_POSE);
+  ASSERT_(map.isBootstrapping());
+  map.insertObservation(*scan, SENSOR_POSE);
+  ASSERT_(!map.isBootstrapping());
+
+  std::cout << "test_bootstrap_is_bounded: OK" << std::endl;
+}
+
 void test_serialization_roundtrip()
 {
   mola::TSDF map(TEST_VOXEL);
@@ -432,6 +545,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_pt2pl_pairing_of_a_plane();
     test_plane_sign_is_carried_through();
     test_noise_averaging();
+    test_bootstrap_answers_before_the_field_can();
+    test_bootstrap_is_bounded();
     test_serialization_roundtrip();
     test_pruning();
     test_voxel_budget_is_a_ceiling();

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -1,0 +1,294 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-mola_metric_maps_tsdf.cpp
+ * @brief  Test the TSDF map class
+ * @author Jose Luis Blanco Claraco
+ * @date   Sep 02, 2026
+ */
+
+#include <mola_metric_maps/TSDF.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+
+namespace
+{
+constexpr float PLANE_SPAN     = 6.0f;
+constexpr float PLANE_STEP     = 0.05f;
+constexpr float SENSOR_HEIGHT  = 2.0f;
+constexpr float TEST_VOXEL     = 0.25f;
+constexpr float QUERY_TOLERANC = 0.02f;
+
+/** Fills a horizontal plane z=0, observed from a sensor above it. */
+void fill_ground_plane(mola::TSDF& map, float zPlane = .0f, float noiseSigma = .0f)
+{
+  std::mt19937                    rng(1234);
+  std::normal_distribution<float> noise(.0f, noiseSigma);
+  const mrpt::math::TPoint3Df     sensor(.0f, .0f, SENSOR_HEIGHT);
+
+  for (float x = -PLANE_SPAN; x <= PLANE_SPAN; x += PLANE_STEP)
+  {
+    for (float y = -PLANE_SPAN; y <= PLANE_SPAN; y += PLANE_STEP)
+    {
+      const float z = zPlane + (noiseSigma > 0 ? noise(rng) : .0f);
+      map.insertPoint({x, y, z}, sensor);
+    }
+  }
+}
+
+void test_field_of_a_plane()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels    = 4.0;
+  map.insertionOptions.min_weight_for_query = 1.0;
+
+  fill_ground_plane(map);
+  ASSERT_(!map.isEmpty());
+
+  // Above the plane (free space, sensor side) the field must be positive and
+  // equal to the height; below it, negative. Samples are stored as distances
+  // along their own ray, so the field is a projective distance and the metric
+  // one is recovered by dividing by the gradient norm.
+  for (const float zq : {-0.4f, -0.2f, 0.0f, 0.2f, 0.4f})
+  {
+    const auto q = map.queryField({0.3f, -0.2f, zq});
+    ASSERTMSG_(q.valid, mrpt::format("field query invalid at z=%.2f", zq));
+
+    // The gradient must be the surface normal, pointing up (towards the
+    // sensor), and of norm 1/cos(incidence), which is close to 1 here.
+    const float gn = std::sqrt(
+        q.gradient.x * q.gradient.x + q.gradient.y * q.gradient.y + q.gradient.z * q.gradient.z);
+    ASSERTMSG_(gn > 0.9f && gn < 1.2f, mrpt::format("gradient norm %.4f out of range", gn));
+    ASSERT_(q.gradient.z / gn > 0.99f);
+
+    const float metricDist = q.dist / gn;
+    ASSERTMSG_(
+        std::abs(metricDist - zq) < QUERY_TOLERANC,
+        mrpt::format("field %.4f != %.4f at z=%.2f", metricDist, zq, zq));
+  }
+
+  std::cout << "test_field_of_a_plane: OK" << std::endl;
+}
+
+/** The zero level set is what registration is steered by, so a systematic
+ *  offset in it is a range bias on every scan. It is produced by off-axis
+ *  samples, whose along-ray distance over-estimates the distance to the
+ *  surface, so it grows with the ray tube radius: guard the shipped default.
+ */
+double surface_offset(float tubeSigmaVoxels)
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels = 4.0;
+  map.insertionOptions.tube_sigma_voxels = tubeSigmaVoxels;
+  map.insertionOptions.max_weight        = 1e9;
+
+  fill_ground_plane(map);
+
+  const auto q = map.queryField({0.3f, -0.2f, .0f});
+  ASSERT_(q.valid);
+  const float gn = std::sqrt(
+      q.gradient.x * q.gradient.x + q.gradient.y * q.gradient.y + q.gradient.z * q.gradient.z);
+  ASSERT_GT_(gn, 1e-3f);
+
+  // Height of the estimated surface under a query sitting on the true plane:
+  return -q.dist / gn;
+}
+
+/** The zero level set is what registration is steered by, so a systematic
+ *  offset in it is a range bias on every scan. It is produced by the samples
+ *  the ray passes to one side of, whose along-ray distance over-estimates the
+ *  distance to the surface, so it is controlled by the tube profile. Guard both
+ *  the shipped default and the fact that the knob still works.
+ */
+void test_surface_is_not_displaced()
+{
+  const double atDefault = surface_offset(mola::TSDF::TInsertionOptions().tube_sigma_voxels);
+  const double atNarrow  = surface_offset(0.15);
+
+  std::cout << "test_surface_is_not_displaced: default = " << atDefault * 1000
+            << " mm, narrow profile = " << atNarrow * 1000 << " mm" << std::endl;
+
+  ASSERTMSG_(
+      std::abs(atDefault) < 0.015,
+      mrpt::format("default profile displaces the surface by %.2f mm", atDefault * 1000));
+
+  // Narrowing the profile has to remove most of it, or the knob is not live:
+  ASSERTMSG_(
+      std::abs(atNarrow) < 0.003,
+      mrpt::format("narrow profile still displaces the surface by %.2f mm", atNarrow * 1000));
+  ASSERT_LT_(std::abs(atNarrow), std::abs(atDefault));
+}
+
+void test_pt2pl_pairing_of_a_plane()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels = 4.0;
+
+  fill_ground_plane(map);
+
+  // A query point 0.3 m above the ground must pair against a plane at z=0
+  // whose normal is vertical, and report 0.3 m of distance.
+  const mrpt::math::TPoint3Df query(0.5f, 0.5f, 0.3f);
+
+  const auto r = map.nn_search_pt2pl(query, 1.0f);
+  ASSERT_(r.pairing.has_value());
+  ASSERTMSG_(
+      std::abs(r.distance - 0.3f) < QUERY_TOLERANC,
+      mrpt::format("pt2pl distance %.4f != 0.3", r.distance));
+
+  const auto& c = r.pairing->pl_global.centroid;
+  ASSERTMSG_(std::abs(c.z) < QUERY_TOLERANC, mrpt::format("plane foot z=%.4f != 0", c.z));
+  ASSERTMSG_(
+      std::abs(c.x - query.x) < QUERY_TOLERANC && std::abs(c.y - query.y) < QUERY_TOLERANC,
+      "plane foot is not the query's own projection");
+
+  // Beyond the truncation there is no field, hence no pairing:
+  const auto rFar = map.nn_search_pt2pl({0.5f, 0.5f, 3.0f}, 5.0f);
+  ASSERT_(!rFar.pairing.has_value());
+
+  std::cout << "test_pt2pl_pairing_of_a_plane: OK" << std::endl;
+}
+
+/** The point of the map class: fusing many noisy views of one surface must
+ *  estimate it better than any single measurement does.
+ */
+void test_noise_averaging()
+{
+  constexpr float SIGMA = 0.05f;
+
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.truncation_voxels = 4.0;
+  map.insertionOptions.max_weight        = 1e6;  // no forgetting, for the test
+
+  fill_ground_plane(map, .0f, SIGMA);
+
+  // Sample the recovered zero level set over the plane and check that its
+  // spread is well below the per-measurement noise.
+  double sum  = 0;
+  double sum2 = 0;
+  size_t n    = 0;
+  for (float x = -2.0f; x <= 2.0f; x += 0.13f)
+  {
+    for (float y = -2.0f; y <= 2.0f; y += 0.13f)
+    {
+      const auto q = map.queryField({x, y, 0.1f});
+      if (!q.valid)
+      {
+        continue;
+      }
+      const float gn = std::sqrt(
+          q.gradient.x * q.gradient.x + q.gradient.y * q.gradient.y + q.gradient.z * q.gradient.z);
+      if (gn < 1e-3f)
+      {
+        continue;
+      }
+      // Height of the zero crossing under this query:
+      const double zSurf = 0.1 - q.dist / gn;
+      sum += zSurf;
+      sum2 += zSurf * zSurf;
+      n++;
+    }
+  }
+  ASSERT_GT_(n, 100U);
+
+  const double mean = sum / n;
+  const double var  = sum2 / n - mean * mean;
+  const double rms  = std::sqrt(std::max(.0, var));
+
+  std::cout << "test_noise_averaging: n=" << n << " mean=" << mean << " rms=" << rms << std::endl;
+
+  // The claim under test is about the SPREAD: fusing many views of one surface
+  // has to estimate it far better than any single measurement does.
+  ASSERTMSG_(
+      rms < 0.25 * SIGMA,
+      mrpt::format(
+          "fused surface spread %.4f is not well below the %.4f measurement noise", rms,
+          static_cast<double>(SIGMA)));
+
+  // The mean is a different quantity, and it does not go to zero: it carries
+  // the tube profile's own displacement (see test_surface_is_not_displaced),
+  // which grows with the roughness of the surface being fused.
+  ASSERTMSG_(std::abs(mean) < 0.03, mrpt::format("fused surface is biased: mean=%.4f", mean));
+}
+
+void test_serialization_roundtrip()
+{
+  mola::TSDF map(TEST_VOXEL);
+  fill_ground_plane(map);
+
+  mrpt::io::CMemoryStream buf;
+  auto                    arch = mrpt::serialization::archiveFrom(buf);
+  arch << map;
+
+  buf.Seek(0);
+  mola::TSDF map2;
+  arch >> map2;
+
+  ASSERT_EQUAL_(map.size(), map2.size());
+
+  const auto q1 = map.queryField({0.3f, -0.2f, 0.2f});
+  const auto q2 = map2.queryField({0.3f, -0.2f, 0.2f});
+  ASSERT_(q1.valid && q2.valid);
+  ASSERT_(std::abs(q1.dist - q2.dist) < 1e-6f);
+
+  std::cout << "test_serialization_roundtrip: OK" << std::endl;
+}
+
+void test_pruning()
+{
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.remove_voxels_farther_than = 2.0;
+
+  fill_ground_plane(map);
+  const size_t nBefore = map.size();
+  ASSERT_GT_(nBefore, 0U);
+
+  // Inserting an observation from the origin prunes everything beyond 2 m:
+  mrpt::obs::CObservationPointCloud obs;
+  obs.pointcloud = mrpt::maps::CSimplePointsMap::Create();
+  obs.pointcloud->insertPointFast(0.1f, 0.1f, -2.0f);
+  map.insertObservation(obs, mrpt::poses::CPose3D::Identity());
+
+  ASSERT_LT_(map.size(), nBefore);
+
+  // ...and nothing far away survived:
+  const auto qFar = map.queryField({5.0f, 5.0f, .0f});
+  ASSERT_(!qFar.valid);
+
+  std::cout << "test_pruning: OK" << std::endl;
+}
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+  try
+  {
+    test_field_of_a_plane();
+    test_surface_is_not_displaced();
+    test_pt2pl_pairing_of_a_plane();
+    test_noise_averaging();
+    test_serialization_roundtrip();
+    test_pruning();
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << mrpt::exception_to_str(e) << "\n";
+    return 1;
+  }
+  return 0;
+}

--- a/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_tsdf.cpp
@@ -424,6 +424,39 @@ void test_bootstrap_answers_before_the_field_can()
   }
 }
 
+/** A neighborhood with no plane in it must yield no pairing, not an exception.
+ *
+ *  On the first scans a k-NN neighborhood can easily be a single scan line, and
+ *  a plane fit that throws on that case escapes the matcher and is treated by
+ *  the caller as a fatal error, which stops the run outright.
+ */
+void test_bootstrap_survives_a_degenerate_neighborhood()
+{
+  auto obs                                        = mrpt::obs::CObservationPointCloud::Create();
+  obs->sensorPose                                 = mrpt::poses::CPose3D::Identity();
+  auto pts                                        = mrpt::maps::CSimplePointsMap::Create();
+  pts->insertionOptions.minDistBetweenLaserPoints = .0f;
+
+  // A single straight line of points: collinear, so there is no tangent plane.
+  for (int i = 0; i < 200; i++)
+  {
+    pts->insertPointFast(0.05f * static_cast<float>(i) - 5.0f, .0f, -SENSOR_HEIGHT);
+  }
+  pts->mark_as_modified();
+  obs->pointcloud = pts;
+
+  mola::TSDF map(TEST_VOXEL);
+  map.insertionOptions.bootstrap_min_scans = 100;  // stay in the warm-up
+  map.insertionOptions.bootstrap_max_scans = 100;
+  map.insertObservation(*obs, SENSOR_POSE);
+  ASSERT_(map.isBootstrapping());
+
+  const auto np = map.nn_search_pt2pl({0.1f, 0.02f, 0.1f}, 1.0f);
+  ASSERT_(!np.pairing.has_value());
+
+  std::cout << "test_bootstrap_survives_a_degenerate_neighborhood: OK" << std::endl;
+}
+
 /** The warm-up must be bounded: a field that never becomes ready must not
  *  leave the map silently answering as a point cloud for the whole run.
  */
@@ -547,6 +580,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     test_noise_averaging();
     test_bootstrap_answers_before_the_field_can();
     test_bootstrap_is_bounded();
+    test_bootstrap_survives_a_degenerate_neighborhood();
     test_serialization_roundtrip();
     test_pruning();
     test_voxel_budget_is_a_ceiling();


### PR DESCRIPTION
Adds `mola::TSDF`, a truncated signed distance field local map stored as a voxel hash.

Every existing map class in `mola_metric_maps` stores points and answers a query by *selecting* among them: a representative per cell, a k-NN set, a candidate list. A field map stores no points at all. The residual of a query point is the trilinearly interpolated field value at it, and the surface normal is the analytical gradient of that interpolant, so there is no correspondence search and no `argmin` anywhere in the query path.

It exposes `mp2p_icp::NearestPlaneCapable`, so **`Matcher_Point2Plane` and `Solver_GaussNewton` use it unchanged** -- no new matcher, no new solver, no new residual type. Adding it to a pipeline is a `localmap_generator` change.

### What is in here

- `insertPoint(pt, sensorPt)` fuses one measurement into a narrow cylinder around its own ray, truncated at `truncation_distance` either side of the surface, by a weighted running average capped at `max_weight`.
- `queryField(p)` returns the interpolated value and its analytical gradient, and is valid only when all eight surrounding voxels exist and carry at least `min_weight_for_query` of evidence.
- `nn_search_pt2pl()` converts that into a point-to-plane pairing: the metric distance is `d/|grad d|` (the stored value is a distance *along the measurement ray*, which is a projective distance, not a metric one), the foot of the perpendicular is the pairing point, and the normalized gradient is the plane normal.
- Extent pruning and a hard voxel-count ceiling. Eviction is **by distance, not by age**, so the map stays a pure function of its contents and the sensor pose and does not depend on insertion order.

### Two things worth reviewing closely

**The tube has two knobs, not one, and that is deliberate.** `ray_tube_voxels` is the coverage cutoff: it must reach at least half the spacing between adjacent beams at working range, or the field is undefined between them. `tube_sigma_voxels` is the weight profile. They have to be separate because a sample stored as its distance *along its own ray* over-estimates the distance to the surface for an off-axis voxel, so averaging over a wide tube pushes the zero level set away from the sensor. Measured on a synthetic plane, that displacement is **-36.9 mm** with a flat profile and **-1.8 mm** with a narrow one at the same cutoff. A unit test guards both the shipped default and the knob's liveness, so a future edit cannot quietly widen the profile back.

**This class does not use `mola::index3d_hash`.** That functor truncates the hash to 20 bits, capping it at 2^20 distinct values. That has never mattered, because a point-based voxel map holds one cell per occupied voxel and no map in this library had come near a million. A field map is the first that does: it fills a band around *every* surface, so at a 0.3 m voxel it passes a million voxels within seconds of driving, and past that point every new key collides. Measured end to end on one KITTI sequence: **112 GB and no trajectory** with the shared hash against **0.83 GB and a complete one** with a full-entropy hash. The shared functor is deliberately untouched here -- widening it reorders the iteration of every existing voxel map, and with it the summation order of anything accumulating over one, so it needs its own change with its own before/after evidence. That is a separate PR.

### Testing

Nine unit tests (`test-mola_metric_maps_tsdf`), all passing: the field of a known plane; the surface displacement above; the analytical gradient against finite differences on a tilted plane (18 checks); the pt2pl pairing; the sign convention end to end; noise averaging (5.3 mm RMS out of 50 mm of input noise); serialization round-trip; pruning; and the voxel budget as a ceiling.

Closed-loop on KITTI 00-10 through `mola_lidar_odometry`, against a control that runs the *same* point-to-plane residual over the shipped point map (`Matcher_Points_KnnPlane`), so the map representation is the only difference: tilt drift **0.582x (7/7 sequences better)**, APE 0.846x (6/7), vertical drift rate 0.621x (6/7), translation drift 0.882x (6/6). Run-to-run determinism is byte-exact (n=4).

### Known limitation, and why this is not wired into any shipped profile

At a fine voxel the map does not bootstrap: a single scan does not fill eight corners of a cell anywhere useful, so the first ICP finds no field, the local map resets, and the run never starts. On KITTI at 0.25 m this affects 4 of 11 sequences. A field map is empty in a way a point map is not -- one scan of points is immediately queryable, one scan of field is not. The follow-up is a warm-up policy that registers against an `IncrementalPointCloud` until the field is dense enough to answer, and switches then. Until that lands, this class is opt-in and no shipped pipeline references it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1FqZXozHmo5QJ8hAsHNxz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TSDF volumetric mapping for representing surfaces with signed-distance fields.
  * Supports configurable voxel resolution, truncation, weighting, pruning, visualization, serialization, gradients, and point-to-plane queries.
  * Supports insertion from point-cloud and range-sensor observations.
  * Provides bootstrap queries while the field is being populated, with updated readiness and scan-limit defaults.
  * TSDF maps can be registered and used alongside other metric map types.

* **Tests**
  * Added coverage for field queries, gradients, fusion, bootstrap behavior, serialization, and voxel limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->