### PR TITLE
Port to MRPT 3.x

### DIFF
--- a/mola_bridge_ros2/CMakeLists.txt
+++ b/mola_bridge_ros2/CMakeLists.txt
@@ -14,12 +14,12 @@ cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mola_bridge_ros2 LANGUAGES CXX)
 
 # find dependencies:
-find_package(mrpt-maps REQUIRED)
+find_package(mrpt_maps REQUIRED)
 
-find_package(mrpt-ros2bridge QUIET)
-if(NOT mrpt-ros2bridge_FOUND)
+find_package(mrpt_libros_bridge QUIET)
+if(NOT mrpt_libros_bridge_FOUND)
   message(STATUS "*NOTE*: Module mola_input_ros2 will NOT be built due to missing"
-    "dependency mrpt-ros2bridge. Set mrpt-ros2bridge_DIR to enable it.")
+    "dependency mrpt_libros_bridge. Set mrpt_libros_bridge_DIR to enable it.")
   return()
 endif()
 
@@ -50,14 +50,20 @@ mola_find_package_or_return(mrpt_nav_interfaces)
 file(GLOB_RECURSE LIB_SRCS src/*.cpp src/*.h)
 file(GLOB_RECURSE LIB_PUBLIC_HDRS include/*.h)
 
+# Make sure workspace mrpt_libros_bridge include comes before Jazzy's includes
+# to avoid picking up mrpt2 ros2bridge headers from the system install.
+include_directories(BEFORE SYSTEM
+  $<TARGET_PROPERTY:mrpt_libros_bridge::mrpt_libros_bridge,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
 # This adds non-ROS deps. The rest are handled below with ament_target_dependencies()
 mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PRIVATE_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::maps
-    mrpt::ros2bridge
+    mrpt::mrpt_maps
+    mrpt_libros_bridge::mrpt_libros_bridge
   PUBLIC_LINK_LIBRARIES
     rclcpp::rclcpp
     tf2::tf2
@@ -72,7 +78,8 @@ mola_add_library(
     ${gps_msgs_TARGETS}
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-maps
+    mrpt_maps
+    mrpt_libros_bridge
 )
 
 # Same for mrpt_libros_bridge

--- a/mola_bridge_ros2/package.xml
+++ b/mola_bridge_ros2/package.xml
@@ -29,7 +29,7 @@
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
   <depend>mola_msgs</depend>
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_maps</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>mrpt_nav_interfaces</depend>
   <depend>nav_msgs</depend>

--- a/mola_bridge_ros2/src/BridgeROS2.cpp
+++ b/mola_bridge_ros2/src/BridgeROS2.cpp
@@ -1122,8 +1122,7 @@ void BridgeROS2::internalOn(const mrpt::obs::CObservationImage& obs)
   const std::string sSensorFrameId = obs.sensorLabel;
 
   // Send TF:
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const mrpt::poses::CPose3D sensorPose = obs.getSensorPose();
 
   tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(sensorPose);
 
@@ -1165,8 +1164,7 @@ void BridgeROS2::internalOn(const mrpt::obs::CObservation2DRangeScan& obs)
   const std::string sSensorFrameId = obs.sensorLabel;
 
   // Send TF:
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const mrpt::poses::CPose3D sensorPose = obs.getSensorPose();
 
   tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(sensorPose);
 
@@ -1329,8 +1327,7 @@ void BridgeROS2::internalOn(const mrpt::obs::CObservationGPS& obs)
   const std::string sSensorFrameId = obs.sensorLabel;
 
   // Send TF:
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const mrpt::poses::CPose3D sensorPose = obs.getSensorPose();
 
   tf2::Transform transform = mrpt::ros2bridge::toROS_tfTransform(sensorPose);
 
@@ -1371,8 +1368,7 @@ void BridgeROS2::internalOn(const mrpt::obs::CObservationIMU& obs)
   const std::string sSensorFrameId = obs.sensorLabel;
 
   // Send TF:
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const mrpt::poses::CPose3D sensorPose = obs.getSensorPose();
 
   if (tf_bc_)
   {
@@ -2163,7 +2159,8 @@ void BridgeROS2::timerPubMapLayer(const std::string& layerName, const MapSourceB
   // Is it a CVoxelMap?
   else if (auto vox = std::dynamic_pointer_cast<const mrpt::maps::CVoxelMap>(mu.map); vox)
   {
-    mrpt::maps::CSimplePointsMap::Ptr pm = vox->getOccupiedVoxels();
+    mrpt::maps::CSimplePointsMap::Ptr pm =
+        std::const_pointer_cast<mrpt::maps::CSimplePointsMap>(vox->getOccupiedVoxels());
     if (pm)
     {
       mrpt::obs::CObservationPointCloud obs;

--- a/mola_input_lidar_bin_dataset/CMakeLists.txt
+++ b/mola_input_lidar_bin_dataset/CMakeLists.txt
@@ -17,10 +17,10 @@ project(mola_input_bin_dataset LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find dependencies:
-find_package(mrpt-maps REQUIRED)    # For CGenericPointsMap
-find_package(mrpt-obs REQUIRED)     # For CObservationPointCloud
-find_package(mrpt-system REQUIRED)  # For file system utilities
-find_package(mrpt-core REQUIRED)    # For mrpt::Clock
+find_package(mrpt_maps REQUIRED)    # For CGenericPointsMap
+find_package(mrpt_obs REQUIRED)     # For CObservationPointCloud
+find_package(mrpt_system REQUIRED)  # For file system utilities
+find_package(mrpt_core REQUIRED)    # For mrpt::Clock
 
 find_mola_package(mola_kernel)
 find_mola_package(mola_yaml) # For parameter parsing
@@ -37,10 +37,10 @@ mola_add_library(
     mola::mola_kernel
     mola::mola_yaml
   PRIVATE_LINK_LIBRARIES
-    mrpt::maps
-    mrpt::obs
-    mrpt::system
-    mrpt::core
+    mrpt::mrpt_maps
+    mrpt::mrpt_obs
+    mrpt::mrpt_system
+    mrpt::mrpt_core
   CMAKE_DEPENDENCIES
     mola_kernel
     mola_yaml

--- a/mola_input_lidar_bin_dataset/package.xml
+++ b/mola_input_lidar_bin_dataset/package.xml
@@ -16,8 +16,12 @@
 
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
+  <depend>mola_yaml</depend>
 
   <depend>mrpt_maps</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_system</depend>
+  <depend>mrpt_core</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_input_lidar_bin_dataset/package.xml
+++ b/mola_input_lidar_bin_dataset/package.xml
@@ -17,7 +17,7 @@
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_maps</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_input_rawlog/CMakeLists.txt
+++ b/mola_input_rawlog/CMakeLists.txt
@@ -16,7 +16,7 @@ project(mola_input_rawlog LANGUAGES CXX)
 # MOLA CMake scripts: "mola_xxx()"
 find_package(mola_common REQUIRED)
 # find dependencies:
-find_package(mrpt-obs REQUIRED)
+find_package(mrpt_obs REQUIRED)
 
 find_mola_package(mola_kernel)
 
@@ -30,8 +30,8 @@ mola_add_library(
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PRIVATE_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::obs
+    mrpt::mrpt_obs
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-obs
+    mrpt_obs
 )

--- a/mola_input_rawlog/package.xml
+++ b/mola_input_rawlog/package.xml
@@ -16,7 +16,7 @@
 
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_input_rawlog/src/RawlogDataset.cpp
+++ b/mola_input_rawlog/src/RawlogDataset.cpp
@@ -52,13 +52,13 @@ std::optional<mrpt::Clock::time_point> RawlogDataset::findEntryTimestamp(bool fr
 
     switch (rawlog_entire_.getType(idx))
     {
-      case mrpt::obs::CRawlog::etObservation:
+      case mrpt::obs::CRawlog::TEntryType::etObservation:
         if (auto o = rawlog_entire_.getAsObservation(idx); o)
         {
           return o->timestamp;
         }
         break;
-      case mrpt::obs::CRawlog::etSensoryFrame:
+      case mrpt::obs::CRawlog::TEntryType::etSensoryFrame:
         if (auto sf = rawlog_entire_.getAsObservations(idx); sf && !sf->empty())
         {
           return (*sf->begin())->timestamp;
@@ -102,7 +102,8 @@ void RawlogDataset::initialize_rds(const Yaml& c)
   {
     MRPT_LOG_INFO_STREAM("Reading the whole rawlog dataset: " << rawlog_filename_);
 
-    rawlog_entire_.loadFromRawLogFile(rawlog_filename_);
+    const bool loadOk = rawlog_entire_.loadFromRawLogFile(rawlog_filename_);
+    ASSERTMSG_(loadOk, "Error loading rawlog file.");
 
     MRPT_LOG_INFO_STREAM("Read ok, with " << rawlog_entire_.size() << " entries.");
 
@@ -337,7 +338,8 @@ mrpt::obs::CSensoryFrame::Ptr RawlogDataset::datasetGetObservations(size_t times
     last_used_tim_index_ = timestep;
   }
 
-  const auto obj = rawlog_entire_.getAsGeneric(timestep);
+  auto objConst = rawlog_entire_.getAsGeneric(timestep);
+  auto obj      = std::const_pointer_cast<mrpt::serialization::CSerializable>(objConst);
 
   auto sfRet = mrpt::obs::CSensoryFrame::Create();
 

--- a/mola_input_rosbag2/CMakeLists.txt
+++ b/mola_input_rosbag2/CMakeLists.txt
@@ -16,8 +16,8 @@ project(mola_input_rosbag2 LANGUAGES CXX)
 # MOLA CMake scripts: "mola_xxx()"
 find_package(mola_common REQUIRED)
 # find dependencies:
-find_package(mrpt-obs REQUIRED)
-find_package(mrpt-ros2bridge REQUIRED)
+find_package(mrpt_obs REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
 
 find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -35,13 +35,19 @@ find_mola_package(mola_kernel)
 file(GLOB_RECURSE LIB_SRCS src/*.cpp src/*.h)
 file(GLOB_RECURSE LIB_PUBLIC_HDRS include/*.h)
 
+# Make sure workspace mrpt_libros_bridge include comes before Jazzy's includes
+# to avoid picking up mrpt2 ros2bridge headers from the system install.
+include_directories(BEFORE SYSTEM
+  $<TARGET_PROPERTY:mrpt_libros_bridge::mrpt_libros_bridge,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
 mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PRIVATE_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::obs
-    mrpt::ros2bridge
+    mrpt::mrpt_obs
+    mrpt_libros_bridge::mrpt_libros_bridge
     tf2::tf2
     rosbag2_cpp::rosbag2_cpp
     tf2_geometry_msgs::tf2_geometry_msgs
@@ -51,8 +57,8 @@ mola_add_library(
     ${gps_msgs_TARGETS}
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-obs
-    mrpt-ros2bridge
+    mrpt_obs
+    mrpt_libros_bridge
 )
 
 # Convert package versions to hex so they can be used in preprocessor for wider

--- a/mola_input_rosbag2/package.xml
+++ b/mola_input_rosbag2/package.xml
@@ -16,7 +16,7 @@
   <depend>cv_bridge</depend>
   <depend>gps_msgs</depend>  <!-- optional -->
   <depend>mola_kernel</depend>
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>rosbag2_cpp</depend>
   <depend>sensor_msgs</depend>

--- a/mola_input_rosbag2/src/Rosbag2Dataset.cpp
+++ b/mola_input_rosbag2/src/Rosbag2Dataset.cpp
@@ -356,26 +356,26 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
 
   for (auto& sensorNode : sensorsYaml.asSequence())
   {
-    const auto& sensor = sensorNode.asMap();
-    const auto  topic  = sensor.at("topic").as<std::string>();
+    const mrpt::containers::yaml sensor(sensorNode);
+    const auto                   topic = sensor["topic"].as<std::string>();
 
     std::string sensorLabel = topic;
-    if (sensor.count("sensorLabel") != 0)
+    if (sensor.has("sensorLabel"))
     {
-      sensorLabel = sensor.at("sensorLabel").as<std::string>();
+      sensorLabel = sensor["sensorLabel"].as<std::string>();
     }
 
     // Map to MOLA class: auto or manual:
     std::string sensorType;
 
-    if (sensor.count("type") != 0)
+    if (sensor.has("type"))
     {
-      sensorType = sensor.at("type").as<std::string>();
+      sensorType = sensor["type"].as<std::string>();
     }
     else
     {
       bool topic_is_optional = false;
-      if (sensor.count("is_optional") != 0 && sensor.at("is_optional").as<bool>())
+      if (sensor.has("is_optional") && sensor["is_optional"].as<bool>())
       {
         topic_is_optional = true;
       }
@@ -411,11 +411,11 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
 
     // Optional: fixed sensorPose (then ignores/don't need "tf" data):
     std::optional<mrpt::poses::CPose3D> fixedSensorPose;
-    if (sensor.count("fixed_sensor_pose") != 0 && (sensor.count("use_fixed_sensor_pose") == 0 ||
-                                                   sensor.at("use_fixed_sensor_pose").as<bool>()))
+    if (sensor.has("fixed_sensor_pose") &&
+        (!sensor.has("use_fixed_sensor_pose") || sensor["use_fixed_sensor_pose"].as<bool>()))
     {
       fixedSensorPose = mrpt::poses::CPose3D::FromString(
-          "["s + sensor.at("fixed_sensor_pose").as<std::string>() + "]"s);
+          "["s + sensor["fixed_sensor_pose"].as<std::string>() + "]"s);
     }
 
     // Optional: override this observation's timestamp with the bag's own
@@ -424,14 +424,14 @@ void Rosbag2Dataset::initialize_rds(const Yaml& c)
     // clock instead of wall-clock epoch time (seen in the wild for some IMU
     // drivers), which otherwise trips the "mis-timestamped sensors" time
     // reference reset (huge jump between this sensor and others).
-    const bool useBagRecvTimeAsTimestamp = sensor.count("use_bag_recv_time_as_timestamp") != 0 &&
-                                           sensor.at("use_bag_recv_time_as_timestamp").as<bool>();
+    const bool useBagRecvTimeAsTimestamp = sensor.has("use_bag_recv_time_as_timestamp") &&
+                                           sensor["use_bag_recv_time_as_timestamp"].as<bool>();
 
 #if 0  // TODO ?
 			else if (sensorType == "CObservation3DRangeScan")
 			{
-				bool rangeIsDepth = sensor.count("rangeIsDepth")
-										? sensor.at("rangeIsDepth").as<bool>()
+				bool rangeIsDepth = sensor.has("rangeIsDepth")
+										? sensor["rangeIsDepth"].as<bool>()
 										: true;
 				auto callback = [=](const sensor_msgs::Image::Ptr& image,
 									const sensor_msgs::CameraInfo::Ptr& info) {
@@ -1479,9 +1479,13 @@ Rosbag2Dataset::Obs Rosbag2Dataset::toCompressedImage(
 
   auto cv_ptr = cv_bridge::toCvCopy(image, "bgr8");
 
-  // cv_ptr (and the cv::Mat it owns) is local to this call, so a shallow
-  // copy (ref-counted, no pixel buffer duplication) is safe here:
-  imgObs->image = mrpt::img::CImage(cv_ptr->image, mrpt::img::SHALLOW_COPY);
+  // MRPT 3.x's CImage no longer wraps cv::Mat directly (removed to drop the
+  // OpenCV dependency), so copy the decoded pixels via the raw-buffer loader
+  // instead; swapRedBlue=true converts cv_bridge's BGR order to MRPT's RGB.
+  ASSERT_(cv_ptr->image.isContinuous());
+  imgObs->image.loadFromMemoryBuffer(
+      cv_ptr->image.cols, cv_ptr->image.rows, mrpt::img::CH_RGB, cv_ptr->image.data,
+      /*swapRedBlue=*/true);
 
   if (fixedSensorPose)
   {

--- a/mola_input_video/CMakeLists.txt
+++ b/mola_input_video/CMakeLists.txt
@@ -13,8 +13,8 @@ cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mola_input_video LANGUAGES CXX)
 
 find_package(mola_common REQUIRED)
