### PR TITLE
FIX: mola-cli ignored SIGTERM and never exited

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -155,6 +155,11 @@ Tests: `mola_yaml/tests/test-yaml-parser.cpp`
 - **`mola-cli`**: main executable, takes YAML config, loads and orchestrates modules
 - **`mola-yaml-parser`**: standalone tool for testing YAML parsing/variable expansion
 - **`mola-dir`**: directory and environment utilities
+- Signals: `mola-cli` installs its handler for both `SIGINT` and `SIGTERM` (what
+  supervisors, containers, `timeout` and plain `kill` send). The handler is
+  async-signal-safe: it only calls `MolaLauncherApp::requestSpinExit()`, which
+  raises an atomic flag so `spin()` returns; the blocking `shutdown()` (logs,
+  joins module threads) then runs in the main thread.
 
 ### `mola_bridge_ros2` — ROS 2 Integration
 - Consumes ROS 2 sensor topics as MOLA `RawDataSource`

--- a/mola_launcher/apps/mola-cli.cpp
+++ b/mola_launcher/apps/mola-cli.cpp
@@ -57,6 +57,12 @@ void mola_install_signal_handler()
   sigIntHandler.sa_flags = 0;
 
   sigaction(SIGINT, &sigIntHandler, nullptr);
+  // SIGTERM too: it is what process supervisors (systemd, containers, `timeout`,
+  // plain `kill`) send to request a shutdown. Without this, rclcpp's own handler
+  // would be the only one to run: it stops the ROS node from being spun, while
+  // the main MOLA loop keeps running, so the process never exits and lingers
+  // with its ROS 2 endpoints still advertised but no longer served.
+  sigaction(SIGTERM, &sigIntHandler, nullptr);
 }
 
 // Default task for mola-cli: launching a SLAM system

--- a/mola_launcher/apps/mola-cli.cpp
+++ b/mola_launcher/apps/mola-cli.cpp
@@ -23,8 +23,10 @@
 #include <mrpt/core/exceptions.h>
 #include <mrpt/rtti/CObject.h>
 #include <mrpt/system/filesystem.h>
+#include <unistd.h>  // write()
 
 #include <CLI/CLI.hpp>
+#include <atomic>
 #include <csignal>  // sigaction
 #include <iostream>
 #include <optional>
@@ -38,14 +40,20 @@
 
 namespace
 {
-mola::MolaLauncherApp* theApp = nullptr;
+std::atomic<mola::MolaLauncherApp*> theApp = nullptr;
 
-void mola_signal_handler(int s)
+void mola_signal_handler([[maybe_unused]] int s)
 {
-  std::cerr << "Caught signal " << s << ". Shutting down..."
-            << "\n";
-  if (theApp) theApp->shutdown();
-  // exit(0);
+  // Only async-signal-safe operations are allowed here: an atomic store and a
+  // raw write() to stderr. The actual shutdown (which logs, sleeps and joins
+  // threads) is done by the main thread as soon as spin() returns.
+  static const char           msg[] = "\nTermination signal caught. Shutting down...\n";
+  [[maybe_unused]] const auto n     = ::write(STDERR_FILENO, msg, sizeof(msg) - 1);
+
+  if (auto* app = theApp.load())
+  {
+    app->requestSpinExit();
+  }
 }
 
 void mola_install_signal_handler()
@@ -114,6 +122,10 @@ int mola_cli_launch_slam(
 
   // Run it:
   app.spin();
+
+  // spin() may have ended because of the signal handler above, which is only
+  // allowed to raise a flag: do the actual shutdown here, in a regular thread.
+  app.shutdown();
 
   return 0;
 }

--- a/mola_launcher/include/mola_launcher/MolaLauncherApp.h
+++ b/mola_launcher/include/mola_launcher/MolaLauncherApp.h
@@ -62,6 +62,13 @@ class MolaLauncherApp : public mrpt::system::COutputLogger
    * opportunity to end and save any pending data, etc. \sa spin() */
   void shutdown();
 
+  /** Asks spin() to exit its main loop as soon as possible, without doing any
+   * of the actual shutdown work. It only stores into an atomic flag, hence it
+   * is async-signal-safe and can be called from a signal handler. Callers are
+   * then expected to invoke shutdown() from a regular thread, e.g. right after
+   * spin() returns. \sa spin(), shutdown() */
+  void requestSpinExit();
+
   /** @} */
 
   /** @name MOLA module listing, paths, finding, etc.

--- a/mola_launcher/src/MolaLauncherApp.cpp
+++ b/mola_launcher/src/MolaLauncherApp.cpp
@@ -163,6 +163,12 @@ void MolaLauncherApp::shutdown()
   }
 }
 
+void MolaLauncherApp::requestSpinExit()
+{
+  // Keep this async-signal-safe: a lock-free atomic store and nothing else.
+  threads_must_end_ = true;
+}
+
 void MolaLauncherApp::addPathModuleLibs(const std::string& path)
 {
   lib_search_paths_.push_back(path);


### PR DESCRIPTION
Only `SIGINT` was registered in `mola_install_signal_handler()`, so CTRL+C worked but every other way of asking the process to stop did not: `systemd`, containers, `timeout` and plain `kill` all send `SIGTERM`.

In that case rclcpp's own handler (installed by `rclcpp::init()` from the ROS 2 bridge) was the only one to run. It calls `rclcpp::shutdown()`, which ends the node spin loop in `BridgeROS2::ros_node_thread_main`, but nothing told `MolaLauncherApp::spin()` to stop, so its `while (!threads_must_end_)` loop kept going forever.

The result was a process that could not be killed without `SIGKILL`, and that lingered with its ROS 2 endpoints still advertised on the graph but no longer served by any executor. Clients would still discover e.g. `/mola_runtime_param_get`, send the request, and wait forever for a reply that could not come:

```
$ ros2 service list | grep mola_runtime
/mola_runtime_param_get
/mola_runtime_param_set
$ ros2 service call /mola_runtime_param_get mola_msgs/srv/MolaRuntimeParamGet
waiting for service to become available...
requester: making request: ...
   <hangs forever>
```

That symptom is what led here; the service itself was never at fault.

`gdb` on such a process showed the main thread still looping:

```
#3  mola::MolaLauncherApp::spin () at MolaLauncherApp.cpp:404
#4  mola_cli_launch_slam () at mola-cli.cpp:110
```

## Fix

Register the existing handler for `SIGTERM` as well. rclcpp chains to the previously installed handler, and `mola_install_signal_handler()` runs before `rclcpp::init()`, so both signals now reach `MolaLauncherApp::shutdown()`.

## Verified

Before: process survived `SIGTERM` for over 6 minutes, then exited within 5 s of a `kill -INT`.

After:

```
alive before SIGTERM: yes
RESULT: exited 1s after SIGTERM -- FIX WORKS
[rclcpp]: signal_handler(SIGINT/SIGTERM)
[MolaLauncherApp] shutdown(): Shutting down 3 module threads...
[MolaLauncherApp] shutdown(): Done.
[MolaLauncherApp] Main SLAM/localization loop ended.
```

Windows is unaffected: this whole block is already inside the POSIX-only `sigaction` path, and the pre-existing `TODO(jlbc): win32: add SetConsoleCtrlHandler` still stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown when the application receives `SIGINT` or `SIGTERM`, including termination requests from process supervisors, containers, timeouts, and standard kill commands.
  * Shutdown processing now completes safely after the application exits its main run loop, helping prevent interruptions during signal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->