### PR TITLE
Give the voxel spatial hash its full entropy, and mix its low bits

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/index3d_t.h
+++ b/mola_metric_maps/include/mola_metric_maps/index3d_t.h
@@ -71,9 +71,16 @@ std::ostream& operator<<(std::ostream& o, const index3d_t<cell_coord_t>& idx)
  *
  * The hash function is the optimized spatial hash from:
  *   Teschner et al., "Optimized spatial hashing for collision detection of
- *   deformable objects", VMV 2003.
- * It mixes the three integer coordinates with large prime multipliers and
- * truncates to 20 bits, giving good distribution for typical voxel grids.
+ *   deformable objects", VMV 2003,
+ * which mixes the three integer coordinates with large prime multipliers,
+ * followed by a splitmix64 finalizer.
+ *
+ * The finalizer is not cosmetic. `tsl::robin_map`, the container these keys are
+ * used with, indexes its buckets with the *low* bits of the hash, and the low
+ * bits of a sum of odd-prime multiples depend on very few input bits, so
+ * grid-aligned keys cluster. Mixing costs two multiplies and pays for itself:
+ * on a 4 M-key voxel set, the longest bucket chain drops from 14 to 8 and
+ * lookups get about 30% faster.
  *
  * The `operator()(k1,k2)` overload provides a strict weak ordering on
  * `index3d_t` (X-primary, Y-secondary, Z-tertiary) for `std::map`.
@@ -91,7 +98,19 @@ struct index3d_hash
     static_assert(offsetof(index3d_t<cell_coord_t>, cz) == 2 * sizeof(uint32_t));
 
     const uint32_t* vec = reinterpret_cast<const uint32_t*>(&k);
-    return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349663 ^ vec[2] * 83492791);
+
+    uint64_t h = (static_cast<uint64_t>(vec[0]) * 73856093ULL) ^
+                 (static_cast<uint64_t>(vec[1]) * 19349663ULL) ^
+                 (static_cast<uint64_t>(vec[2]) * 83492791ULL);
+
+    // splitmix64 finalizer, so that every output bit depends on every input bit
+    h ^= h >> 30;
+    h *= 0xbf58476d1ce4e5b9ULL;
+    h ^= h >> 27;
+    h *= 0x94d049bb133111ebULL;
+    h ^= h >> 31;
+
+    return static_cast<std::size_t>(h);
   }
 
   /// k1 < k2? for std::map containers

--- a/mola_metric_maps/include/mola_metric_maps/index3d_t.h
+++ b/mola_metric_maps/include/mola_metric_maps/index3d_t.h
@@ -110,6 +110,10 @@ struct index3d_hash
     h *= 0x94d049bb133111ebULL;
     h ^= h >> 31;
 
+    // Narrowing to a 32-bit `std::size_t` is harmless: the finalizer above
+    // spreads every input bit across the whole word, so the low half is as
+    // good a hash as the full one, and 2^32 distinct values is far beyond
+    // anything a voxel map holds.
     return static_cast<std::size_t>(h);
   }
 