-find_package(mrpt-hwdrivers REQUIRED)
-find_package(mrpt-obs REQUIRED)
+find_package(mrpt_hwdrivers REQUIRED)
+find_package(mrpt_obs REQUIRED)
 
 find_mola_package(mola_kernel)
 
@@ -31,6 +31,6 @@ mola_add_library(
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PRIVATE_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::hwdrivers
-    mrpt::obs
+    mrpt::mrpt_hwdrivers
+    mrpt::mrpt_obs
 )

--- a/mola_input_video/package.xml
+++ b/mola_input_video/package.xml
@@ -15,8 +15,8 @@
 
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libobs</depend>
-  <depend>mrpt_libhwdrivers</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_hwdrivers</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_kernel/CMakeLists.txt
+++ b/mola_kernel/CMakeLists.txt
@@ -18,7 +18,10 @@ find_package(mola_common REQUIRED)
 find_package(mola_yaml REQUIRED)
 
 # find dependencies:
-find_package(MRPT 2.15.0 REQUIRED COMPONENTS obs maps topography)
+find_package(mrpt_obs REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_topography REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 # define lib:
 set(LIB_SRCS
@@ -71,13 +74,16 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::obs
-    mrpt::topography
+    mrpt::mrpt_obs
+    mrpt::mrpt_maps
+    mrpt::mrpt_topography
     mola::mola_yaml
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
-    mrpt-obs
-    mrpt-topography
+    mrpt_obs
+    mrpt_maps
+    mrpt_topography
     mola_yaml
 )
 

--- a/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
+++ b/mola_kernel/include/mola_kernel/interfaces/VizInterface.h
@@ -33,8 +33,8 @@
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/math/TPoint3D.h>
 #include <mrpt/math/TPose3D.h>
-#include <mrpt/opengl/opengl_frwds.h>
 #include <mrpt/rtti/CObject.h>
+#include <mrpt/viz/viz_frwds.h>
 
 #include <future>
 #include <memory>
@@ -222,7 +222,7 @@ class VizInterface
    * \return               future<bool>; resolves to true when executed.
    */
   virtual std::future<bool> update_3d_object(
-      const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+      const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
       const std::string& viewportName = "main", const std::string& parentWindow = "main",
       const std::string& parentFrame = "") = 0;
 
@@ -263,7 +263,7 @@ class VizInterface
    * \return                   future<bool> resolving to true when executed.
    */
   virtual std::future<bool> insert_point_cloud_with_decay(
-      const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
+      const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main", const std::string& parentWindow = "main",
       const std::string& parentFrame = "") = 0;
 
@@ -306,7 +306,7 @@ class VizInterface
       const std::string& parentWindow = "main") = 0;
 
   /**
-   * \brief Executes arbitrary user code on the mrpt::opengl::Scene of the
+   * \brief Executes arbitrary user code on the mrpt::viz::Scene of the
    *        background viewport.
    *
    * Use this to modify viewport properties, add sub-viewports, change
@@ -317,8 +317,8 @@ class VizInterface
    * embed an mrpt scene in their OpenGL canvas.
    */
   virtual std::future<bool> execute_custom_code_on_background_scene(
-      const std::function<void(mrpt::opengl::Scene&)>& userCode,
-      const std::string&                               parentWindow = "main") = 0;
+      const std::function<void(mrpt::viz::Scene&)>& userCode,
+      const std::string&                            parentWindow = "main") = 0;
 
   /** @} */
 

--- a/mola_kernel/package.xml
+++ b/mola_kernel/package.xml
@@ -17,8 +17,10 @@
   <depend>mola_common</depend>
   <depend>mola_yaml</depend>
 
