### PR TITLE
FIX: relocalization requests raced with MOLA module discovery

### DIFF
--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -468,6 +468,17 @@ class BridgeROS2 : public RawDataSourceBase,
   double lastTimeCheckMolaSubs_ = 0;
   void   doLookForNewMolaSubs();
 
+  /// Returns a copy of the set of MOLA modules implementing mola::Relocalization.
+  /// `discoverIfEmpty` runs one module scan when none is known yet, so that a
+  /// request arriving before the periodic scan (see period_check_new_mola_subs)
+  /// is not dropped.
+  [[nodiscard]] std::set<std::shared_ptr<mola::Relocalization>> relocalizationModules(
+      bool discoverIfEmpty);
+
+  /// Returns the MapServer module ROS 2 service requests are forwarded to, or
+  /// an empty pointer if none is running.
+  [[nodiscard]] std::shared_ptr<mola::MapServer> firstMapServer();
+
   void internalOn(const mrpt::obs::CObservationImage& obs);
   void internalOn(const mrpt::obs::CObservation2DRangeScan& obs);
   void internalOn(const mrpt::obs::CObservationPointCloud& obs);

--- a/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
+++ b/mola_bridge_ros2/include/mola_bridge_ros2/BridgeROS2.h
@@ -468,6 +468,12 @@ class BridgeROS2 : public RawDataSourceBase,
   double lastTimeCheckMolaSubs_ = 0;
   void   doLookForNewMolaSubs();
 
+  /// Timestamp of the last module scan triggered on demand (see
+  /// relocalizationModules()). Atomic: unlike lastTimeCheckMolaSubs_, which
+  /// only the spinOnce() thread touches, this one is written from ROS
+  /// callback threads.
+  std::atomic<double> lastOnDemandMolaSubsScan_{0};
+
   /// Returns a copy of the set of MOLA modules implementing mola::Relocalization.
   /// `discoverIfEmpty` runs one module scan when none is known yet, so that a
   /// request arriving before the periodic scan (see period_check_new_mola_subs)

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1644,10 +1644,19 @@ std::set<std::shared_ptr<mola::Relocalization>> BridgeROS2::relocalizationModule
     }
   }
 