--- a/mola_metric_maps/tests/CMakeLists.txt
+++ b/mola_metric_maps/tests/CMakeLists.txt
@@ -28,6 +28,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test-mola_metric_maps_index3d_hash
+  SOURCES test-mola_metric_maps_index3d_hash.cpp
+  LINK_LIBRARIES
+  mola_metric_maps
+)
+
+mola_add_test(
   TARGET  test-mola_metric_maps_serialization
   SOURCES test-serialization.cpp
   LINK_LIBRARIES

--- a/mola_metric_maps/tests/test-mola_metric_maps_index3d_hash.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_index3d_hash.cpp
@@ -1,0 +1,160 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-mola_metric_maps_index3d_hash.cpp
+ * @brief  Test the spatial hash used by every voxel map class
+ * @author Jose Luis Blanco Claraco
+ * @date   Sep 02, 2026
+ */
+
+#include <mola_metric_maps/index3d_t.h>
+#include <mrpt/core/exceptions.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+using key_t = mola::index3d_t<int32_t>;
+
+/// A cube of voxel indices, offset so the negative-coordinate path is used.
+std::vector<key_t> denseBox(int side, int offset)
+{
+  std::vector<key_t> v;
+  v.reserve(static_cast<size_t>(side) * side * side);
+  for (int x = 0; x < side; x++)
+  {
+    for (int y = 0; y < side; y++)
+    {
+      for (int z = 0; z < side; z++)
+      {
+        v.emplace_back(x + offset, y + offset, z + offset);
+      }
+    }
+  }
+  return v;
+}
+
+/** The hash must not be capped to a fixed width.
+ *
+ * A point-based voxel map holds one cell per occupied voxel and never came
+ * near a million of them, so a 20-bit hash went unnoticed for years. A field
+ * map fills a band around every surface and passes that in seconds, and past
+ * the cap every new key collides with an existing one: the container's probing
+ * degrades without bound, which is a memory blow-up rather than a slowdown.
+ */
+void test_hash_is_not_capped()
+{
+  const auto           keys = denseBox(128, -64);
+  mola::index3d_hash<> h;
+
+  std::vector<uint64_t> hs;
+  hs.reserve(keys.size());
+  for (const auto& k : keys)
+  {
+    hs.push_back(h(k));
+  }
+  std::sort(hs.begin(), hs.end());
+  const size_t distinct = static_cast<size_t>(std::unique(hs.begin(), hs.end()) - hs.begin());
+
+  const double frac = double(distinct) / double(keys.size());
+  std::cout << "test_hash_is_not_capped: " << distinct << " distinct of " << keys.size()  //
+            << " (" << 100.0 * frac << "%)\n";
+
+  // A 20-bit hash cannot exceed 2^20 distinct values, i.e. 50% of this set.
+  ASSERT_GT_(frac, 0.95);
+}
+
+/** The low bits must be mixed, because those are the ones that index buckets.
+ *
+ * `tsl::robin_map` uses a power-of-two growth policy, so the bucket of a key is
+ * the low bits of its hash. The low bits of a sum of odd-prime multiples of the
+ * coordinates depend on very few input bits, so grid-aligned keys pile into a
+ * few buckets even when the full-width hash is well spread.
+ */
+void test_low_bits_are_mixed()
+{
+  const auto           keys = denseBox(128, -64);
+  mola::index3d_hash<> h;
+
+  // Occupancy of a power-of-two table at a load factor of 0.5, as the
+  // container would size it.
+  size_t bits = 1;
+  while ((1ULL << bits) < keys.size() * 2)
+  {
+    bits++;
+  }
+  const uint64_t nBuckets = 1ULL << bits;
+  const uint64_t mask     = nBuckets - 1;
+
+  std::vector<uint32_t> occupancy(nBuckets, 0);
+  for (const auto& k : keys)
+  {
+    occupancy[h(k) & mask]++;
+  }
+
+  const double expected = double(keys.size()) / double(nBuckets);
+  double       chi2     = 0;
+  uint32_t     worst    = 0;
+  for (const uint32_t o : occupancy)
+  {
+    const double d = o - expected;
+    chi2 += d * d / expected;
+    worst = std::max(worst, o);
+  }
+  // Normalized so that a uniform hash gives 1.0 and worse is higher.
+  const double chi2n = chi2 / double(nBuckets);
+
+  std::cout << "test_low_bits_are_mixed: chi2n = " << chi2n << ", longest chain = " << worst
+            << "\n";
+
+  ASSERT_LT_(chi2n, 1.3);
+  ASSERT_LT_(worst, 12U);
+}
+
+/// The same functor doubles as the `std::map` comparator, which the hash
+/// change must leave alone.
+void test_comparator_is_a_strict_weak_ordering()
+{
+  mola::index3d_hash<> c;
+
+  const key_t a(1, 2, 3);
+  const key_t b(1, 2, 4);
+  const key_t d(1, 3, 0);
+  const key_t e(2, 0, 0);
+
+  ASSERT_(c(a, b));
+  ASSERT_(!c(b, a));
+  ASSERT_(c(b, d));
+  ASSERT_(c(d, e));
+  ASSERT_(!c(a, a));
+}
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+  try
+  {
+    test_hash_is_not_capped();
+    test_low_bits_are_mixed();
+    test_comparator_is_a_strict_weak_ordering();
+  }
+  catch (std::exception& e)
+  {
+    std::cerr << e.what() << "\n";
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
`mola::index3d_hash` truncated its result to 20 bits, capping it at 2^20 = 1.05 M distinct values. This PR widens it to the full 64-bit mix and adds a splitmix64 finalizer.

### Why the cap went unnoticed, and why it matters now

A point-based voxel map holds one cell per occupied voxel at a decimetre-to-metre cell size, and no map class in this library had ever come near a million cells. A distance-field map is the first that does: it fills a band around *every* surface rather than one cell per measured point, so at a 0.3 m voxel it passes a million voxels within seconds of driving. Past the cap every new key collides with an existing hash, `tsl::robin_map`'s robin-hood probing degrades without bound, and the symptom is not a slowdown but a memory blow-up.

Measured end to end on one KITTI sequence, changing only the voxel budget: **112 GB and no trajectory** against **0.83 GB and a complete one**. Before that, bytes-per-voxel is a flat 51 B up to exactly 1.0 M voxels, and then neither memory nor time completes another doubling.

### Why widening alone is not the whole fix

`tsl::robin_map`'s default growth policy is `power_of_two_growth_policy`, so a key's bucket is the **low bits** of its hash. The low bits of a sum of odd-prime multiples of the coordinates depend on very few input bits, so grid-aligned keys, which is all these ever are, cluster. Widening fixes the capacity and leaves the clustering exactly as it was.

A splitmix64 finalizer costs two multiplies and three shifts, and pays for itself. Measured over four key sets (a TSDF-like surface band and a dense box, at the origin and offset into negative coordinates), at a load factor of 0.5:

| key set | | distinct | bucket chi2 (1.0 = uniform) | longest chain | insert | lookup |
|---|---|---|---|---|---|---|
| surface band, 518 k keys | shipped | 57.2% | 1.85 | 12 | 52.4 ms | 12.7 ms |
| | widened | 96.5% | 1.85 | 12 | 52.6 ms | 12.6 ms |
| | **this PR** | 96.5% | **1.07** | **7** | 48.6 ms | **9.4 ms** |
| dense box, 4.1 M keys | shipped | *aborted: exceeded a 12 GB address-space cap* ||||
| | widened | 100.0% | 1.98 | 14 | 651 ms | 226 ms |
| | **this PR** | 100.0% | **1.00** | **8** | 560 ms | **158 ms** |

So: lookups about 30% faster, and the container no longer dies on a key set a field map reaches in seconds.

### Blast radius, and the closed-loop A/B

The functor is used two ways. As a **hash** it keys `tsl::robin_map` in `mola::NDT` and `mola::HashedVoxelPointCloud`. As a **comparator** it orders `std::map`/`std::set` in `mola::SparseVoxelPointCloud` and `mola::SparseTreesPointCloud`; that overload is untouched, so those classes cannot be affected.

Changing where entries land could in principle change the iteration order of the two hashed classes, and with it the summation order of anything accumulated over one. So both shipped pipelines whose local map is one of those classes were run on all of KITTI 00-10, old hash against new, from the same source tree one header apart, in two separate install prefixes:

| pipeline | local map | sequences | result |
|---|---|---|---|
| `lidar3d-icp.yaml` | `mola::HashedVoxelPointCloud` | 11/11 | **trajectories byte-identical** |
| `lidar3d-ndt.yaml` | `mola::NDT` | 11/11 | **trajectories byte-identical** |

Not "within noise" -- the output md5s match. Neither class's query path iterates the container, so the hash decides only where entries live, not the order anything is summed in. The flagship `lidar3d-default.yaml` uses `mola::KeyframePointCloudMap`, which does not use this functor at all.

### Testing

New `test-mola_metric_maps_index3d_hash`, which fails on the old header and passes on the new one:

- `test_hash_is_not_capped`: 2.1 M distinct keys must produce >95% distinct hashes. Old: **35.3%**. New: **99.999%**.
- `test_low_bits_are_mixed`: the normalized bucket chi-square at load factor 0.5 must be below 1.3 and the longest chain below 12. New: 1.00 and 8.
- `test_comparator_is_a_strict_weak_ordering`: guards the untouched overload.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1FqZXozHmo5QJ8hAsHNxz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved spatial hash distribution across hash-map buckets, reducing the likelihood of collisions and long lookup chains.
  * Hash values now use the full coordinate range rather than being limited to a fixed width.

* **Tests**
  * Added coverage for hash uniqueness, bucket distribution, and comparator ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->