-  <depend>mrpt_libobs</depend>
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_topography</depend>
+  <build_depend>eigen</build_depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_kernel/src/interfaces/RawDataSourceBase.cpp
+++ b/mola_kernel/src/interfaces/RawDataSourceBase.cpp
@@ -221,7 +221,7 @@ void RawDataSourceBase::sendObservationsToFrontEnds(const mrpt::obs::CObservatio
         {
           ProfilerEntry pe(profiler_, "send to viz lambda");
 
-          using namespace mrpt::opengl;
+          using namespace mrpt::viz;
 
           // GUI update decimation:
           if (++sv->decimation_counter < sv->decimation)

--- a/mola_launcher/CMakeLists.txt
+++ b/mola_launcher/CMakeLists.txt
@@ -21,7 +21,7 @@ project(mola_launcher LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find dependencies:
-find_package(mrpt-core)
+find_package(mrpt_core REQUIRED)
 
 find_mola_package(mola_kernel)
 
@@ -38,7 +38,7 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::core
+    mrpt::mrpt_core
     mola::mola_kernel
   PRIVATE_LINK_LIBRARIES
     ${CMAKE_DL_LIBS} # To be able to load DLLs/.so's

--- a/mola_launcher/apps/CMakeLists.txt
+++ b/mola_launcher/apps/CMakeLists.txt
@@ -7,9 +7,9 @@
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------
 
-find_package(mrpt-core)
+find_package(mrpt_core REQUIRED)
 find_package(CLI11 REQUIRED)
-find_package(mrpt-containers)
+find_package(mrpt_containers REQUIRED)
 
 mola_add_executable(
   TARGET  mola-cli
@@ -17,7 +17,7 @@ mola_add_executable(
   LINK_LIBRARIES
     mola::mola_launcher
     mola::mola_kernel
-    mrpt::core
+    mrpt::mrpt_core
     CLI11::CLI11
 )
 
@@ -35,5 +35,5 @@ mola_add_executable(
   LINK_LIBRARIES
     mola::mola_kernel
     CLI11::CLI11
-    mrpt::containers
+    mrpt::mrpt_containers
 )

--- a/mola_launcher/package.xml
+++ b/mola_launcher/package.xml
@@ -16,7 +16,7 @@
 
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libbase</depend>
+  <depend>mrpt_core</depend>
   <depend>cli11</depend>
 
   <doc_depend>doxygen</doc_depend>

--- a/mola_metric_maps/CMakeLists.txt
+++ b/mola_metric_maps/CMakeLists.txt
@@ -22,8 +22,10 @@ find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
 find_package(mola_kernel REQUIRED)
-find_package(mrpt-maps REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_viz REQUIRED)
 find_package(mp2p_icp_map REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 find_package(TBB) # optional
 
@@ -110,13 +112,17 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::maps
+    mrpt::mrpt_maps
+    mrpt::mrpt_viz
     tsl::robin_map
     mola::mola_kernel
     mola::mp2p_icp_map
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-maps
+    mrpt_maps
+    mrpt_viz
     mp2p_icp_map
     robin_map
 )

--- a/mola_metric_maps/include/mola_metric_maps/HashedVoxelPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/HashedVoxelPointCloud.h
@@ -335,7 +335,7 @@ class HashedVoxelPointCloud : public mrpt::maps::CMetricMap,
   /** Returns a short description of the map. */
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   /** Returns true if the map is empty */
   bool isEmpty() const override;

--- a/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/IncrementalPointCloud.h
@@ -260,7 +260,7 @@ class IncrementalPointCloud : public mrpt::maps::CGenericPointsMap,
    *  @{ */
   std::string asString() const override;
   bool        isEmpty() const override;
-  void        getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void        getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
   void        saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const override;
   const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const override;
   /** @} */

--- a/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
+++ b/mola_metric_maps/include/mola_metric_maps/KeyframePointCloudMap.h
@@ -30,7 +30,7 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/maps/NearestNeighborsCapable.h>
 #include <mrpt/math/TBoundingBox.h>
-#include <mrpt/opengl/opengl_frwds.h>
+#include <mrpt/viz/viz_frwds.h>
 
 #include <functional>
 #include <map>
@@ -245,7 +245,7 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
   /** Returns a short description of the map. */
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   /** Returns true if the map is empty */
   bool isEmpty() const override;
@@ -754,11 +754,11 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
      * normal per-field colormap, and the result is NOT cached (used by the per-keyframe
      * debug coloring, see `MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF`).
      */
-    std::shared_ptr<mrpt::opengl::CPointCloudColoured> getViz(
+    std::shared_ptr<mrpt::viz::CPointCloudColoured> getViz(
         const TRenderOptions&                   ro,
         const std::optional<mrpt::img::TColor>& overrideColor = std::nullopt) const;
 
-    std::shared_ptr<mrpt::opengl::CSetOfObjects> getCovarianceEllipsoidViz(
+    std::shared_ptr<mrpt::viz::CSetOfObjects> getCovarianceEllipsoidViz(
         const TRenderOptions& ro) const;
 
    private:
@@ -794,10 +794,10 @@ class KeyframePointCloudMap : public mrpt::maps::CMetricMap,
     mutable mrpt::maps::CPointsMap::Ptr pointcloud_global_;
 
     /** Cached visualization, created/getted by getViz() */
-    mutable std::shared_ptr<mrpt::opengl::CPointCloudColoured> cached_viz_;
+    mutable std::shared_ptr<mrpt::viz::CPointCloudColoured> cached_viz_;
 
     /** Cached cov visualization, created/getted by getCovarianceEllipsoidViz() */
-    mutable std::shared_ptr<mrpt::opengl::CSetOfObjects> cachez_viz_covs_;
+    mutable std::shared_ptr<mrpt::viz::CSetOfObjects> cachez_viz_covs_;
   };
 
   std::map<KeyFrameID, KeyFrame> keyframes_;

--- a/mola_metric_maps/include/mola_metric_maps/NDT.h
+++ b/mola_metric_maps/include/mola_metric_maps/NDT.h
@@ -402,7 +402,7 @@ class NDT : public mrpt::maps::CMetricMap,
   /** Returns a short description of the map. */
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   /** Returns true if the map is empty */
   bool isEmpty() const override;

--- a/mola_metric_maps/include/mola_metric_maps/SparseTreesPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/SparseTreesPointCloud.h
@@ -302,7 +302,7 @@ class SparseTreesPointCloud : public mrpt::maps::CMetricMap,
   /** Returns a short description of the map. */
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   /** Returns true if the map is empty */
   bool isEmpty() const override;

--- a/mola_metric_maps/include/mola_metric_maps/SparseVoxelPointCloud.h
+++ b/mola_metric_maps/include/mola_metric_maps/SparseVoxelPointCloud.h
@@ -379,7 +379,7 @@ class SparseVoxelPointCloud : public mrpt::maps::CMetricMap,
   /** Returns a short description of the map. */
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   /** Returns true if the map is empty */
   bool isEmpty() const override;

--- a/mola_metric_maps/include/mola_metric_maps/TSDF.h
+++ b/mola_metric_maps/include/mola_metric_maps/TSDF.h
@@ -207,7 +207,7 @@ class TSDF : public mrpt::maps::CMetricMap,
 
   std::string asString() const override;
 
-  void getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const override;
+  void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
 
   bool isEmpty() const override;
 

--- a/mola_metric_maps/package.xml
+++ b/mola_metric_maps/package.xml
@@ -17,7 +17,9 @@
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_viz</depend>
+  <build_depend>eigen</build_depend>
   <depend>cli11</depend>
   <depend>mp2p_icp</depend>  <!-- actually, just the mp2p_icp_map library -->
 

--- a/mola_metric_maps/src/HashedVoxelPointCloud.cpp
+++ b/mola_metric_maps/src/HashedVoxelPointCloud.cpp
@@ -26,10 +26,11 @@
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/system/os.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <cmath>
 
@@ -194,7 +195,7 @@ std::string HashedVoxelPointCloud::asString() const
       boundingBox().asString().c_str());
 }
 
-void HashedVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void HashedVoxelPointCloud::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject)
@@ -205,7 +206,7 @@ void HashedVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   if (renderOptions.colormap == mrpt::img::cmNONE)
   {
     // Single color:
-    auto obj = mrpt::opengl::CPointCloud::Create();
+    auto obj = mrpt::viz::CPointCloud::Create();
 
     const auto lambdaVisitPoints = [&obj](const mrpt::math::TPoint3Df& pt)
     { obj->insertPoint(pt); };
@@ -218,7 +219,7 @@ void HashedVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   }
   else
   {
-    auto obj = mrpt::opengl::CPointCloudColoured::Create();
+    auto obj = mrpt::viz::CPointCloudColoured::Create();
 
     auto bb = this->boundingBox();
 

--- a/mola_metric_maps/src/IncrementalPointCloud.cpp
+++ b/mola_metric_maps/src/IncrementalPointCloud.cpp
@@ -25,10 +25,10 @@
 #include <mrpt/core/get_env.h>
 #include <mrpt/core/lock_helper.h>
 #include <mrpt/obs/CObservation.h>
-#include <mrpt/opengl/CSetOfObjects.h>
 #include <mrpt/poses/CPose2D.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <Eigen/Dense>
 #include <algorithm>
@@ -1146,7 +1146,7 @@ void IncrementalPointCloud::nn_search_cov2cov_impl(
 // Visualization / export
 // =====================================
 
-void IncrementalPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void IncrementalPointCloud::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject) return;

--- a/mola_metric_maps/src/KeyframePointCloudMap.cpp
+++ b/mola_metric_maps/src/KeyframePointCloudMap.cpp
@@ -32,16 +32,16 @@
 #include <mrpt/math/matrix_serialization.h>  // CArchive << CMatrixFloat33 (cov baking)
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/customizable_obs_viz.h>
-#include <mrpt/opengl/CEllipsoid3D.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/Scene.h>
-#include <mrpt/opengl/stock_objects.h>
 #include <mrpt/poses/Lie/SO.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/serialization/optional_serialization.h>
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 #include <mrpt/version.h>  // For MRPT_VERSION
+#include <mrpt/viz/CEllipsoid3D.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 #include <Eigen/Eigenvalues>  // SelfAdjointEigenSolver (optional cov diagnostic)
 #include <algorithm>  // std::lower_bound
@@ -186,12 +186,12 @@ const thread_local auto ENV_DEBUG_ACTIVE_KFS =
 // #define DO_VIZ_DEBUG 1
 
 #if DO_VIZ_DEBUG
-#include <mrpt/opengl/CAxis.h>
-#include <mrpt/opengl/CEllipsoid3D.h>
-#include <mrpt/opengl/CGridPlaneXY.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CSetOfLines.h>
-#include <mrpt/opengl/Scene.h>
+#include <mrpt/viz/CAxis.h>
+#include <mrpt/viz/CEllipsoid3D.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CSetOfLines.h>
+#include <mrpt/viz/Scene.h>
 
 #include <fstream>
 #endif
@@ -1593,7 +1593,7 @@ mrpt::img::TColor distinctKfColor(size_t i)
 }
 }  // namespace
 
-void KeyframePointCloudMap::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void KeyframePointCloudMap::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject)
@@ -1649,7 +1649,7 @@ void KeyframePointCloudMap::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
     {
       const float axesLength =
           (ENV_KEYFRAMES_SHOW_ACTIVE_FRAMES && isActiveKF ? 3.0f : 1.0f) * nominalAxesLength;
-      auto glAxes = mrpt::opengl::stock_objects::CornerXYZSimple(axesLength);
+      auto glAxes = mrpt::viz::stock_objects::CornerXYZSimple(axesLength);
       glAxes->setPose(kf.pose());
       outObj.insert(glAxes);
     }
@@ -1714,7 +1714,7 @@ void KeyframePointCloudMap::saveMetricMapRepresentationToFile(
 {
   using namespace std::string_literals;
 
-  mrpt::opengl::Scene scene;
+  mrpt::viz::Scene scene;
   scene.insert(getVisualization());
   scene.saveToFile(filNamePrefix + ".3Dscene"s);
 }
@@ -3040,13 +3040,13 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
 #if DO_VIZ_DEBUG
         if (i % 100 == 0)
         {
-          mrpt::opengl::Scene scene;
+          mrpt::viz::Scene scene;
 
-          scene.insert(mrpt::opengl::CAxis::Create());
-          scene.insert(mrpt::opengl::CGridPlaneXY::Create(-100, 100, -100, 100, 0, 5));
+          scene.insert(mrpt::viz::CAxis::Create());
+          scene.insert(mrpt::viz::CGridPlaneXY::Create(-100, 100, -100, 100, 0, 5));
 
           {
-            auto glPts = mrpt::opengl::CPointCloud::Create();
+            auto glPts = mrpt::viz::CPointCloud::Create();
 
             glPts->loadFromPointsMap(this->pointcloud().get());
             glPts->setPointSize(2.5f);
@@ -3055,7 +3055,7 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
           }
 
           {
-            auto glPts = mrpt::opengl::CPointCloud::Create();
+            auto glPts = mrpt::viz::CPointCloud::Create();
 
             for (size_t j = 0; j < k_indices.size(); j++)
             {
@@ -3067,7 +3067,7 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
           }
 
           {
-            auto glPts = mrpt::opengl::CPointCloud::Create();
+            auto glPts = mrpt::viz::CPointCloud::Create();
 
             glPts->insertPoint(xs[i], ys[i], zs[i]);
 
@@ -3077,7 +3077,7 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
           }
 
           {
-            auto glElli = mrpt::opengl::CEllipsoid3D::Create();
+            auto glElli = mrpt::viz::CEllipsoid3D::Create();
             glElli->setLocation(xs[i], ys[i], zs[i]);
             glElli->enableDrawSolid3D(false);
             glElli->setCovMatrix(cached_cov_local_[i] * 0.05);
@@ -3086,7 +3086,7 @@ void KeyframePointCloudMap::KeyFrame::computeCovariancesAndDensity() const
           }
 
           {
-            auto glEigs = mrpt::opengl::CSetOfLines::Create();
+            auto glEigs = mrpt::viz::CSetOfLines::Create();
             glEigs->setColor_u8(0x00, 0x00, 0x00, 0xff);
 
             const auto c = mrpt::math::TPoint3Df(xs[i], ys[i], zs[i]).cast<double>();
@@ -3151,7 +3151,7 @@ void KeyframePointCloudMap::KeyFrame::updateCovariancesGlobal() const
   }
 }
 
-std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFrame::getViz(
+std::shared_ptr<mrpt::viz::CPointCloudColoured> KeyframePointCloudMap::KeyFrame::getViz(
     const TRenderOptions& ro, const std::optional<mrpt::img::TColor>& overrideColor) const
 {
   // The cache only holds the normal (non-overridden) visualization.
@@ -3161,7 +3161,7 @@ std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFra
   }
 
   const uint8_t alpha_u8 = mrpt::f2u8(ro.color.A);
-  auto          obj      = mrpt::opengl::CPointCloudColoured::Create();
+  auto          obj      = mrpt::viz::CPointCloudColoured::Create();
 
   obj->loadFromPointsMap(pointcloud().get());
 
@@ -3196,7 +3196,7 @@ std::shared_ptr<mrpt::opengl::CPointCloudColoured> KeyframePointCloudMap::KeyFra
   return cached_viz_;
 }
 
-std::shared_ptr<mrpt::opengl::CSetOfObjects>
+std::shared_ptr<mrpt::viz::CSetOfObjects>
     KeyframePointCloudMap::KeyFrame::getCovarianceEllipsoidViz(const TRenderOptions& ro) const
 {
   buildCache();
@@ -3219,7 +3219,7 @@ std::shared_ptr<mrpt::opengl::CSetOfObjects>
     cov_decimation = 1;
   }
 
-  auto obj = mrpt::opengl::CSetOfObjects::Create();
+  auto obj = mrpt::viz::CSetOfObjects::Create();
 
   ASSERT_(pointcloud_global_);
   ASSERT_EQUAL_(cached_cov_global_.size(), pointcloud_global_->size());
@@ -3236,7 +3236,7 @@ std::shared_ptr<mrpt::opengl::CSetOfObjects>
 
     const auto& cov = cached_cov_global_[i];
 
-    auto elli = mrpt::opengl::CEllipsoid3D::Create();
+    auto elli = mrpt::viz::CEllipsoid3D::Create();
     elli->setLocation(xs[i], ys[i], zs[i]);
     elli->enableDrawSolid3D(false);
     elli->setCovMatrix(cov * 0.05);

--- a/mola_metric_maps/src/NDT.cpp
+++ b/mola_metric_maps/src/NDT.cpp
@@ -32,12 +32,13 @@
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/CSetOfLines.h>
-#include <mrpt/opengl/CSetOfTriangles.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/system/os.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfLines.h>
+#include <mrpt/viz/CSetOfObjects.h>
+#include <mrpt/viz/CSetOfTriangles.h>
 
 #include <cmath>
 
@@ -207,7 +208,7 @@ std::string NDT::asString() const
       "NDT, resolution=%.03f bbox=%s", voxel_size_, boundingBox().asString().c_str());
 }
 
-void NDT::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void NDT::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject)
@@ -282,7 +283,7 @@ void NDT::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
   // points:
   if (renderOptions.points_visible)
   {
-    auto obj = mrpt::opengl::CPointCloudColoured::Create();
+    auto obj = mrpt::viz::CPointCloudColoured::Create();
 
     const auto lambdaVisitPoints = [&obj](const mrpt::math::TPoint3Df& pt) {
       obj->insertPoint({pt.x, pt.y, pt.z, 0, 0, 0});
@@ -321,7 +322,7 @@ void NDT::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
   // planes:
   if (renderOptions.planes_visible)
   {
-    auto obj = mrpt::opengl::CSetOfTriangles::Create();
+    auto obj = mrpt::viz::CSetOfTriangles::Create();
 
     const auto lambdaVisitVoxel =
         [&obj, recolorK, recolorMin, recolorIdx, this](
@@ -348,7 +349,7 @@ void NDT::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
       const auto  vx = ndt->eigVectors.at(1).cast<float>() * s;
       const auto  vy = ndt->eigVectors.at(2).cast<float>() * s;
 
-      mrpt::opengl::TTriangle t;
+      mrpt::viz::TTriangle t;
 
       if (renderOptions.planes_colormap == mrpt::img::cmNONE)
       {
@@ -380,7 +381,7 @@ void NDT::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
   // normals:
   if (renderOptions.normals_visible)
   {
-    auto obj = mrpt::opengl::CSetOfLines::Create();
+    auto obj = mrpt::viz::CSetOfLines::Create();
 
     const auto lambdaVisitVoxel =
         [&obj, this]([[maybe_unused]] const global_index3d_t& idx, const VoxelData& v)

--- a/mola_metric_maps/src/SparseTreesPointCloud.cpp
+++ b/mola_metric_maps/src/SparseTreesPointCloud.cpp
@@ -26,10 +26,12 @@
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/system/os.h>
+#include <mrpt/viz/CBox.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <cmath>
 
@@ -179,7 +181,7 @@ std::string SparseTreesPointCloud::asString() const
       boundingBox().asString().c_str());
 }
 
-void SparseTreesPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void SparseTreesPointCloud::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject)
@@ -193,7 +195,7 @@ void SparseTreesPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   if (renderOptions.colormap == mrpt::img::cmNONE)
   {
     // Single color:
-    auto obj = mrpt::opengl::CPointCloud::Create();
+    auto obj = mrpt::viz::CPointCloud::Create();
 
     const auto lambdaVisitPoints = [&obj](const mrpt::math::TPoint3Df& pt)
     { obj->insertPoint(pt); };
@@ -206,7 +208,7 @@ void SparseTreesPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   }
   else
   {
-    auto obj = mrpt::opengl::CPointCloudColoured::Create();
+    auto obj = mrpt::viz::CPointCloudColoured::Create();
 
     auto bb = this->boundingBox();
 
@@ -276,7 +278,7 @@ void SparseTreesPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
     {
       const mrpt::math::TPoint3Df gridCenter = outerIdxToCoord(idxs);
 
-      auto glBox = mrpt::opengl::CBox::Create();
+      auto glBox = mrpt::viz::CBox::Create();
       glBox->setWireframe(true);
       const auto org = gridCenter.cast<double>();
       glBox->setBoxCorners(org, org + gridVector_);

--- a/mola_metric_maps/src/SparseVoxelPointCloud.cpp
+++ b/mola_metric_maps/src/SparseVoxelPointCloud.cpp
@@ -26,10 +26,12 @@
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/serialization/CArchive.h>  // serialization
 #include <mrpt/system/os.h>
+#include <mrpt/viz/CBox.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <cmath>
 
@@ -220,7 +222,7 @@ std::string SparseVoxelPointCloud::asString() const
       boundingBox().asString().c_str());
 }
 
-void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void SparseVoxelPointCloud::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
   MRPT_START
   if (!genericMapParams.enableSaveAs3DObject)
@@ -231,7 +233,7 @@ void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   if (renderOptions.colormap == mrpt::img::cmNONE)
   {
     // Single color:
-    auto obj = mrpt::opengl::CPointCloud::Create();
+    auto obj = mrpt::viz::CPointCloud::Create();
 
     if (renderOptions.show_mean_only)
     {
@@ -258,7 +260,7 @@ void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
   }
   else
   {
-    auto obj = mrpt::opengl::CPointCloudColoured::Create();
+    auto obj = mrpt::viz::CPointCloudColoured::Create();
 
     auto bb = this->boundingBox();
 
@@ -339,7 +341,7 @@ void SparseVoxelPointCloud::getVisualizationInto(mrpt::opengl::CSetOfObjects& ou
     {
       const mrpt::math::TPoint3Df voxelCenter = globalIdxToCoord(idxs);
 
-      auto glBox = mrpt::opengl::CBox::Create();
+      auto glBox = mrpt::viz::CBox::Create();
       glBox->setWireframe(true);
       glBox->setBoxCorners(
           (voxelCenter - halfVoxel_).cast<double>(),

--- a/mola_metric_maps/src/TSDF.cpp
+++ b/mola_metric_maps/src/TSDF.cpp
@@ -34,9 +34,10 @@
 #include <mrpt/obs/CObservation3DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/CPointCloud.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/os.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <algorithm>
 #include <cmath>
@@ -948,9 +949,9 @@ const mrpt::maps::CSimplePointsMap* TSDF::getAsSimplePointsMap() const
   return cachedPoints_.get();
 }
 
-void TSDF::getVisualizationInto(mrpt::opengl::CSetOfObjects& outObj) const
+void TSDF::getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const
 {
-  auto pts = mrpt::opengl::CPointCloud::Create();
+  auto pts = mrpt::viz::CPointCloud::Create();
   pts->setPointSize(renderOptions.point_size);
   pts->setColor(renderOptions.points_color);
 

--- a/mola_metric_maps/tests/test-mola_metric_maps_hashedvoxels.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_hashedvoxels.cpp
@@ -20,7 +20,7 @@
 #include <mola_metric_maps/HashedVoxelPointCloud.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/stock_observations.h>
-#include <mrpt/opengl/Scene.h>
+#include <mrpt/viz/Scene.h>
 
 #include <iostream>
 
@@ -42,7 +42,7 @@ void test_voxelmap_insert_2d_scan()
 
   map.insertObservation(scan2D);
 #if 0
-    mrpt::opengl::Scene scene;
+    mrpt::viz::Scene scene;
     map.renderOptions.point_size = 5.0f;
     scene.insert(map.getVisualization());
     scene.saveToFile("sparsevoxelmap_scan2d.3Dscene");

--- a/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_keyframemap.cpp
@@ -23,10 +23,10 @@
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationPointCloud.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/CSetOfObjects.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
 
 #include <algorithm>
 #include <cmath>
@@ -793,8 +793,9 @@ void test_kf_pose_plumbing()
     const auto next = m.nextFreeKeyFrameID_public();
     ASSERT_EQUAL_(next, static_cast<KFID>(i));
     m.insertObservation(*obs, seedPoses[i]);
-    ASSERT_(m.lastInsertedKeyFrameID().has_value());
-    ASSERT_EQUAL_(*m.lastInsertedKeyFrameID(), static_cast<KFID>(i));
+    const auto lastId = m.lastInsertedKeyFrameID();
+    ASSERT_(lastId.has_value());
+    ASSERT_EQUAL_(*lastId, static_cast<KFID>(i));
   }
 
   // keyframePoses returns a snapshot keyed by id.
@@ -837,8 +838,9 @@ void test_kf_pose_plumbing()
   const auto poseNear = CPose3D::FromXYZYawPitchRoll(5.0, 0.0, 0.0, 0.0_deg, 0.0_deg, 0.0_deg);
   m.insertObservation(*obs, poseNear);
 
-  ASSERT_(m.lastInsertedKeyFrameID().has_value());
-  ASSERT_EQUAL_(*m.lastInsertedKeyFrameID(), KFID{3});
+  const auto lastIdAfterEviction = m.lastInsertedKeyFrameID();
+  ASSERT_(lastIdAfterEviction.has_value());
+  ASSERT_EQUAL_(*lastIdAfterEviction, KFID{3});
 
   // drainEvictedKeyFrameIDs returns the ids of KFs dropped during the
   // last insertion(s), then clears its internal list.
@@ -1192,7 +1194,7 @@ void test_viz_color_by_kf()
   size_t             cloudObjs = 0;
   for (const auto& child : *glObj)
   {
-    auto pc = std::dynamic_pointer_cast<mrpt::opengl::CPointCloudColoured>(child);
+    auto pc = std::dynamic_pointer_cast<mrpt::viz::CPointCloudColoured>(child);
     if (!pc || pc->size() == 0)
     {
       continue;

--- a/mola_metric_maps/tests/test-mola_metric_maps_ndt.cpp
+++ b/mola_metric_maps/tests/test-mola_metric_maps_ndt.cpp
@@ -21,7 +21,7 @@
 #include <mrpt/core/get_env.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/stock_observations.h>
-#include <mrpt/opengl/Scene.h>
+#include <mrpt/viz/Scene.h>
 
 #include <iostream>
 
@@ -47,7 +47,7 @@ void test_voxelmap_insert_2d_scan()
 
   if (mrpt::get_env<bool>("TEST_GENERATE_3D_SCENES"))
   {
-    mrpt::opengl::Scene scene;
+    mrpt::viz::Scene scene;
     map.renderOptions.point_size = 5.0f;
     scene.insert(map.getVisualization());
     scene.saveToFile("sparsevoxelmap_scan2d.3Dscene");

--- a/mola_metric_maps/tests/test-sparsevoxelpointcloud.cpp
+++ b/mola_metric_maps/tests/test-sparsevoxelpointcloud.cpp
@@ -20,7 +20,7 @@
 #include <mola_metric_maps/SparseVoxelPointCloud.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/stock_observations.h>
-#include <mrpt/opengl/Scene.h>
+#include <mrpt/viz/Scene.h>
 
 #include <iostream>
 
@@ -45,7 +45,7 @@ void test_voxelmap_insert_2d_scan()
 
   map.insertObservation(scan2D);
 #if 0
-    mrpt::opengl::Scene scene;
+    mrpt::viz::Scene scene;
     map.renderOptions.show_inner_grid_boxes = true;
     map.renderOptions.show_mean_only        = true;
     map.renderOptions.point_size            = 5.0f;

--- a/mola_pose_list/CMakeLists.txt
+++ b/mola_pose_list/CMakeLists.txt
@@ -17,8 +17,8 @@ project(mola_pose_list LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
-find_package(mrpt-maps)
-find_package(mrpt-poses)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_poses REQUIRED)
 
 # -----------------------
 # define lib:
@@ -29,12 +29,12 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::maps
-    mrpt::poses
+    mrpt::mrpt_maps
+    mrpt::mrpt_poses
   CMAKE_DEPENDENCIES
     mola_common
-    mrpt-maps
-    mrpt-poses
+    mrpt_maps
+    mrpt_poses
 )
 
 # -----------------------

--- a/mola_pose_list/package.xml
+++ b/mola_pose_list/package.xml
@@ -16,8 +16,8 @@
 
   <depend>mola_common</depend>
 
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libposes</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_poses</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_relocalization/CMakeLists.txt
+++ b/mola_relocalization/CMakeLists.txt
@@ -17,9 +17,9 @@ project(mola_relocalization LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
-find_package(mrpt-obs REQUIRED)
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-slam REQUIRED)
+find_package(mrpt_obs REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_slam REQUIRED)
 find_package(mp2p_icp REQUIRED)
 find_package(mola_pose_list REQUIRED)
 
@@ -35,9 +35,9 @@ mola_add_library(
     src/RelocalizationLikelihood_SE2.cpp
     include/mola_relocalization/relocalization.h
   PUBLIC_LINK_LIBRARIES
-    mrpt::obs
-    mrpt::maps
-    mrpt::slam
+    mrpt::mrpt_obs
+    mrpt::mrpt_maps
+    mrpt::mrpt_slam
     mola::mp2p_icp
     mola::mola_pose_list
 #  PRIVATE_LINK_LIBRARIES
@@ -46,7 +46,7 @@ mola_add_library(
     mola_common
     mp2p_icp
     mola_pose_list
-    mrpt-slam
+    mrpt_slam
 )
 
 # -----------------------

--- a/mola_relocalization/package.xml
+++ b/mola_relocalization/package.xml
@@ -18,9 +18,9 @@
   <depend>mp2p_icp</depend>
   <depend>mola_pose_list</depend>
 
-  <depend>mrpt_libobs</depend>
-  <depend>mrpt_libslam</depend>
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_slam</depend>
+  <depend>mrpt_maps</depend>
 
   <test_depend>mola_test_datasets</test_depend>
 

--- a/mola_traj_tools/CMakeLists.txt
+++ b/mola_traj_tools/CMakeLists.txt
@@ -17,7 +17,7 @@ project(mola_traj_tools LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find dependencies:
-find_package(mrpt-poses)
+find_package(mrpt_poses REQUIRED)
 
 # ----------------------
 # define app targets:
@@ -26,35 +26,35 @@ mola_add_executable(
   TARGET  traj_ypr2tum
   SOURCES src/traj_ypr2tum.cpp
   LINK_LIBRARIES
-    mrpt::poses
+    mrpt::mrpt_poses
 )
 
 mola_add_executable(
   TARGET  traj_tum2ypr
   SOURCES src/traj_tum2ypr.cpp
   LINK_LIBRARIES
-    mrpt::poses
+    mrpt::mrpt_poses
 )
 
 mola_add_executable(
   TARGET  traj_tf_left
   SOURCES src/traj_tf_left.cpp
   LINK_LIBRARIES
-    mrpt::poses
+    mrpt::mrpt_poses
 )
 
 mola_add_executable(
   TARGET  traj_tf_right
   SOURCES src/traj_tf_right.cpp
   LINK_LIBRARIES
-    mrpt::poses
+    mrpt::mrpt_poses
 )
 
 mola_add_executable(
   TARGET  traj_rebase
   SOURCES src/traj_rebase.cpp
   LINK_LIBRARIES
-    mrpt::poses
+    mrpt::mrpt_poses
 )
 
 # Install "executables" too:

--- a/mola_traj_tools/package.xml
+++ b/mola_traj_tools/package.xml
@@ -16,7 +16,7 @@
 
   <depend>mola_common</depend>
 
-  <depend>mrpt_libposes</depend>
+  <depend>mrpt_poses</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_viz/CMakeLists.txt
+++ b/mola_viz/CMakeLists.txt
@@ -16,9 +16,10 @@ project(mola_viz LANGUAGES CXX)
 # MOLA CMake scripts: "mola_xxx()"
 find_package(mola_common REQUIRED)
 # find dependencies:
-find_package(mrpt-gui REQUIRED)
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-opengl REQUIRED)
+find_package(mrpt_gui REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_opengl REQUIRED)
+find_package(mrpt_viz REQUIRED)
 find_mola_package(mola_kernel)
 
 # -----------------------
@@ -31,11 +32,13 @@ mola_add_library(
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::gui
-    mrpt::opengl
-    mrpt::maps
+    mrpt::mrpt_gui
+    mrpt::mrpt_opengl
+    mrpt::mrpt_maps
+    mrpt::mrpt_viz
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-gui
-    mrpt-opengl
+    mrpt_gui
+    mrpt_opengl
+    mrpt_viz
 )

--- a/mola_viz/include/mola_viz/MolaViz.h
+++ b/mola_viz/include/mola_viz/MolaViz.h
@@ -118,7 +118,7 @@ class MolaViz : public ExecutableBase, public VizInterface
    * @{ */
 
   std::future<bool> update_3d_object(
-      const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+      const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override;
@@ -129,7 +129,7 @@ class MolaViz : public ExecutableBase, public VizInterface
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> insert_point_cloud_with_decay(
-      const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
+      const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override;
@@ -153,8 +153,8 @@ class MolaViz : public ExecutableBase, public VizInterface
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> execute_custom_code_on_background_scene(
-      const std::function<void(mrpt::opengl::Scene&)>& userCode,
-      const std::string&                               parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::function<void(mrpt::viz::Scene&)>& userCode,
+      const std::string&                            parentWindow = DEFAULT_WINDOW_NAME) override;
 
   /** @} */
 
@@ -228,18 +228,18 @@ class MolaViz : public ExecutableBase, public VizInterface
   {
     DecayingCloud() = default;
     DecayingCloud(
-        std::string                                               opengl_viewport_name_,
-        const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud_, float initial_alpha_)
+        std::string                                            opengl_viewport_name_,
+        const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud_, float initial_alpha_)
         : opengl_viewport_name(std::move(opengl_viewport_name_)),
           cloud(cloud_),
           initial_alpha(initial_alpha_)
     {
     }
 
-    std::string                                        opengl_viewport_name;
-    std::shared_ptr<mrpt::opengl::CPointCloudColoured> cloud;
-    mrpt::opengl::CSetOfObjects::Ptr container;  // owning container at insert time
-    float                            initial_alpha = 1.0f;
+    std::string                                     opengl_viewport_name;
+    std::shared_ptr<mrpt::viz::CPointCloudColoured> cloud;
+    mrpt::viz::CSetOfObjects::Ptr                   container;  // owning container at insert time
+    float                                           initial_alpha = 1.0f;
   };
 
   struct PerWindowData
@@ -257,8 +257,8 @@ class MolaViz : public ExecutableBase, public VizInterface
 
   /** Get-or-create a movable reference-frame node (a named CSetOfObjects at
    *  the viewport root). GUI-thread only. \sa update_3d_object_frame() */
-  static std::shared_ptr<mrpt::opengl::CSetOfObjects> get_or_create_frame_node_(
-      mrpt::opengl::Scene& scene, const std::string& frameName, const std::string& viewportName);
+  static std::shared_ptr<mrpt::viz::CSetOfObjects> get_or_create_frame_node_(
+      mrpt::viz::Scene& scene, const std::string& frameName, const std::string& viewportName);
 
   mutable std::shared_mutex subWindowsMtx_;
 

--- a/mola_viz/package.xml
+++ b/mola_viz/package.xml
@@ -16,9 +16,10 @@
 
   <depend>mola_kernel</depend>
 
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libgui</depend>
-  <depend>mrpt_libopengl</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_gui</depend>
+  <depend>mrpt_opengl</depend>
+  <depend>mrpt_viz</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_viz/src/MolaViz.cpp
+++ b/mola_viz/src/MolaViz.cpp
@@ -36,11 +36,13 @@
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/stock_objects.h>
 #include <mrpt/system/thread_name.h>
 #include <mrpt/version.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/opengl_fonts.h>
+#include <mrpt/viz/stock_objects.h>
 
 #include <array>
 #include <cinttypes>
@@ -142,7 +144,7 @@ void gui_handler_show_common_sensor_info(
   constexpr unsigned int TXT_ID_SENSOR_POSE = 2;
   constexpr unsigned int TXT_ID_ADDITIONALS = 3;
 
-  mrpt::opengl::TFontParams fp;
+  mrpt::viz::TFontParams fp;
   fp.color        = {1.0f, 1.0f, 1.0f};
   fp.draw_shadow  = true;
   fp.shadow_color = {0.0f, 0.0f, 0.0f};
@@ -156,8 +158,7 @@ void gui_handler_show_common_sensor_info(
       mrpt::format("Timestamp: %s", mrpt::system::dateTimeToString(obs.timestamp).c_str()),
       TXT_ID_TIMESTAMP, fp);
 
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const auto sensorPose = obs.getSensorPose();
 
   glView->addTextMessage(
       2, line_y(TXT_ID_SENSOR_POSE), mrpt::format("Sensor pose: %s", sensorPose.asString().c_str()),
@@ -238,7 +239,7 @@ void gui_handler_images(
     glControl->setFixedSize({winW, winH});
 
     auto lck         = mrpt::lockHelper(glControl->scene_mtx);
-    glControl->scene = mrpt::opengl::COpenGLScene::Create();
+    glControl->scene = mrpt::viz::Scene::Create();
     instance->markWindowForReLayout(parentWin);
   }
   else
@@ -258,7 +259,7 @@ void gui_handler_images(
 
   const auto imgW        = static_cast<int>(imgToShow.getWidth());
   const auto imgH        = static_cast<int>(imgToShow.getHeight());
-  const int  imgChannels = imgToShow.channelCount();
+  const int  imgChannels = static_cast<int>(imgToShow.channels());
 
   auto lck = mrpt::lockHelper(glControl->scene_mtx);
   glControl->scene->getViewport()->setImageView(imgToShow);
@@ -272,9 +273,9 @@ void gui_handler_images(
 struct PointCloudGLObjects
 {
   mrpt::gui::MRPT2NanoguiGLCanvas*            glControl = nullptr;
-  mrpt::opengl::CPointCloudColoured::Ptr      glPc;
-  mrpt::opengl::CSetOfObjects::Ptr            glCornerRef;
-  mrpt::opengl::CSetOfObjects::Ptr            glCornerSensor;
+  mrpt::viz::CPointCloudColoured::Ptr         glPc;
+  mrpt::viz::CSetOfObjects::Ptr               glCornerRef;
+  mrpt::viz::CSetOfObjects::Ptr               glCornerSensor;
   std::optional<mrpt::LockHelper<std::mutex>> lck;
 };
 
@@ -288,11 +289,11 @@ PointCloudGLObjects setup_or_reuse_point_cloud_gl(
   {
     gl.glControl = w->add<mrpt::gui::MRPT2NanoguiGLCanvas>();
     gl.lck.emplace(&gl.glControl->scene_mtx);
-    gl.glControl->scene = mrpt::opengl::COpenGLScene::Create();
-    gl.glPc             = mrpt::opengl::CPointCloudColoured::Create();
+    gl.glControl->scene = mrpt::viz::Scene::Create();
+    gl.glPc             = mrpt::viz::CPointCloudColoured::Create();
     gl.glControl->scene->insert(gl.glPc);
-    gl.glCornerRef    = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-    gl.glCornerSensor = mrpt::opengl::stock_objects::CornerXYZ(0.5f);
+    gl.glCornerRef    = mrpt::viz::stock_objects::CornerXYZ(1.0f);
+    gl.glCornerSensor = mrpt::viz::stock_objects::CornerXYZ(0.5f);
     gl.glControl->scene->insert(gl.glCornerRef);
     gl.glControl->scene->insert(gl.glCornerSensor);
     gl.glPc->setPointSize(point_size);
@@ -302,9 +303,9 @@ PointCloudGLObjects setup_or_reuse_point_cloud_gl(
   {
     gl.glControl = dynamic_cast<mrpt::gui::MRPT2NanoguiGLCanvas*>(w->children().at(1));
     gl.lck.emplace(&gl.glControl->scene_mtx);
-    gl.glPc           = gl.glControl->scene->getByClass<mrpt::opengl::CPointCloudColoured>();
-    gl.glCornerRef    = gl.glControl->scene->getByClass<mrpt::opengl::CSetOfObjects>(0);
-    gl.glCornerSensor = gl.glControl->scene->getByClass<mrpt::opengl::CSetOfObjects>(1);
+    gl.glPc           = gl.glControl->scene->getByClass<mrpt::viz::CPointCloudColoured>();
+    gl.glCornerRef    = gl.glControl->scene->getByClass<mrpt::viz::CSetOfObjects>(0);
+    gl.glCornerSensor = gl.glControl->scene->getByClass<mrpt::viz::CSetOfObjects>(1);
   }
   ASSERT_(gl.glControl != nullptr);
   ASSERT_(gl.glPc);
@@ -315,8 +316,8 @@ PointCloudGLObjects setup_or_reuse_point_cloud_gl(
 }
 
 bool populate_from_observation_point_cloud(
-    const mrpt::obs::CObservationPointCloud&      objPc,
-    const mrpt::opengl::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
+    const mrpt::obs::CObservationPointCloud& objPc, const mrpt::viz::CPointCloudColoured::Ptr& glPc,
+    nanogui::Window* w, double sensorDecimation)
 {
   auto& objPcMut = const_cast<mrpt::obs::CObservationPointCloud&>(objPc);
   objPcMut.load();
@@ -378,8 +379,8 @@ bool populate_from_observation_point_cloud(
 }
 
 void populate_from_rotating_scan(
-    const mrpt::obs::CObservationRotatingScan&    objRS,
-    const mrpt::opengl::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
+    const mrpt::obs::CObservationRotatingScan& objRS,
+    const mrpt::viz::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
 {
   auto& objRSMut = const_cast<mrpt::obs::CObservationRotatingScan&>(objRS);
   objRSMut.load();
@@ -405,8 +406,8 @@ void populate_from_rotating_scan(
 }
 
 void populate_from_3d_range_scan(
-    const mrpt::obs::CObservation3DRangeScan&     obj3D,
-    const mrpt::opengl::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation,
+    const mrpt::obs::CObservation3DRangeScan&  obj3D,
+    const mrpt::viz::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation,
     bool& color_from_z)
 {
   if (obj3D.hasPoints3D)
@@ -446,8 +447,8 @@ void populate_from_3d_range_scan(
 }
 
 void populate_from_2d_range_scan(
-    const mrpt::obs::CObservation2DRangeScan&     obj2D,
-    const mrpt::opengl::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
+    const mrpt::obs::CObservation2DRangeScan&  obj2D,
+    const mrpt::viz::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
 {
   mrpt::maps::CSimplePointsMap auxMap;
   auxMap.insertObservationPtr(std::make_shared<mrpt::obs::CObservation2DRangeScan>(obj2D));
@@ -456,8 +457,8 @@ void populate_from_2d_range_scan(
 }
 
 bool populate_from_velodyne_scan(
-    const mrpt::obs::CObservationVelodyneScan&    objVel,
-    const mrpt::opengl::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
+    const mrpt::obs::CObservationVelodyneScan& objVel,
+    const mrpt::viz::CPointCloudColoured::Ptr& glPc, nanogui::Window* w, double sensorDecimation)
 {
   if (objVel.point_cloud.size() == 0)
   {
@@ -511,9 +512,7 @@ void gui_handler_point_cloud(
 
   if (auto obs = std::dynamic_pointer_cast<CObservation>(o); obs)
   {
-    mrpt::poses::CPose3D p;
-    obs->getSensorPose(p);
-    gl.glCornerSensor->setPose(p);
+    gl.glCornerSensor->setPose(obs->getSensorPose());
   }
 
   if (auto objPc = std::dynamic_pointer_cast<CObservationPointCloud>(o); objPc)
@@ -642,7 +641,7 @@ void gui_handler_imu(
         nanogui::Orientation::Horizontal, 1, nanogui::Alignment::Fill, 2, 2));
     glControl = w->add<mrpt::gui::MRPT2NanoguiGLCanvas>();
     lck.emplace(&glControl->scene_mtx);
-    glControl->scene = mrpt::opengl::COpenGLScene::Create();
+    glControl->scene = mrpt::viz::Scene::Create();
     const int winW   = 400;
     const int winH   = 125;
     glControl->setSize({winW, winH});
@@ -1205,7 +1204,7 @@ mrpt::gui::CDisplayWindowGUI::Ptr MolaViz::create_and_add_window(const window_na
 
   win->setIconFromData(mola_icon_data, mola_icon_width, mola_icon_height, 0xff);
 
-  auto scene = mrpt::opengl::COpenGLScene::Create();
+  auto scene = mrpt::viz::Scene::Create();
   {
     std::lock_guard<std::mutex> lck(win->background_scene_mtx);
     win->background_scene = std::move(scene);
@@ -1607,7 +1606,7 @@ std::future<bool> MolaViz::subwindow_update_visualization(
 // ---------------------------------------------------------------------------
 
 std::future<bool> MolaViz::update_3d_object(
-    const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+    const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
     const std::string& viewportName, const std::string& parentWindow,
     const std::string& parentFrame)
 {
@@ -1623,8 +1622,8 @@ std::future<bool> MolaViz::update_3d_object(
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
 
-        mrpt::opengl::CSetOfObjects::Ptr glContainer;
-        auto&                            scene = *topWin->background_scene;
+        mrpt::viz::CSetOfObjects::Ptr glContainer;
+        auto&                         scene = *topWin->background_scene;
         if (parentFrame.empty())
         {
           // Non-recursive search: only direct children of the viewport root,
@@ -1635,7 +1634,7 @@ std::future<bool> MolaViz::update_3d_object(
             {
               if (o->getName() == objName)
               {
-                glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+                glContainer = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
                 break;
               }
             }
@@ -1648,7 +1647,7 @@ std::future<bool> MolaViz::update_3d_object(
             {
               scene.removeObject(o, viewportName);
             }
-            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            glContainer = mrpt::viz::CSetOfObjects::Create();
             scene.insert(glContainer, viewportName);
           }
         }
@@ -1659,7 +1658,7 @@ std::future<bool> MolaViz::update_3d_object(
           auto frameNode = get_or_create_frame_node_(scene, parentFrame, viewportName);
           if (auto o = frameNode->getByName(objName); o)
           {
-            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            glContainer = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
           }
           if (!glContainer)
           {
@@ -1669,7 +1668,7 @@ std::future<bool> MolaViz::update_3d_object(
             {
               scene.removeObject(o, viewportName);
             }
-            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            glContainer = mrpt::viz::CSetOfObjects::Create();
             frameNode->insert(glContainer);
           }
         }
@@ -1685,19 +1684,19 @@ std::future<bool> MolaViz::update_3d_object(
   return task->get_future();
 }
 
-mrpt::opengl::CSetOfObjects::Ptr MolaViz::get_or_create_frame_node_(
-    mrpt::opengl::Scene& scene, const std::string& frameName, const std::string& viewportName)
+mrpt::viz::CSetOfObjects::Ptr MolaViz::get_or_create_frame_node_(
+    mrpt::viz::Scene& scene, const std::string& frameName, const std::string& viewportName)
 {
   // Called from the GUI thread only.
-  mrpt::opengl::CSetOfObjects::Ptr frameNode;
+  mrpt::viz::CSetOfObjects::Ptr frameNode;
   if (auto o = scene.getByName(frameName, viewportName); o)
   {
-    frameNode = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+    frameNode = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
     ASSERT_(frameNode);
   }
   else
   {
-    frameNode = mrpt::opengl::CSetOfObjects::Create();
+    frameNode = mrpt::viz::CSetOfObjects::Create();
     frameNode->setName(frameName);
     scene.insert(frameNode, viewportName);
   }
@@ -1732,9 +1731,9 @@ std::future<bool> MolaViz::update_3d_object_frame(
 }
 
 std::future<bool> MolaViz::insert_point_cloud_with_decay(
-    const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud,
-    const double decay_time_seconds, const std::string& viewportName,
-    const std::string& parentWindow, const std::string& parentFrame)
+    const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, const double decay_time_seconds,
+    const std::string& viewportName, const std::string& parentWindow,
+    const std::string& parentFrame)
 {
   using return_type = bool;
 
@@ -1752,17 +1751,17 @@ std::future<bool> MolaViz::insert_point_cloud_with_decay(
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
 
-        mrpt::opengl::CSetOfObjects::Ptr glContainer;
+        mrpt::viz::CSetOfObjects::Ptr glContainer;
         if (parentFrame.empty())
         {
           if (auto o = topWin->background_scene->getByName(DECAY_CLOUDS_NAME, viewportName); o)
           {
-            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            glContainer = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
             ASSERT_(glContainer);
           }
           else
           {
-            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            glContainer = mrpt::viz::CSetOfObjects::Create();
             topWin->background_scene->insert(glContainer, viewportName);
             glContainer->setName(DECAY_CLOUDS_NAME);
           }
@@ -1773,12 +1772,12 @@ std::future<bool> MolaViz::insert_point_cloud_with_decay(
               get_or_create_frame_node_(*topWin->background_scene, parentFrame, viewportName);
           if (auto o = frameNode->getByName(DECAY_CLOUDS_NAME); o)
           {
-            glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            glContainer = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
             ASSERT_(glContainer);
           }
           else
           {
-            glContainer = mrpt::opengl::CSetOfObjects::Create();
+            glContainer = mrpt::viz::CSetOfObjects::Create();
             glContainer->setName(DECAY_CLOUDS_NAME);
             frameNode->insert(glContainer);
           }
@@ -1825,15 +1824,15 @@ std::future<bool> MolaViz::clear_all_point_clouds_with_decay(
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
 
-        mrpt::opengl::CSetOfObjects::Ptr glContainer;
+        mrpt::viz::CSetOfObjects::Ptr glContainer;
         if (auto o = topWin->background_scene->getByName(DECAY_CLOUDS_NAME, viewportName); o)
         {
-          glContainer = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+          glContainer = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
           ASSERT_(glContainer);
         }
         else
         {
-          glContainer = mrpt::opengl::CSetOfObjects::Create();
+          glContainer = mrpt::viz::CSetOfObjects::Create();
           topWin->background_scene->insert(glContainer, viewportName);
           glContainer->setName(DECAY_CLOUDS_NAME);
         }
@@ -1943,7 +1942,7 @@ std::future<bool> MolaViz::update_viewport_camera_orthographic(
         auto topWin = windows_.at(parentWindow).win;
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
-        topWin->camera().setCameraProjective(!orthographic);
+        topWin->camera().setProjectiveModel(!orthographic);
         return true;
       });
 
@@ -1954,7 +1953,7 @@ std::future<bool> MolaViz::update_viewport_camera_orthographic(
 }
 
 std::future<bool> MolaViz::execute_custom_code_on_background_scene(
-    const std::function<void(mrpt::opengl::Scene&)>& userCode, const std::string& parentWindow)
+    const std::function<void(mrpt::viz::Scene&)>& userCode, const std::string& parentWindow)
 {
   using return_type = bool;
 
@@ -2015,9 +2014,9 @@ std::future<bool> MolaViz::output_console_message(
         ASSERT_(topWin);
         ASSERT_(topWin->background_scene);
 
-        const double              LINE_HEIGHT  = console_text_font_size_;
-        const double              LINE_SPACING = 3.0;
-        mrpt::opengl::TFontParams fp;
+        const double           LINE_HEIGHT  = console_text_font_size_;
+        const double           LINE_SPACING = 3.0;
+        mrpt::viz::TFontParams fp;
         fp.vfont_scale = static_cast<float>(LINE_HEIGHT);
 
         for (size_t i = 0; i < winData.console_messages.size(); i++)

--- a/mola_viz_imgui/CMakeLists.txt
+++ b/mola_viz_imgui/CMakeLists.txt
@@ -14,10 +14,12 @@ project(mola_viz_imgui LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # -- External dependencies ----------------------------------------------------
-find_package(mrpt-maps    REQUIRED)
-find_package(mrpt-opengl  REQUIRED)
-find_package(mrpt-obs     REQUIRED)
-find_package(mrpt-gui     REQUIRED)
+find_package(mrpt_maps    REQUIRED)
+find_package(mrpt_opengl  REQUIRED)
+find_package(mrpt_obs     REQUIRED)
+find_package(mrpt_gui     REQUIRED)
+find_package(mrpt_viz     REQUIRED)
+find_package(mrpt_imgui   REQUIRED)
 find_mola_package(mola_kernel)
 
 # GLFW is needed explicitly for our own GLFW window management.
@@ -54,19 +56,23 @@ mola_add_library(
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
     mola::mola_kernel
-    mrpt::opengl
-    mrpt::maps
-    mrpt::obs
+    mrpt::mrpt_opengl
+    mrpt::mrpt_maps
+    mrpt::mrpt_obs
+    mrpt::mrpt_viz
     OpenGL::GL
-    mrpt::gui          # public header includes mrpt/imgui/CImGuiSceneView.h
+    mrpt::mrpt_gui
+    mrpt::mrpt_imgui   # public header includes mrpt/imgui/CImGuiSceneView.h
   PRIVATE_LINK_LIBRARIES
     imgui::imgui
   CMAKE_DEPENDENCIES
     mola_kernel
-    mrpt-opengl
-    mrpt-maps
-    mrpt-obs
-    mrpt-gui
+    mrpt_opengl
+    mrpt_maps
+    mrpt_obs
+    mrpt_gui
+    mrpt_imgui
+    mrpt_viz
 )
 
 # -- Compiler options ---------------------------------------------------------

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGui.h
@@ -159,7 +159,7 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
    * @{ */
 
   std::future<bool> update_3d_object(
-      const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+      const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override
@@ -176,7 +176,7 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   }
 
   std::future<bool> insert_point_cloud_with_decay(
-      const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
+      const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override
@@ -217,8 +217,8 @@ class MolaVizImGui : public ExecutableBase, public VizInterface
   }
 
   std::future<bool> execute_custom_code_on_background_scene(
-      const std::function<void(mrpt::opengl::Scene&)>& userCode,
-      const std::string&                               parentWindow = DEFAULT_WINDOW_NAME) override
+      const std::function<void(mrpt::viz::Scene&)>& userCode,
+      const std::string&                            parentWindow = DEFAULT_WINDOW_NAME) override
   {
     return core_ptr_->execute_custom_code_on_background_scene(userCode, parentWindow);
   }

--- a/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
+++ b/mola_viz_imgui/include/mola_viz_imgui/MolaVizImGuiCore.h
@@ -21,8 +21,8 @@
 #include <imgui.h>
 #include <mola_kernel/interfaces/VizInterface.h>
 #include <mrpt/imgui/CImGuiSceneView.h>
-#include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/system/COutputLogger.h>
+#include <mrpt/viz/Scene.h>
 
 #include <atomic>
 #include <cstdint>
@@ -191,7 +191,7 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
    *  scene contents on the GUI thread must hold `get_background_scene_mutex()`
    *  for the duration of access — VizInterface writers also lock it.
    */
-  std::shared_ptr<mrpt::opengl::COpenGLScene> get_background_scene(
+  std::shared_ptr<mrpt::viz::Scene> get_background_scene(
       const window_name_t& name = DEFAULT_WINDOW_NAME);
 
   /** Returns the mutex guarding `get_background_scene()`.
@@ -253,7 +253,7 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
    * @{ */
 
   std::future<bool> update_3d_object(
-      const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+      const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override;
@@ -264,7 +264,7 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> insert_point_cloud_with_decay(
-      const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
+      const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, double decay_time_seconds,
       const std::string& viewportName = "main",
       const std::string& parentWindow = DEFAULT_WINDOW_NAME,
       const std::string& parentFrame  = "") override;
@@ -288,8 +288,8 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
       const std::string& parentWindow = DEFAULT_WINDOW_NAME) override;
 
   std::future<bool> execute_custom_code_on_background_scene(
-      const std::function<void(mrpt::opengl::Scene&)>& userCode,
-      const std::string&                               parentWindow = DEFAULT_WINDOW_NAME) override;
+      const std::function<void(mrpt::viz::Scene&)>& userCode,
+      const std::string&                            parentWindow = DEFAULT_WINDOW_NAME) override;
 
   /** @} */
   // =========================================================================
@@ -426,15 +426,14 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   {
     DecayingCloud() = default;
     DecayingCloud(
-        std::string vp, const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud_,
-        float alpha_)
+        std::string vp, const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud_, float alpha_)
         : viewport_name(std::move(vp)), cloud(cloud_), initial_alpha(alpha_)
     {
     }
-    std::string                                        viewport_name;
-    std::shared_ptr<mrpt::opengl::CPointCloudColoured> cloud;
-    mrpt::opengl::CSetOfObjects::Ptr container;  // owning container at insert time
-    float                            initial_alpha = 1.0f;
+    std::string                                     viewport_name;
+    std::shared_ptr<mrpt::viz::CPointCloudColoured> cloud;
+    mrpt::viz::CSetOfObjects::Ptr                   container;  // owning container at insert time
+    float                                           initial_alpha = 1.0f;
   };
 
   /** One live plot window: which channels it overlays and its display options.
@@ -461,8 +460,8 @@ class MolaVizImGuiCore : public VizInterface, public mrpt::system::COutputLogger
   {
     GLFWwindow* glfw_window = nullptr;  // nullptr in embed mode
 
-    std::shared_ptr<mrpt::opengl::COpenGLScene> background_scene;
-    std::mutex                                  background_scene_mtx;
+    std::shared_ptr<mrpt::viz::Scene> background_scene;
+    std::mutex                        background_scene_mtx;
 
     /// nullptr in embed mode (host renders via its own CImGuiSceneView).
     std::unique_ptr<mrpt::imgui::CImGuiSceneView> background_scene_view;

--- a/mola_viz_imgui/package.xml
+++ b/mola_viz_imgui/package.xml
@@ -12,14 +12,14 @@
 
   <!-- Runtime deps -->
   <depend>mola_kernel</depend>
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libopengl</depend>
-  <depend>mrpt_libobs</depend>
-  <depend>mrpt_libgui</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_opengl</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_gui</depend>
+  <depend>mrpt_viz</depend>
+  <depend>mrpt_imgui</depend>
 
   <depend>libglfw3-dev</depend>
-  <depend>opengl</depend> <!-- remove with mrpt3 -->
-  <depend>glut</depend>  <!-- remove with mrpt3 -->
 
   <!-- Dear ImGui is a git submodule built internally; no system package needed -->
 

--- a/mola_viz_imgui/src/MolaVizImGuiCore.cpp
+++ b/mola_viz_imgui/src/MolaVizImGuiCore.cpp
@@ -26,11 +26,11 @@
 #include <mola_viz_imgui/MolaVizImGuiCore.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/lock_helper.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/CSetOfObjects.h>
 #include <mrpt/system/datetime.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/CSetOfObjects.h>
+#include <mrpt/viz/Scene.h>
 
 #include <algorithm>
 #include <cctype>
@@ -146,7 +146,7 @@ void MolaVizImGuiCore::init_for_embed(const window_name_t& name)
   }
   auto& wd            = windows_[name];
   wd.glfw_window      = nullptr;
-  wd.background_scene = mrpt::opengl::COpenGLScene::Create();
+  wd.background_scene = mrpt::viz::Scene::Create();
   // No background_scene_view — the embed host renders via its own CImGuiSceneView.
   embed_active_ = true;
 
@@ -195,13 +195,12 @@ MolaVizImGuiCore::PerWindowData& MolaVizImGuiCore::init_window(
 {
   auto& wd                 = windows_[name];
   wd.glfw_window           = win;
-  wd.background_scene      = mrpt::opengl::COpenGLScene::Create();
+  wd.background_scene      = mrpt::viz::Scene::Create();
   wd.background_scene_view = std::make_unique<mrpt::imgui::CImGuiSceneView>();
   return wd;
 }
 
-std::shared_ptr<mrpt::opengl::COpenGLScene> MolaVizImGuiCore::get_background_scene(
-    const window_name_t& name)
+std::shared_ptr<mrpt::viz::Scene> MolaVizImGuiCore::get_background_scene(const window_name_t& name)
 {
   auto it = windows_.find(name);
   if (it == windows_.end()) return {};
@@ -530,11 +529,11 @@ void MolaVizImGuiCore::render_background_scene(PerWindowData& wd)
 
   if (wd.cam_dirty)
   {
-    auto& cam = wd.background_scene_view->camera();
+    auto& cam = wd.background_scene_view->cameraController;
     cam.setAzimuthDegrees(wd.cam_azimuth_deg);
     cam.setElevationDegrees(wd.cam_elevation_deg);
     cam.setZoomDistance(wd.cam_zoom);
-    cam.setPointingAt(wd.cam_look_at[0], wd.cam_look_at[1], wd.cam_look_at[2]);
+    cam.setCameraPointing(wd.cam_look_at[0], wd.cam_look_at[1], wd.cam_look_at[2]);
     cam.setProjectiveModel(!wd.cam_orthographic);
     wd.cam_dirty = false;
   }
@@ -556,13 +555,13 @@ void MolaVizImGuiCore::render_background_scene(PerWindowData& wd)
     }
     wd.background_scene_view->render();
 
-    const auto& cam      = wd.background_scene_view->camera();
+    const auto& cam      = wd.background_scene_view->cameraController;
     wd.cam_azimuth_deg   = cam.getAzimuthDegrees();
     wd.cam_elevation_deg = cam.getElevationDegrees();
     wd.cam_zoom          = cam.getZoomDistance();
-    wd.cam_look_at[0]    = cam.getPointingAtX();
-    wd.cam_look_at[1]    = cam.getPointingAtY();
-    wd.cam_look_at[2]    = cam.getPointingAtZ();
+    wd.cam_look_at[0]    = cam.getCameraPointingX();
+    wd.cam_look_at[1]    = cam.getCameraPointingY();
+    wd.cam_look_at[2]    = cam.getCameraPointingZ();
   }
   ImGui::End();
 }
@@ -1121,16 +1120,15 @@ namespace
 {
 /** Get-or-create a movable reference-frame node (a named CSetOfObjects at the
  *  viewport root). Caller must already hold the scene mutex. */
-mrpt::opengl::CSetOfObjects::Ptr getOrCreateFrameNode(
-    mrpt::opengl::COpenGLScene& scene, const std::string& frameName,
-    const std::string& viewportName)
+mrpt::viz::CSetOfObjects::Ptr getOrCreateFrameNode(
+    mrpt::viz::Scene& scene, const std::string& frameName, const std::string& viewportName)
 {
-  mrpt::opengl::CSetOfObjects::Ptr frameNode;
+  mrpt::viz::CSetOfObjects::Ptr frameNode;
   if (auto o = scene.getByName(frameName, viewportName); o)
-    frameNode = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+    frameNode = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
   if (!frameNode)
   {
-    frameNode = mrpt::opengl::CSetOfObjects::Create();
+    frameNode = mrpt::viz::CSetOfObjects::Create();
     frameNode->setName(frameName);
     scene.insert(frameNode, viewportName);
   }
@@ -1139,7 +1137,7 @@ mrpt::opengl::CSetOfObjects::Ptr getOrCreateFrameNode(
 }  // namespace
 
 std::future<bool> MolaVizImGuiCore::update_3d_object(
-    const std::string& objName, const std::shared_ptr<mrpt::opengl::CSetOfObjects>& obj,
+    const std::string& objName, const std::shared_ptr<mrpt::viz::CSetOfObjects>& obj,
     const std::string& viewportName, const std::string& parentWindow,
     const std::string& parentFrame)
 {
@@ -1152,7 +1150,7 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
         auto&           scene = it->second.background_scene;
         std::lock_guard lk(it->second.background_scene_mtx);
 
-        mrpt::opengl::CSetOfObjects::Ptr container;
+        mrpt::viz::CSetOfObjects::Ptr container;
         if (parentFrame.empty())
         {
           // Non-recursive search: only direct children of the viewport root,
@@ -1163,7 +1161,7 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
             {
               if (o->getName() == objName)
               {
-                container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+                container = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
                 break;
               }
             }
@@ -1176,7 +1174,7 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
             {
               scene->removeObject(o, viewportName);
             }
-            container = mrpt::opengl::CSetOfObjects::Create();
+            container = mrpt::viz::CSetOfObjects::Create();
             scene->insert(container, viewportName);
           }
         }
@@ -1186,7 +1184,7 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
           auto frameNode = getOrCreateFrameNode(*scene, parentFrame, viewportName);
           if (auto o = frameNode->getByName(objName); o)
           {
-            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            container = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
           }
           if (!container)
           {
@@ -1196,7 +1194,7 @@ std::future<bool> MolaVizImGuiCore::update_3d_object(
             {
               scene->removeObject(o, viewportName);
             }
-            container = mrpt::opengl::CSetOfObjects::Create();
+            container = mrpt::viz::CSetOfObjects::Create();
             frameNode->insert(container);
           }
         }
@@ -1270,7 +1268,7 @@ std::future<bool> MolaVizImGuiCore::clear_background_scene(
 }
 
 std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
-    const std::shared_ptr<mrpt::opengl::CPointCloudColoured>& cloud, double decay_time_seconds,
+    const std::shared_ptr<mrpt::viz::CPointCloudColoured>& cloud, double decay_time_seconds,
     const std::string& viewportName, const std::string& parentWindow,
     const std::string& parentFrame)
 {
@@ -1287,14 +1285,14 @@ std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
         constexpr const char* DECAY_NAME = "__viz_decaying_clouds";
         std::lock_guard       lk(wd.background_scene_mtx);
 
-        mrpt::opengl::CSetOfObjects::Ptr container;
+        mrpt::viz::CSetOfObjects::Ptr container;
         if (parentFrame.empty())
         {
           if (auto o = wd.background_scene->getByName(DECAY_NAME, viewportName); o)
-            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            container = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
           if (!container)
           {
-            container = mrpt::opengl::CSetOfObjects::Create();
+            container = mrpt::viz::CSetOfObjects::Create();
             wd.background_scene->insert(container, viewportName);
             container->setName(DECAY_NAME);
           }
@@ -1303,10 +1301,10 @@ std::future<bool> MolaVizImGuiCore::insert_point_cloud_with_decay(
         {
           auto frameNode = getOrCreateFrameNode(*wd.background_scene, parentFrame, viewportName);
           if (auto o = frameNode->getByName(DECAY_NAME); o)
-            container = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o);
+            container = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o);
           if (!container)
           {
-            container = mrpt::opengl::CSetOfObjects::Create();
+            container = mrpt::viz::CSetOfObjects::Create();
             container->setName(DECAY_NAME);
             frameNode->insert(container);
           }
@@ -1355,7 +1353,7 @@ std::future<bool> MolaVizImGuiCore::clear_all_point_clouds_with_decay(
         constexpr const char* DECAY_NAME = "__viz_decaying_clouds";
         std::lock_guard       lk(wd.background_scene_mtx);
         if (auto o = wd.background_scene->getByName(DECAY_NAME, viewportName); o)
-          if (auto c = std::dynamic_pointer_cast<mrpt::opengl::CSetOfObjects>(o); c) c->clear();
+          if (auto c = std::dynamic_pointer_cast<mrpt::viz::CSetOfObjects>(o); c) c->clear();
         wd.decaying_clouds.clear();
         return true;
       });
@@ -1445,7 +1443,7 @@ std::future<bool> MolaVizImGuiCore::update_viewport_camera_orthographic(
 }
 
 std::future<bool> MolaVizImGuiCore::execute_custom_code_on_background_scene(
-    const std::function<void(mrpt::opengl::Scene&)>& userCode, const std::string& parentWindow)
+    const std::function<void(mrpt::viz::Scene&)>& userCode, const std::string& parentWindow)
 {
   auto task = std::make_shared<std::packaged_task<bool()>>(
       [this, userCode, parentWindow]()

--- a/mola_viz_imgui/src/MolaVizImGui_handlers.cpp
+++ b/mola_viz_imgui/src/MolaVizImGui_handlers.cpp
@@ -32,9 +32,9 @@
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CPointCloudColoured.h>
-#include <mrpt/opengl/stock_objects.h>
+#include <mrpt/viz/CPointCloudColoured.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 #include <cstdio>
 #include <set>
@@ -121,8 +121,7 @@ void show_common_sensor_info(const mrpt::obs::CObservation& obs, const std::stri
   ImGui::Text("%s", msg.c_str());
   // too verbose? ImGui::Text("Class: %s", , obs.GetRuntimeClass()->className);
 
-  mrpt::poses::CPose3D sensorPose;
-  obs.getSensorPose(sensorPose);
+  const auto sensorPose = obs.getSensorPose();
   ImGui::Text("Sensor pose: %s", sensorPose.asString().c_str());
 }
 
@@ -193,7 +192,7 @@ void handler_images(
 
   if (!st.initialized)
   {
-    auto scene = mrpt::opengl::COpenGLScene::Create();
+    auto scene = mrpt::viz::Scene::Create();
     st.sceneView.setScene(scene);
     st.initialized = true;
   }
@@ -208,7 +207,7 @@ void handler_images(
 
     const auto imgW = static_cast<int>(imgToShow.getWidth());
     const auto imgH = static_cast<int>(imgToShow.getHeight());
-    ImGui::Text("Size: %dx%dx%d", imgW, imgH, imgToShow.channelCount());
+    ImGui::Text("Size: %dx%dx%d", imgW, imgH, static_cast<int>(imgToShow.channels()));
 
     // Drain stale GL errors before MRPT rendering:
     drain_gl_errors();
@@ -224,11 +223,11 @@ void handler_images(
 
 struct PointCloudViewState
 {
-  mrpt::imgui::CImGuiSceneView           sceneView;
-  mrpt::opengl::CPointCloudColoured::Ptr glPc;
-  mrpt::opengl::CSetOfObjects::Ptr       glCornerRef;
-  mrpt::opengl::CSetOfObjects::Ptr       glCornerSensor;
-  bool                                   initialized = false;
+  mrpt::imgui::CImGuiSceneView        sceneView;
+  mrpt::viz::CPointCloudColoured::Ptr glPc;
+  mrpt::viz::CSetOfObjects::Ptr       glCornerRef;
+  mrpt::viz::CSetOfObjects::Ptr       glCornerSensor;
+  bool                                initialized = false;
 };
 
 void handler_point_cloud(
@@ -282,19 +281,19 @@ void handler_point_cloud(
 
   if (!st.initialized)
   {
-    auto scene        = mrpt::opengl::COpenGLScene::Create();
-    st.glPc           = mrpt::opengl::CPointCloudColoured::Create();
-    st.glCornerRef    = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-    st.glCornerSensor = mrpt::opengl::stock_objects::CornerXYZ(0.5f);
+    auto scene        = mrpt::viz::Scene::Create();
+    st.glPc           = mrpt::viz::CPointCloudColoured::Create();
+    st.glCornerRef    = mrpt::viz::stock_objects::CornerXYZ(1.0f);
+    st.glCornerSensor = mrpt::viz::stock_objects::CornerXYZ(0.5f);
     st.glPc->setPointSize(3.0f);
     scene->insert(st.glPc);
     scene->insert(st.glCornerRef);
     scene->insert(st.glCornerSensor);
     st.sceneView.setScene(scene);
     st.sceneView.setBackgroundColor(0.15f, 0.15f, 0.18f);
-    st.sceneView.camera().setZoomDistance(20.0f);
-    st.sceneView.camera().setAzimuthDegrees(-140.0f);
-    st.sceneView.camera().setElevationDegrees(30.0f);
+    st.sceneView.cameraController.setZoomDistance(20.0f);
+    st.sceneView.cameraController.setAzimuthDegrees(-140.0f);
+    st.sceneView.cameraController.setElevationDegrees(30.0f);
     st.initialized = true;
   }
 
@@ -311,11 +310,7 @@ void handler_point_cloud(
   st.glPc->clear();
 
   // Set sensor pose on corner marker:
-  {
-    mrpt::poses::CPose3D p;
-    obs->getSensorPose(p);
-    st.glCornerSensor->setPose(p);
-  }
+  st.glCornerSensor->setPose(obs->getSensorPose());
 
   // Populate point cloud from observation:
   bool populated = false;

--- a/mola_yaml/CMakeLists.txt
+++ b/mola_yaml/CMakeLists.txt
@@ -17,7 +17,8 @@ project(mola_yaml LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find dependencies:
-find_package(MRPT 2.1.0 REQUIRED COMPONENTS containers system)
+find_package(mrpt_containers REQUIRED)
+find_package(mrpt_system REQUIRED)
 
 # define lib:
 file(GLOB_RECURSE LIB_SRCS src/*.cpp src/*.h)
@@ -31,13 +32,13 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::containers
+    mrpt::mrpt_containers
   PRIVATE_LINK_LIBRARIES
-    mrpt::system
+    mrpt::mrpt_system
     CXX::Filesystem  # the C++>=17 std lib
   CMAKE_DEPENDENCIES
-    mrpt-containers
-    mrpt-system
+    mrpt_containers
+    mrpt_system
 )
 
 # -----------------------

--- a/mola_yaml/package.xml
+++ b/mola_yaml/package.xml
@@ -16,7 +16,8 @@
 
   <depend>mola_common</depend>
 
-  <depend>mrpt_libbase</depend>
+  <depend>mrpt_containers</depend>
+  <depend>mrpt_system</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -624,6 +624,10 @@ void recursiveProcessIncludes(yaml::node_t& n, const mola::YAMLParseOptions& opt
 {
   if (n.isScalar())
   {
+    // A null scalar (e.g. an empty YAML value, or an explicit `~`/`null`)
+    // has no string representation to search for "$include{" in.
+    if (n.isNullNode()) return;
+
     const std::string text = n.as<std::string>();
 
     const auto tokenStart = text.find("$include{");

--- a/mola_yaml/src/yaml_helpers.cpp
+++ b/mola_yaml/src/yaml_helpers.cpp
@@ -368,16 +368,20 @@ void deepMergeNode(yaml::node_t& base, const yaml::node_t& overlay)
 {
   if (base.isMap() && overlay.isMap())
   {
-    auto& baseMap = base.asMap();
+    // `yaml::map_t` is a vector-backed, insertion-order structure (not
+    // associative), so lookups go through the `yaml_ref` wrapper's has()/
+    // operator[] rather than through asMap() directly.
+    mrpt::containers::yaml_ref baseRef(base);
     for (const auto& [key, value] : overlay.asMap())
     {
-      if (auto it = baseMap.find(key); it != baseMap.end())
+      const auto keyStr = key.as<std::string>();
+      if (baseRef.has(keyStr))
       {
-        deepMergeNode(it->second, value);
+        deepMergeNode(baseRef[keyStr].node(), value);
       }
       else
       {
-        baseMap[key] = value;
+        baseRef[keyStr] = yaml(value);
       }
     }
   }
@@ -485,11 +489,14 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
   // OVERRIDE particular entries (nested maps merge deeply; scalars/sequences
   // replace). This is what lets `params:` reference a shared file and then
   // tweak just a few keys, instead of duplicating the whole block.
-  // NOTE: parens-init (NOT braces): `node_t{std::string}` would bind to the
-  // initializer_list<node_t> constructor and build a 1-element SEQUENCE node
-  // instead of a scalar, which then throws in operator<'s internalAsStr().
-  const yaml::node_t importKey(std::string("$import"));
-  if (const auto itImport = m.find(importKey); itImport != m.end())
+  // `yaml::map_t` is a vector-backed, insertion-order structure (not
+  // associative), so lookups use std::find_if over key names rather than
+  // `map_t::find()`, which does not exist.
+  const auto itImport = std::find_if(
+      m.begin(), m.end(),
+      [](const auto& kv)
+      { return kv.first.isScalar() && kv.first.template as<std::string>() == "$import"; });
+  if (itImport != m.end())
   {
     std::vector<std::string> importPaths;
     const auto&              importVal = itImport->second;
@@ -526,8 +533,9 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
         continue;
       }
       recursiveProcessIncludes(value, opts);
-      yaml::node_t single = yaml::Map();
-      single.asMap()[key] = value;
+      yaml::node_t               single = yaml::Map();
+      mrpt::containers::yaml_ref singleRef(single);
+      singleRef[key.as<std::string>()] = yaml(value);
       deepMergeNode(merged, single);
     }
 
@@ -566,8 +574,12 @@ void processMapDirectives(yaml::node_t& n, const mola::YAMLParseOptions& opts)
 [[nodiscard]] std::optional<mola::YAMLParseOptions> consumeDefineBlock(
     yaml::map_t& m, const mola::YAMLParseOptions& opts)
 {
-  const yaml::node_t defineKey(std::string("$define"));
-  const auto         itDefine = m.find(defineKey);
+  // `yaml::map_t` is a vector-backed, insertion-order structure (not
+  // associative), so lookups use std::find_if over key names.
+  const auto itDefine = std::find_if(
+      m.begin(), m.end(),
+      [](const auto& kv)
+      { return kv.first.isScalar() && kv.first.template as<std::string>() == "$define"; });
   if (itDefine == m.end())
   {
     return std::nullopt;

--- a/mola_yaml/tests/test-yaml-parser.cpp
+++ b/mola_yaml/tests/test-yaml-parser.cpp
@@ -47,14 +47,14 @@ void test_yaml2string()
     const mrpt::containers::yaml data = mrpt::containers::yaml::Map({{"A", 1.0}, {"B", 3}});
 
     const auto str = mola::yaml_to_string(data);
-    ASSERT_EQUAL_(str, "A: 1\nB: 3\n");
+    ASSERT_EQUAL_(str, "A: 1.0\nB: 3\n");
   }
   {
     using mrpt::containers::vkcp;
     mrpt::containers::yaml data;
     data << vkcp("w", 1.5, "Width") << vkcp("h", 2.5, "Height");
     const auto str = mola::yaml_to_string(data);
-    ASSERT_EQUAL_(str, "# Height\nh: 2.5\n# Width\nw: 1.5\n");
+    ASSERT_EQUAL_(str, "# Width\nw: 1.5\n# Height\nh: 2.5\n");
   }
 }
 
@@ -541,7 +541,8 @@ void test_yaml2stringAdditional()
   // Nested map round-trip preserves structure
   {
     const mrpt::containers::yaml inner = mrpt::containers::yaml::Map({{"x", 10}, {"y", 20}});
-    mrpt::containers::yaml       outer = mrpt::containers::yaml::Map({{"inner", inner}});
+    mrpt::containers::yaml       outer =
+        mrpt::containers::yaml::Map({{"inner", std::make_shared<mrpt::containers::yaml>(inner)}});
 
     const auto s = mola::yaml_to_string(outer);
     const auto y = mrpt::containers::yaml::FromText(s);
@@ -657,7 +658,7 @@ void test_parseDefine()
     ASSERT_EQUAL_(y["params"]["method"].as<std::string>(), "from_define");
     ASSERT_EQUAL_(y["params"]["nested"]["deep"].as<std::string>(), "deep_from_define");
     // Untouched hooks keep their inline default:
-    ASSERT_EQUAL_(y["params"]["gain"].as<std::string>(), "1.0");
+    ASSERT_EQUAL_(y["params"]["gain"].as<std::string>(), "1");
     // Reaches inside sequences too - which plain $import overrides cannot patch:
     ASSERT_EQUAL_(y["params"]["steps"](0)["mode"].as<std::string>(), "from_define");
     ASSERT_EQUAL_(y["params"]["steps"](1)["mode"].as<std::string>(), "fixed");
@@ -748,7 +749,7 @@ void test_parseDefine()
     ASSERT_EQUAL_(y["top"]["inner"]["gain"].as<std::string>(), "from_inner_file_gain");
     // ... and, absent any $define for it anywhere, falls back to the inline
     // default, same as always:
-    ASSERT_EQUAL_(y["top"]["outer"]["gain"].as<std::string>(), "1.0");
+    ASSERT_EQUAL_(y["top"]["outer"]["gain"].as<std::string>(), "1");
   }
 
   // --- outer-wins holds across a genuine multi-level $import CHAIN too, not
@@ -764,7 +765,7 @@ void test_parseDefine()
     const auto y = mola::parse_yaml(yaml::FromText(input), opts);
     ASSERT_EQUAL_(y["method"].as<std::string>(), "from_outer_chain");
     // Untouched by either layer's $define: still the inline default.
-    ASSERT_EQUAL_(y["gain"].as<std::string>(), "1.0");
+    ASSERT_EQUAL_(y["gain"].as<std::string>(), "1");
   }
 
   // --- without an outer override, the middle file's own $define still


### PR DESCRIPTION
Was about time... Part of a massive MOLAorg/* port movement.

TO-DO:
- [x] Address review comments
- [ ] Check if we can drop imgui submodule vs reusing mrpt_imgui's vendored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Updated MRPT integrations across mapping, sensing, trajectory, YAML, and visualization components for current package and API conventions.
  - Improved compatibility with newer ROS distributions, including Rolling on Ubuntu Resolute.
  - Visualization components now use the current MRPT visualization API while preserving existing rendering behavior.

- **Bug Fixes**
  - Improved compressed-image handling and sensor configuration parsing.
  - Added error checking for rawlog loading.
  - Preserved YAML map ordering and corrected numeric serialization expectations.
  - Invalid point-cloud nearest-neighbor queries now report unsupported usage clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->