-  // Nothing known yet: the periodic scan (period_check_new_mola_subs) may not
-  // have run since the modules were created. Scan now so that an early request
-  // is served instead of silently dropped.
-  doLookForNewMolaSubs();
+  // Nothing known yet: the periodic scan may not have run since the modules
+  // were created. Scan now so that an early request is served instead of
+  // silently dropped, but no more often than period_check_new_mola_subs:
+  // while no module implements the interface, every incoming message would
+  // otherwise trigger a full scan. The compare-exchange also coalesces
+  // concurrent callers into a single scan.
+  const double tNow  = mrpt::Clock::nowDouble();
+  double       tLast = lastOnDemandMolaSubsScan_.load();
+  if (tNow - tLast > params_.period_check_new_mola_subs &&
+      lastOnDemandMolaSubsScan_.compare_exchange_strong(tLast, tNow))
+  {
+    doLookForNewMolaSubs();
+  }
 
   auto lck = mrpt::lockHelper(molaSubsMtx_);
   return molaSubs_.relocalization;

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1559,14 +1559,16 @@ void BridgeROS2::service_relocalize_from_se(
     std::shared_ptr<mola_msgs::srv::RelocalizeFromStateEstimator::Response>
         response)  // NOLINT(performance-unnecessary-value-param)
 {
-  auto lck = mrpt::lockHelper(rosPubsMtx_);
-  if (molaSubs_.relocalization.empty())
+  // This service only exists once a Relocalization module has been found, so
+  // there is nothing to discover here (see relocalizationModules()).
+  const auto relocModules = relocalizationModules(false);
+  if (relocModules.empty())
   {
     response->accepted = false;
     return;
   }
 
-  for (const auto& m : molaSubs_.relocalization)
+  for (const auto& m : relocModules)
   {
     m->relocalize_from_gnss();
   }
@@ -1579,8 +1581,8 @@ void BridgeROS2::service_relocalize_near_pose(
     std::shared_ptr<mola_msgs::srv::RelocalizeNearPose::Response>
         response)  // NOLINT(performance-unnecessary-value-param)
 {
-  auto lck = mrpt::lockHelper(rosPubsMtx_);
-  if (molaSubs_.relocalization.empty())
+  const auto relocModules = relocalizationModules(false);
+  if (relocModules.empty())
   {
     response->accepted = false;
     return;
@@ -1593,7 +1595,7 @@ void BridgeROS2::service_relocalize_near_pose(
     return;
   }
 
-  for (const auto& m : molaSubs_.relocalization)
+  for (const auto& m : relocModules)
   {
     m->relocalize_near_pose_pdf(p);
   }
@@ -1603,7 +1605,18 @@ void BridgeROS2::service_relocalize_near_pose(
 
 void BridgeROS2::callbackOnRelocalizeTopic(const geometry_msgs::msg::PoseWithCovarianceStamped& o)
 {
-  auto lck = mrpt::lockHelper(rosPubsMtx_);
+  // Unlike the services, this subscription exists from start-up, so a request
+  // may well arrive before any Relocalization module has been discovered:
+  const auto relocModules = relocalizationModules(true);
+  if (relocModules.empty())
+  {
+    MRPT_LOG_THROTTLE_WARN_FMT(
+        5.0,
+        "Ignoring relocalization request on topic '%s': no running MOLA module implements "
+        "mola::Relocalization.",
+        params_.relocalize_from_topic.c_str());
+    return;
+  }
 
   mrpt::poses::CPose3DPDFGaussian p;
   if (!relocalizationPoseInReferenceFrame(o, p))
@@ -1614,10 +1627,42 @@ void BridgeROS2::callbackOnRelocalizeTopic(const geometry_msgs::msg::PoseWithCov
     return;
   }
 
-  for (const auto& m : molaSubs_.relocalization)
+  for (const auto& m : relocModules)
   {
     m->relocalize_near_pose_pdf(p);
   }
+}
+
+std::set<std::shared_ptr<mola::Relocalization>> BridgeROS2::relocalizationModules(
+    bool discoverIfEmpty)
+{
+  {
+    auto lck = mrpt::lockHelper(molaSubsMtx_);
+    if (!molaSubs_.relocalization.empty() || !discoverIfEmpty)
+    {
+      return molaSubs_.relocalization;
+    }
+  }
+
+  // Nothing known yet: the periodic scan (period_check_new_mola_subs) may not
+  // have run since the modules were created. Scan now so that an early request
+  // is served instead of silently dropped.
+  doLookForNewMolaSubs();
+
+  auto lck = mrpt::lockHelper(molaSubsMtx_);
+  return molaSubs_.relocalization;
+}
+
+std::shared_ptr<mola::MapServer> BridgeROS2::firstMapServer()
+{
+  auto lck = mrpt::lockHelper(molaSubsMtx_);
+  if (molaSubs_.mapServers.empty())
+  {
+    return {};
+  }
+  // Returned by value: map_load()/map_save() may take a long time and must not
+  // hold molaSubsMtx_, which the periodic module scan also needs.
+  return *molaSubs_.mapServers.begin();
 }
 
 bool BridgeROS2::relocalizationPoseInReferenceFrame(
@@ -1650,8 +1695,8 @@ void BridgeROS2::service_map_load(
     std::shared_ptr<mola_msgs::srv::MapLoad::Response>
         response)  // NOLINT(performance-unnecessary-value-param)
 {
-  auto lck = mrpt::lockHelper(rosPubsMtx_);
-  if (molaSubs_.mapServers.empty())
+  const auto m = firstMapServer();
+  if (!m)
   {
     response->success       = false;
     response->error_message = "No MOLA module with MapServer interface is running.";
@@ -1659,8 +1704,6 @@ void BridgeROS2::service_map_load(
     return;
   }
 
-  const auto& m = *molaSubs_.mapServers.begin();
-  ASSERT_(m);
   const auto& r = m->map_load(request->map_path);
 
   response->success       = r.success;
@@ -1673,8 +1716,8 @@ void BridgeROS2::service_map_save(
     std::shared_ptr<mola_msgs::srv::MapSave::Response>
         response)  // NOLINT(performance-unnecessary-value-param)
 {
-  auto lck = mrpt::lockHelper(rosPubsMtx_);
-  if (molaSubs_.mapServers.empty())
+  const auto m = firstMapServer();
+  if (!m)
   {
     response->success       = false;
     response->error_message = "No MOLA module with MapServer interface is running.";
@@ -1682,8 +1725,6 @@ void BridgeROS2::service_map_save(
     return;
   }
 
-  const auto& m = *molaSubs_.mapServers.begin();
-  ASSERT_(m);
   const auto& r = m->map_save(request->map_path);
 
   response->success       = r.success;


### PR DESCRIPTION
### The data race

`molaSubs_.relocalization` is written by `doLookForNewMolaSubs()` under `molaSubsMtx_`, but all three relocalization entry points (`callbackOnRelocalizeTopic`, `service_relocalize_near_pose`, `service_relocalize_from_se`) read it under `rosPubsMtx_` instead — an unsynchronized read of a `std::set` while another thread inserts into it.

`molaSubs_.mapServers` has the identical problem in `service_map_load` / `service_map_save`.

Both are now read under `molaSubsMtx_`, copying what is needed out of the lock so the potentially long `map_load()` / `map_save()` calls no longer block the periodic module scan (they previously held `rosPubsMtx_` across the call, blocking publishers instead).

### The dropped request

The `/initialpose` subscription is created at start-up, but `molaSubs_.relocalization` is only populated by the periodic scan, which runs every `period_check_new_mola_subs` seconds (1 s by default). A request arriving in that window iterated an empty set and was dropped **with no log line at all** — a manual relocalization from RViz or Foxglove right after launch simply did nothing.

Now one discovery pass runs on demand when the set is empty, and a throttled warning is emitted if there is genuinely no module implementing `mola::Relocalization`. The two services need no such pass: they are only advertised once a module has been found, so an empty set there is unreachable in practice.

Paired with MOLAorg/mola_lidar_odometry#167, which fixes the front end silently ignoring the pose these requests carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zosPukwMRmSpzVUUWga5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Relocalization now discovers available modules on demand when needed.
  * Module discovery is throttled to reduce repeated scans while continuing to use cached modules.
  * Simultaneous discovery requests are coordinated to prevent redundant searches.
  * Map server availability is handled consistently when selecting a server for map operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->