### PR TITLE
Drop TSDF's private voxel hash for the shared one

### DIFF
--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -131,34 +131,7 @@ class TSDF : public mrpt::maps::CMetricMap,
     float weight = 0;
   };
 
-  /** Spatial hash for the field's voxels.
-   *
-   *  `mola::index3d_hash` truncates to 20 bits, which caps it at 2^20 distinct
-   *  values. That is ample for a point-based voxel map, which holds one cell
-   *  per occupied voxel at a decimetre-to-metre cell size, and no map class in
-   *  this library had ever come near it. A field map is the first that does: it
-   *  fills a band around *every* surface at a fine voxel, so it passes a
-   *  million voxels within seconds of driving, and past that point every new
-   *  key collides with an existing hash and the container degrades from a
-   *  measured 51 bytes per voxel to effectively unbounded -- 112 GB on a single
-   *  KITTI sequence.
-   *
-   *  So this class uses the full 64-bit mix. The shared functor is deliberately
-   *  left alone: changing it would alter the iteration order of every existing
-   *  voxel map, and with it the summation order of anything that accumulates
-   *  over one.
-   */
-  struct voxel_hash_t
-  {
-    std::size_t operator()(const global_index3d_t& k) const noexcept
-    {
-      return (static_cast<uint64_t>(static_cast<uint32_t>(k.cx)) * 73856093ULL) ^
-             (static_cast<uint64_t>(static_cast<uint32_t>(k.cy)) * 19349663ULL) ^
-             (static_cast<uint64_t>(static_cast<uint32_t>(k.cz)) * 83492791ULL);
-    }
-  };
-
-  using grids_map_t = tsl::robin_map<global_index3d_t, VoxelData, voxel_hash_t>;
+  using grids_map_t = tsl::robin_map<global_index3d_t, VoxelData, index3d_hash<int32_t>>;
 
   /** @} */
 

--- a/mola_metric_maps/include/mola_metric_maps/index3d_t.h
+++ b/mola_metric_maps/include/mola_metric_maps/index3d_t.h
@@ -91,17 +91,15 @@ struct index3d_hash
   /// Hash operator for unordered maps:
   std::size_t operator()(const index3d_t<cell_coord_t>& k) const noexcept
   {
-    // These are the implicit assumptions of the reinterpret cast below:
+    // The coordinates are signed, and the multiplies below are meant to run on
+    // their bit patterns, so each one is converted through uint32_t. That is a
+    // well-defined modulo-2^32 conversion, and on two's complement it keeps the
+    // bits unchanged.
     static_assert(sizeof(cell_coord_t) == sizeof(uint32_t));
-    static_assert(offsetof(index3d_t<cell_coord_t>, cx) == 0 * sizeof(uint32_t));
-    static_assert(offsetof(index3d_t<cell_coord_t>, cy) == 1 * sizeof(uint32_t));
-    static_assert(offsetof(index3d_t<cell_coord_t>, cz) == 2 * sizeof(uint32_t));
 
-    const uint32_t* vec = reinterpret_cast<const uint32_t*>(&k);
-
-    uint64_t h = (static_cast<uint64_t>(vec[0]) * 73856093ULL) ^
-                 (static_cast<uint64_t>(vec[1]) * 19349663ULL) ^
-                 (static_cast<uint64_t>(vec[2]) * 83492791ULL);
+    uint64_t h = (static_cast<uint64_t>(static_cast<uint32_t>(k.cx)) * 73856093ULL) ^
+                 (static_cast<uint64_t>(static_cast<uint32_t>(k.cy)) * 19349663ULL) ^
+                 (static_cast<uint64_t>(static_cast<uint32_t>(k.cz)) * 83492791ULL);
 
     // splitmix64 finalizer, so that every output bit depends on every input bit
     h ^= h >> 30;


### PR DESCRIPTION
`mola::TSDF` shipped with its own copy of the spatial hash functor. The reason
was real at the time: the shared `mola::index3d_hash` truncated to 20 bits,
which is ample for a point-based voxel map but which a field map exhausts within
seconds of driving (that is what #211's comment describes, and what cost 112 GB
on one KITTI sequence).

#212 removed that cap, and also added a splitmix64 finalizer that the private
copy never had. That finalizer is not cosmetic here: `tsl::robin_map` uses a
power-of-two growth policy, so it indexes buckets by the **low** bits of the
hash, and the low bits of a sum of odd-prime multiples depend on very few input
bits. Grid-aligned keys therefore cluster. So the duplicate was the *worse* of
the two functors, living on the one class whose key set is large enough for the
difference to matter.

This deletes the copy and uses the shared one, which also removes a now-stale
comment claiming the shared functor truncates to 20 bits.

## Verification

- All 22 `mola_metric_maps` tests pass.
- A full Oxford Spires sequence through the TSDF pipeline is **byte-identical**
  before and after, so nothing in this class depends on bucket iteration order
  at the configurations measured: the voxel-count cap never binds there, and the
  cap is the only order-dependent operation in the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1FqZXozHmo5QJ8hAsHNxz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal voxel-map hashing to use a shared hashing implementation.
  * Improved hash calculation consistency across coordinate values.
  * No user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->